### PR TITLE
wallet: Cache keymanager

### DIFF
--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true" scanPeriod="15 seconds">
+<configuration scan="true" scanPeriod="15 seconds" >
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date{ISO8601,UTC}UTC %level [%logger{0}] %msg%n</pattern>
@@ -7,7 +7,7 @@
 
     <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
         <queueSize>8192</queueSize>
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="STDOUT" />
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -16,9 +16,9 @@
             <!-- monthly rollover -->
             <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy/MM}.%i.log.zip</fileNamePattern>
             <!-- each file should be at most 100MB, keep 12 months of history, and at most 5GB in the archive -->
-            <maxFileSize>100GB</maxFileSize>
+            <maxFileSize>100MB</maxFileSize>
             <maxHistory>12</maxHistory>
-            <totalSizeCap>100GB</totalSizeCap>
+            <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%date{ISO8601,UTC}UTC %level [%logger{0}] %msg%n</pattern>
@@ -27,7 +27,7 @@
 
     <appender name="ASYNC-FILE" class="ch.qos.logback.classic.AsyncAppender">
         <queueSize>8192</queueSize>
-        <appender-ref ref="FILE"/>
+        <appender-ref ref="FILE" />
     </appender>
 
     <root level="INFO">
@@ -35,7 +35,7 @@
         <appender-ref ref="ASYNC-FILE"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="DEBUG"/>
+    <logger name="org.bitcoins.node" level="INFO"/>
 
     <logger name="org.bitcoins.chain" level="INFO"/>
 

--- a/app/server/src/main/resources/logback.xml
+++ b/app/server/src/main/resources/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true" scanPeriod="15 seconds" >
+<configuration scan="true" scanPeriod="15 seconds">
     <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date{ISO8601,UTC}UTC %level [%logger{0}] %msg%n</pattern>
@@ -7,7 +7,7 @@
 
     <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
         <queueSize>8192</queueSize>
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDOUT"/>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -16,9 +16,9 @@
             <!-- monthly rollover -->
             <fileNamePattern>${bitcoins.log.location}/logs/bitcoin-s-%d{yyyy/MM}.%i.log.zip</fileNamePattern>
             <!-- each file should be at most 100MB, keep 12 months of history, and at most 5GB in the archive -->
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>100GB</maxFileSize>
             <maxHistory>12</maxHistory>
-            <totalSizeCap>5GB</totalSizeCap>
+            <totalSizeCap>100GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%date{ISO8601,UTC}UTC %level [%logger{0}] %msg%n</pattern>
@@ -27,7 +27,7 @@
 
     <appender name="ASYNC-FILE" class="ch.qos.logback.classic.AsyncAppender">
         <queueSize>8192</queueSize>
-        <appender-ref ref="FILE" />
+        <appender-ref ref="FILE"/>
     </appender>
 
     <root level="INFO">
@@ -35,7 +35,7 @@
         <appender-ref ref="ASYNC-FILE"/>
     </root>
 
-    <logger name="org.bitcoins.node" level="INFO"/>
+    <logger name="org.bitcoins.node" level="DEBUG"/>
 
     <logger name="org.bitcoins.chain" level="INFO"/>
 

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -74,7 +74,7 @@ sealed trait DLCWalletLoaderApi
         nodeApi = nodeApi,
         chainQueryApi = chainQueryApi
       )(walletConfig)
-    } yield (dlcWallet, walletConfig, dlcConfig)
+    } yield (dlcWallet, dlcWallet.walletConfig, dlcWallet.dlcConfig)
   }
 
   protected def updateWalletConfigs(

--- a/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCWalletLoaderApi.scala
@@ -103,6 +103,10 @@ sealed trait DLCWalletLoaderApi
 
       walletConfig = conf.walletConf.copy(kmConfOpt = Some(kmConfig))
       dlcConfig = conf.dlcConf.copy(walletConfigOpt = Some(walletConfig))
+      _ = require(
+        walletConfig.walletName == dlcConfig.walletName,
+        s"Wallet name in wallet config and dlc config must match, got walletConfig=${walletConfig.walletName} dlcConfig=${dlcConfig.walletName}"
+      )
     } yield (walletConfig, dlcConfig))
   }
 
@@ -295,8 +299,8 @@ sealed trait DLCWalletLoaderApi
         walletNameOpt = walletNameOpt,
         aesPasswordOpt = aesPasswordOpt
       )
-      _ <- stopOldWalletAppConfig(walletConfig)
-      _ <- stopOldDLCAppConfig(dlcConfig)
+      _ <- stopOldWalletAppConfig(newWalletConfig = walletConfig)
+      _ <- stopOldDLCAppConfig(newDlcConfig = dlcConfig)
       nodeCallbacks <- createCallbacks(dlcWallet)
       _ = conf.replaceCallbacks(nodeCallbacks)
       _ <- walletHolder.replaceWallet(dlcWallet)

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
@@ -59,4 +59,20 @@ object HDPurpose extends StringFactory[HDPurpose] {
       sys.error(s"Cannot create HDPurpose from string=$string")
     }
   }
+
+  def toString(purpose: HDPurpose): String = {
+    if (purpose == Legacy) {
+      "legacy"
+    } else if (purpose == SegWit) {
+      "segwit"
+    } else if (purpose == NestedSegWit) {
+      "nested-segwit"
+    } else if (purpose == Taproot) {
+      "taproot"
+    } else if (purpose == Multisig) {
+      "multisig"
+    } else {
+      "unknown"
+    }
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
+++ b/core/src/main/scala/org/bitcoins/core/hd/HDPurpose.scala
@@ -61,18 +61,19 @@ object HDPurpose extends StringFactory[HDPurpose] {
   }
 
   def toString(purpose: HDPurpose): String = {
-    if (purpose == Legacy) {
-      "legacy"
-    } else if (purpose == SegWit) {
-      "segwit"
-    } else if (purpose == NestedSegWit) {
-      "nested-segwit"
-    } else if (purpose == Taproot) {
-      "taproot"
-    } else if (purpose == Multisig) {
-      "multisig"
-    } else {
-      "unknown"
+    purpose match {
+      case Legacy =>
+        "legacy"
+      case SegWit =>
+        "segwit"
+      case NestedSegWit =>
+        "nested-segwit"
+      case Taproot =>
+        "taproot"
+      case Multisig =>
+        "multisig"
+      case other =>
+        sys.error(s"Unsupported HDPurpose: $other (constant=${other.constant})")
     }
   }
 }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -150,7 +150,6 @@ object DLCAppConfig
       dlcConf: DLCAppConfig
   ): Future[DLCWallet] = {
     import dlcConf.ec
-    val bip39PasswordOpt = walletConf.bip39PasswordOpt
     walletConf.hasWallet().flatMap { walletExists =>
       if (walletExists) {
         logger.info(s"Using pre-existing wallet")
@@ -164,8 +163,7 @@ object DLCAppConfig
         Wallet
           .initialize(
             wallet = unInitializedWallet,
-            accountHandling = unInitializedWallet.accountHandling,
-            bip39PasswordOpt = bip39PasswordOpt
+            accountHandling = unInitializedWallet.accountHandling
           )
           .map(DLCWallet.apply)
       }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -162,8 +162,7 @@ object DLCAppConfig
 
         Wallet
           .initialize(
-            wallet = unInitializedWallet,
-            accountHandling = unInitializedWallet.accountHandling
+            wallet = unInitializedWallet
           )
           .map(w => DLCWallet(w)(dlcConf, w.walletConfig))
       }

--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -165,7 +165,7 @@ object DLCAppConfig
             wallet = unInitializedWallet,
             accountHandling = unInitializedWallet.accountHandling
           )
-          .map(DLCWallet.apply)
+          .map(w => DLCWallet(w)(dlcConf, w.walletConfig))
       }
     }
   }

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -154,7 +154,7 @@ val wallet = Wallet(new NodeApi {
     override def getConnectionCount: Future[Int] = Future.successful(0)
   }, chainApi)
 val walletF: Future[WalletApi] = configF.flatMap { _ =>
-  Wallet.initialize(wallet, wallet.accountHandling, None)
+  Wallet.initialize(wallet, wallet.accountHandling)
 }
 
 // when this future completes, ww have sent a transaction

--- a/docs/wallet/wallet.md
+++ b/docs/wallet/wallet.md
@@ -4,6 +4,7 @@ id: wallet
 ---
 
 ## Bitcoin-s wallet
+
 Bitcoin-s comes bundled with a rudimentary Bitcoin wallet. This wallet
 is capable of managing private keys, generating addresses, constructing
 and signing transactions, among other things. It is BIP32/BIP44/BIP49/BIP84
@@ -15,18 +16,22 @@ ready. Use at your own risk, and without too much money depending on it.
 
 ### How is the bitcoin-s wallet implemented
 
-The bitcoin-s wallet is a scalable way for individuals up to large bitcoin exchanges to safely and securely store their bitcoin in a scalable way.
+The bitcoin-s wallet is a scalable way for individuals up to large bitcoin exchanges to safely and securely store their
+bitcoin in a scalable way.
 
-All key interactions are delegated to the [key-manager](../key-manager/key-manager.md) which is a minimal dependency library to store and use key material.
+All key interactions are delegated to the [key-manager](../key-manager/key-manager.md) which is a minimal dependency
+library to store and use key material.
 
-By default, we store the encrypted root key in `$HOME/.bitcoin-s/seeds/encrypted-bitcoin-s-seed.json`. This is the seed that is used for each of the wallets on each bitcoin network.
+By default, we store the encrypted root key in `$HOME/.bitcoin-s/seeds/encrypted-bitcoin-s-seed.json`. This is the seed
+that is used for each of the wallets on each bitcoin network.
 Multiple wallet seeds can be saved using the `bitcoin-s.wallet.walletName` config option.
 You can read more in the [key manager docs](../key-manager/server-key-manager.md).
 
-The wallet itself is used to manage the utxo life cycle, create transactions, and update wallet balances to show how much money you have the on a bitcoin network.
+The wallet itself is used to manage the utxo life cycle, create transactions, and update wallet balances to show how
+much money you have the on a bitcoin network.
 
-We use [slick](https://scala-slick.org/doc/3.3.1/) as middleware to support different database types. Depending on your use case, you can use something as simple as sqlite, or something much more scalable like postgres.
-
+We use [slick](https://scala-slick.org/doc/3.3.1/) as middleware to support different database types. Depending on your
+use case, you can use something as simple as sqlite, or something much more scalable like postgres.
 
 ### Example
 
@@ -74,15 +79,22 @@ import scala.concurrent._
 import org.apache.pekko.actor.ActorSystem
 
 val chainApi = new ChainQueryApi {
-    override def epochSecondToBlockHeight(time: Long): Future[Int] = Future.successful(0)
-    override def getBlockHeight(blockHash: DoubleSha256DigestBE): Future[Option[Int]] = Future.successful(None)
-    override def getBestBlockHash(): Future[DoubleSha256DigestBE] = Future.successful(DoubleSha256DigestBE.empty)
-    override def getNumberOfConfirmations(blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]] = Future.successful(None)
-    override def getFilterCount(): Future[Int] = Future.successful(0)
-    override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] = Future.successful(0)
-    override def getFiltersBetweenHeights(startHeight: Int, endHeight: Int): Future[Vector[FilterResponse]] = Future.successful(Vector.empty)
-    override def getMedianTimePast(): Future[Long] = Future.successful(0L)
-  }
+  override def epochSecondToBlockHeight(time: Long): Future[Int] = Future.successful(0)
+
+  override def getBlockHeight(blockHash: DoubleSha256DigestBE): Future[Option[Int]] = Future.successful(None)
+
+  override def getBestBlockHash(): Future[DoubleSha256DigestBE] = Future.successful(DoubleSha256DigestBE.empty)
+
+  override def getNumberOfConfirmations(blockHashOpt: DoubleSha256DigestBE): Future[Option[Int]] = Future.successful(None)
+
+  override def getFilterCount(): Future[Int] = Future.successful(0)
+
+  override def getHeightByBlockStamp(blockStamp: BlockStamp): Future[Int] = Future.successful(0)
+
+  override def getFiltersBetweenHeights(startHeight: Int, endHeight: Int): Future[Vector[FilterResponse]] = Future.successful(Vector.empty)
+
+  override def getMedianTimePast(): Future[Long] = Future.successful(0L)
+}
 ```
 
 ```scala mdoc:compile-only
@@ -90,7 +102,7 @@ implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
 implicit val system: ActorSystem = ActorSystem("System")
 
 val config = ConfigFactory.parseString {
-    """
+  """
     | bitcoin-s {
     |   network = regtest
     | }
@@ -111,8 +123,8 @@ implicit val chainConfig: ChainAppConfig = ChainAppConfig(datadir, Vector(config
 // databases for managing both chain state
 // and wallet state
 val configF: Future[Unit] = for {
-    _ <- walletConfig.start()
-    _ <- chainConfig.start()
+  _ <- walletConfig.start()
+  _ <- chainConfig.start()
 } yield ()
 
 val bitcoindInstance = BitcoindInstanceLocal.fromDatadir()
@@ -123,61 +135,63 @@ val bitcoind = BitcoindRpcClient(bitcoindInstance)
 // synced our chain handler to our bitcoind
 // peer
 val syncF: Future[ChainApi] = configF.flatMap { _ =>
-    val getBestBlockHashFunc = { () =>
-        bitcoind.getBestBlockHash()
-    }
+  val getBestBlockHashFunc = { () =>
+    bitcoind.getBestBlockHash()
+  }
 
-    
-    val getBlockHeaderFunc = { (hash: DoubleSha256DigestBE) =>
-        bitcoind.getBlockHeader(hash).map(_.blockHeader)
-    }
 
-    val blockHeaderDAO = BlockHeaderDAO()
-    val compactFilterHeaderDAO = CompactFilterHeaderDAO()
-    val compactFilterDAO = CompactFilterDAO()
-    val stateDAO = ChainStateDescriptorDAO()
-    val chainHandler = ChainHandler(
-        blockHeaderDAO,
-        compactFilterHeaderDAO,
-        compactFilterDAO,
-        stateDAO,
-        blockFilterCheckpoints = Map.empty)
+  val getBlockHeaderFunc = { (hash: DoubleSha256DigestBE) =>
+    bitcoind.getBlockHeader(hash).map(_.blockHeader)
+  }
 
-    ChainSync.sync(chainHandler, getBlockHeaderFunc, getBestBlockHashFunc)
+  val blockHeaderDAO = BlockHeaderDAO()
+  val compactFilterHeaderDAO = CompactFilterHeaderDAO()
+  val compactFilterDAO = CompactFilterDAO()
+  val stateDAO = ChainStateDescriptorDAO()
+  val chainHandler = ChainHandler(
+    blockHeaderDAO,
+    compactFilterHeaderDAO,
+    compactFilterDAO,
+    stateDAO,
+    blockFilterCheckpoints = Map.empty)
+
+  ChainSync.sync(chainHandler, getBlockHeaderFunc, getBestBlockHashFunc)
 }
 
 // once this future completes, we have a initialized
 // wallet
 val wallet = Wallet(new NodeApi {
-    override def broadcastTransactions(txs: Vector[Transaction]): Future[Unit] = Future.successful(())
-    override def downloadBlocks(blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = Future.successful(())
-    override def getConnectionCount: Future[Int] = Future.successful(0)
-  }, chainApi)
+  override def broadcastTransactions(txs: Vector[Transaction]): Future[Unit] = Future.successful(())
+
+  override def downloadBlocks(blockHashes: Vector[DoubleSha256DigestBE]): Future[Unit] = Future.successful(())
+
+  override def getConnectionCount: Future[Int] = Future.successful(0)
+}, chainApi)
 val walletF: Future[WalletApi] = configF.flatMap { _ =>
-  Wallet.initialize(wallet, wallet.accountHandling)
+  Wallet.initialize(wallet)
 }
 
 // when this future completes, ww have sent a transaction
 // from bitcoind to the Bitcoin-S wallet
 val transactionF: Future[(Transaction, Option[BlockHashWithConfs])] = for {
-    wallet <- walletF
-    address <- wallet.getNewAddress()
-    txid <- bitcoind.sendToAddress(address, 3.bitcoin)
-    transaction <- bitcoind.getRawTransaction(txid)
-    blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(bitcoind,transaction.blockhash)
+  wallet <- walletF
+  address <- wallet.getNewAddress()
+  txid <- bitcoind.sendToAddress(address, 3.bitcoin)
+  transaction <- bitcoind.getRawTransaction(txid)
+  blockHashWithConfs <- WalletUtil.getBlockHashWithConfs(bitcoind, transaction.blockhash)
 } yield (transaction.hex, blockHashWithConfs)
 
 // when this future completes, we have processed
 // the transaction from bitcoind, and we have
 // queried our balance for the current balance
 val balanceF: Future[CurrencyUnit] = for {
-    wallet <- walletF
-    (tx, blockhash) <- transactionF
-    _ <- wallet.transactionProcessing.processTransaction(tx, blockhash)
-    balance <- wallet.getBalance()
+  wallet <- walletF
+  (tx, blockhash) <- transactionF
+  _ <- wallet.transactionProcessing.processTransaction(tx, blockhash)
+  balance <- wallet.getBalance()
 } yield balance
 
 balanceF.foreach { balance =>
-    println(s"Bitcoin-S wallet balance: $balance")
+  println(s"Bitcoin-S wallet balance: $balance")
 }
 ```

--- a/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
+++ b/key-manager/src/main/scala/org/bitcoins/keymanager/config/KeyManagerAppConfig.scala
@@ -30,7 +30,11 @@ case class KeyManagerAppConfig(
   override type ConfigType = KeyManagerAppConfig
 
   override def newConfigOfType(configs: Vector[Config]): KeyManagerAppConfig =
-    KeyManagerAppConfig(baseDatadir, configs)
+    KeyManagerAppConfig(baseDatadir,
+                        configs,
+                        walletNameOverride,
+                        aesPasswordOverride,
+                        bip39PasswordOverride)
 
   override def moduleName: String = KeyManagerAppConfig.moduleName
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/BitcoinSTestAppConfig.scala
@@ -77,6 +77,13 @@ object BitcoinSTestAppConfig {
       config: Vector[Config],
       forceNamedWallet: Boolean = false
   )(implicit system: ActorSystem): BitcoinSAppConfig = {
+    // don't want to duplicate walletName
+    // shouldn't there be a way to automatically handle this
+    // with the typesafe config library?
+    val walletNameConfig =
+      if (config.exists(_.hasPath("bitcoin-s.wallet.walletName")))
+        ConfigFactory.empty
+      else genWalletNameConf(forceNamedWallet)
     val overrideConf = ConfigFactory
       .parseString {
         s"""
@@ -93,7 +100,7 @@ object BitcoinSTestAppConfig {
            |}
       """.stripMargin
       }
-      .withFallback(genWalletNameConf(forceNamedWallet))
+      .withFallback(walletNameConfig)
       .withFallback(BaseWalletTest.randomAccountTypeConfig)
 
     BitcoinSAppConfig(

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -266,7 +266,7 @@ object BitcoinSWalletTest extends WalletLogger {
       walletConfig.start().flatMap { _ =>
         val wallet =
           Wallet(nodeApi, chainQueryApi)(walletConfig)
-        Wallet.initialize(wallet, wallet.accountHandling)
+        Wallet.initialize(wallet)
       }
     }
   }
@@ -290,7 +290,7 @@ object BitcoinSWalletTest extends WalletLogger {
       val wallet = Wallet(nodeApi, chainQueryApi)(config.walletConf)
 
       Wallet
-        .initialize(wallet, wallet.accountHandling)
+        .initialize(wallet)
         .map(w =>
           DLCWallet(w)(
             config.dlcConf.copy(walletConfigOpt = Some(w.walletConfig))(

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -58,15 +58,15 @@ trait BitcoinSWalletTest
         BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
 
       val mergedConfig = bip39PasswordConfig.withFallback(walletConfig)
-      implicit val newWalletConf =
+      implicit val newWalletConf: WalletAppConfig =
         getFreshWalletAppConfig.withOverrides(mergedConfig)
 
       makeDependentFixture[Wallet](
         build =
           createNewWallet(nodeApi = nodeApi, chainQueryApi = chainQueryApi),
-        destroy = { (_: WalletApi) =>
+        destroy = { (w: Wallet) =>
           for {
-            _ <- destroyWalletAppConfig(newWalletConf)
+            _ <- destroyWalletAppConfig(w.walletConfig)
           } yield ()
         }
       )

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -298,8 +298,9 @@ object BitcoinSWalletTest extends WalletLogger {
         .initialize(wallet, wallet.accountHandling)
         .map(w =>
           DLCWallet(w)(
-            config.dlcConf,
-            config.walletConf
+            config.dlcConf.copy(walletConfigOpt = Some(w.walletConfig))(
+              w.system),
+            w.walletConfig
           ))
     }
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -293,8 +293,7 @@ object BitcoinSWalletTest extends WalletLogger {
         .initialize(wallet)
         .map(w =>
           DLCWallet(w)(
-            config.dlcConf.copy(walletConfigOpt = Some(w.walletConfig))(
-              w.system),
+            config.dlcConf,
             w.walletConfig
           ))
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -53,17 +53,12 @@ trait BitcoinSWalletTest
   /** Lets you customize the parameters for the created wallet */
   val withNewConfiguredWallet: Config => OneArgAsyncTest => FutureOutcome = {
     walletConfig =>
-      val bip39PasswordOpt = KeyManagerTestUtil.bip39PasswordOpt
-      val bip39PasswordConfig: Config =
-        BitcoinSWalletTest.buildBip39PasswordConfig(bip39PasswordOpt)
-
-      val mergedConfig = bip39PasswordConfig.withFallback(walletConfig)
-      implicit val newWalletConf: WalletAppConfig =
-        getFreshWalletAppConfig.withOverrides(mergedConfig)
+      val newWalletConf: WalletAppConfig =
+        getFreshWalletAppConfig.withOverrides(walletConfig)
 
       makeDependentFixture[Wallet](
-        build =
-          createNewWallet(nodeApi = nodeApi, chainQueryApi = chainQueryApi),
+        build = createNewWallet(nodeApi = nodeApi,
+                                chainQueryApi = chainQueryApi)(newWalletConf),
         destroy = { (w: Wallet) =>
           for {
             _ <- destroyWalletAppConfig(w.walletConfig)

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -271,9 +271,7 @@ object BitcoinSWalletTest extends WalletLogger {
       walletConfig.start().flatMap { _ =>
         val wallet =
           Wallet(nodeApi, chainQueryApi)(walletConfig)
-        Wallet.initialize(wallet,
-                          wallet.accountHandling,
-                          walletConfig.bip39PasswordOpt)
+        Wallet.initialize(wallet, wallet.accountHandling)
       }
     }
   }
@@ -297,9 +295,7 @@ object BitcoinSWalletTest extends WalletLogger {
       val wallet = Wallet(nodeApi, chainQueryApi)(config.walletConf)
 
       Wallet
-        .initialize(wallet,
-                    wallet.accountHandling,
-                    config.walletConf.bip39PasswordOpt)
+        .initialize(wallet, wallet.accountHandling)
         .map(w =>
           DLCWallet(w)(
             config.dlcConf,

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -181,6 +181,7 @@ object FundWalletUtil extends FundWalletUtil {
 
   trait FundedTestWallet {
     def wallet: WalletApi
+    def walletConfig: WalletAppConfig
   }
 
   /** This is a wallet that was two funded accounts Account 0 (default account)
@@ -211,8 +212,8 @@ object FundWalletUtil extends FundWalletUtil {
         nodeApi = nodeApi,
         chainQueryApi = chainQueryApi
       )
-      funded <- FundWalletUtil.fundWallet(wallet, config)
-    } yield FundedWallet(funded.wallet, config)
+      funded <- FundWalletUtil.fundWallet(wallet, wallet.walletConfig)
+    } yield FundedWallet(funded.wallet, funded.walletConfig)
   }
 
   def createFundedDLCWallet(nodeApi: NodeApi, chainQueryApi: ChainQueryApi)(

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -226,7 +226,7 @@ object FundWalletUtil extends FundWalletUtil {
         nodeApi = nodeApi,
         chainQueryApi = chainQueryApi
       )
-      funded <- FundWalletUtil.fundWallet(wallet, config.walletConf)
+      funded <- FundWalletUtil.fundWallet(wallet, wallet.walletConfig)
     } yield {
       val dlcWallet = funded.wallet.asInstanceOf[DLCWallet]
       FundedDLCWallet(dlcWallet, dlcWallet.walletConfig, dlcWallet.dlcConfig)

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -144,7 +144,6 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
   }
 
   private def getWallet(config: WalletAppConfig): Future[Wallet] = {
-    val bip39PasswordOpt = None
     val startedF = config.start()
     for {
       _ <- startedF
@@ -155,8 +154,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
         )(config)
       init <- Wallet.initialize(
         wallet = wallet,
-        accountHandling = wallet.accountHandling,
-        bip39PasswordOpt = bip39PasswordOpt
+        accountHandling = wallet.accountHandling
       )
     } yield init
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -148,8 +148,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
           MockChainQueryApi
         )(config)
       init <- Wallet.initialize(
-        wallet = wallet,
-        accountHandling = wallet.accountHandling
+        wallet = wallet
       )
     } yield init
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -129,12 +129,7 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     vectors.filter(_.pathType == HDPurpose.NestedSegWit)
 
   def configForPurposeAndSeed(purpose: HDPurpose): Config = {
-    val purposeStr = purpose match {
-      case HDPurpose.Legacy       => "legacy"
-      case HDPurpose.SegWit       => "segwit"
-      case HDPurpose.NestedSegWit => "nested-segwit"
-      case other                  => fail(s"unexpected purpose: $other")
-    }
+    val purposeStr = HDPurpose.toString(purpose)
     val entropy = mnemonic.toEntropy.toHex
     val confStr = s"""bitcoin-s.wallet.purpose = $purposeStr
                      |bitcoin-s.network = mainnet

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -161,10 +161,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
   it must "be able to call initialize twice without throwing an exception if we have the same key manager" in {
     (wallet: Wallet) =>
       val twiceF = Wallet
-        .initialize(wallet = wallet, accountHandling = wallet.accountHandling)
+        .initialize(wallet = wallet)
         .flatMap { _ =>
-          Wallet.initialize(wallet = wallet,
-                            accountHandling = wallet.accountHandling)
+          Wallet.initialize(wallet = wallet)
         }
 
       twiceF.map(_ => succeed)
@@ -175,7 +174,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
     (wallet: Wallet) =>
       recoverToSucceededIf[RuntimeException] {
         Wallet
-          .initialize(wallet, wallet.accountHandling)
+          .initialize(wallet)
           .flatMap { _ =>
             // use a BIP39 password to make the key-managers different
             val kmConf = wallet.walletConfig.kmConf.withOverrides(
@@ -187,8 +186,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
             val walletBadPw =
               Wallet(wallet.nodeApi, wallet.chainQueryApi)(wConfig)
             Wallet.initialize(
-              walletBadPw,
-              wallet.accountHandling
+              walletBadPw
             )
           }
       }
@@ -215,8 +213,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
       recoverToSucceededIf[IllegalArgumentException] {
         walletDiffKeyManagerF.flatMap { walletDiffKeyManager =>
-          Wallet.initialize(walletDiffKeyManager,
-                            walletDiffKeyManager.accountHandling)
+          Wallet.initialize(walletDiffKeyManager)
         }
       }
   }
@@ -398,15 +395,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
         }
 
-        // create a new wallet config so we get a fresh connection pool
-        // we should be able to remove this once we have #6245
-        walletConfig = wallet.walletConfig
-        _ <- walletConfig.stop().flatMap(_ => walletConfig.start())
-
         // initialize it
         initOldWallet <- Wallet.initialize(
-          wallet = wallet,
-          accountHandling = wallet.accountHandling
+          wallet = wallet
         )
         isOldWalletEmpty <- initOldWallet.isEmpty()
 //        _ <- initOldWallet.stop()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -160,15 +160,11 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it must "be able to call initialize twice without throwing an exception if we have the same key manager" in {
     (wallet: Wallet) =>
-      val bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
       val twiceF = Wallet
-        .initialize(wallet = wallet,
-                    accountHandling = wallet.accountHandling,
-                    bip39PasswordOpt = bip39PasswordOpt)
+        .initialize(wallet = wallet, accountHandling = wallet.accountHandling)
         .flatMap { _ =>
           Wallet.initialize(wallet = wallet,
-                            accountHandling = wallet.accountHandling,
-                            bip39PasswordOpt = bip39PasswordOpt)
+                            accountHandling = wallet.accountHandling)
         }
 
       twiceF.map(_ => succeed)
@@ -177,16 +173,21 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
   it must "be able to detect an incompatible key manager with a wallet" in {
     (wallet: Wallet) =>
-      val bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
       recoverToSucceededIf[RuntimeException] {
         Wallet
-          .initialize(wallet, wallet.accountHandling, bip39PasswordOpt)
+          .initialize(wallet, wallet.accountHandling)
           .flatMap { _ =>
             // use a BIP39 password to make the key-managers different
+            val wConfig = wallet.walletConfig.withOverrides(
+              ConfigFactory.parseString(
+                s"bitcoin-s.keymanager.bip39Password=random-password-to-make-key-managers-different"
+              )
+            )
+            val walletBadPw =
+              Wallet(wallet.nodeApi, wallet.chainQueryApi)(wConfig)
             Wallet.initialize(
-              wallet,
-              wallet.accountHandling,
-              Some("random-password-to-make-key-managers-different")
+              walletBadPw,
+              wallet.accountHandling
             )
           }
       }
@@ -211,7 +212,8 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
       recoverToSucceededIf[IllegalArgumentException] {
         walletDiffKeyManagerF.flatMap { walletDiffKeyManager =>
-          Wallet.initialize(walletDiffKeyManager, wallet.accountHandling, None)
+          Wallet.initialize(walletDiffKeyManager,
+                            walletDiffKeyManager.accountHandling)
         }
       }
   }
@@ -401,8 +403,7 @@ class WalletUnitTest extends BitcoinSWalletTest {
         // initialize it
         initOldWallet <- Wallet.initialize(
           wallet = wallet,
-          accountHandling = wallet.accountHandling,
-          bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
+          accountHandling = wallet.accountHandling
         )
         isOldWalletEmpty <- initOldWallet.isEmpty()
 //        _ <- initOldWallet.stop()

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -178,11 +178,12 @@ class WalletUnitTest extends BitcoinSWalletTest {
           .initialize(wallet, wallet.accountHandling)
           .flatMap { _ =>
             // use a BIP39 password to make the key-managers different
-            val wConfig = wallet.walletConfig.withOverrides(
+            val kmConf = wallet.walletConfig.kmConf.withOverrides(
               ConfigFactory.parseString(
-                s"bitcoin-s.keymanager.bip39Password=random-password-to-make-key-managers-different"
+                s"bitcoin-s.keymanager.bip39password=random-password-to-make-key-managers-different"
               )
             )
+            val wConfig = wallet.walletConfig.copy(kmConfOpt = Some(kmConf))
             val walletBadPw =
               Wallet(wallet.nodeApi, wallet.chainQueryApi)(wConfig)
             Wallet.initialize(
@@ -200,7 +201,9 @@ class WalletUnitTest extends BitcoinSWalletTest {
       val config = ConfigFactory.parseString(
         s"bitcoin-s.keymanager.entropy=${CryptoUtil.randomBytes(16).toHex}"
       )
-      val uniqueEntropyWalletConfig = wallet.walletConfig.withOverrides(config)
+      val kmConf = wallet.walletConfig.kmConf.withOverrides(config)
+      val uniqueEntropyWalletConfig =
+        wallet.walletConfig.copy(kmConfOpt = Some(kmConf))
       val startedF = uniqueEntropyWalletConfig.start()
       val walletDiffKeyManagerF: Future[Wallet] = for {
         _ <- startedF

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -392,7 +392,6 @@ object Wallet extends WalletLogger {
       accountHandling: AccountHandlingApi
   ): Future[Wallet] = {
     import wallet.walletConfig.ec
-
     val createMasterXpubF =
       createMasterXPub(wallet.keyManager)(wallet.walletConfig)
     // We want to make sure all level 0 accounts are created,
@@ -405,13 +404,6 @@ object Wallet extends WalletLogger {
         // we need to create key manager params for each purpose
         // and then initialize a key manager to derive the correct xpub
         val wAppConfig = wallet.walletConfig
-//        val aesPwConfig =
-//          passwordOpt
-//            .map(p => s"bitcoin-s.keymanager.aesPassword=$p")
-//            .getOrElse("")
-//        val bip39PwConfig = bip39PasswordOpt
-//          .map(p => s"bitcoin-s.keymanager.bip39password=$p")
-//          .getOrElse("")
         val purposeConfig =
           s"bitcoin-s.wallet.purpose=${HDPurpose.toString(purpose)}"
 
@@ -448,6 +440,9 @@ object Wallet extends WalletLogger {
         .find(
           _.walletConfig.defaultPurpose == wallet.walletConfig.defaultPurpose)
         .get
+      // start the config we are actually using
+      // we need this for fee rate scheduler
+      _ <- initializedWallet.walletConfig.start()
       _ = accounts.foreach { a =>
         logger.info(s"Created account=${a} to DB")
       }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -414,11 +414,13 @@ object Wallet extends WalletLogger {
                 .filter(_.nonEmpty)
                 .mkString("\n"))
 
+        val kmConf = wallet.walletConfig.kmConf
+        val kmConfOverrides = kmConf.configOverrides
         val overrides =
-          (walletConf +: wallet.walletConfig.configOverrides)
+          (walletConf +: (wallet.walletConfig.configOverrides ++ kmConfOverrides))
             .foldLeft(ConfigFactory.empty())(_.withFallback(_))
         val kmAppConfig =
-          wallet.walletConfig.kmConf.withOverrides(Vector(overrides.resolve()))
+          kmConf.withOverrides(Vector(overrides.resolve()))
         val walletAppConfig = wallet.walletConfig.copy(kmConfOpt =
           Some(kmAppConfig))(wAppConfig.system)
         val w = Wallet(nodeApi = wallet.nodeApi,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,6 +1,5 @@
 package org.bitcoins.wallet
 
-import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -348,13 +347,10 @@ object Wallet extends WalletLogger {
   /** Creates the level 0 account for the given HD purpose, if the root account
     * exists do nothing
     */
-  private def createRootAccount(wallet: Wallet)(implicit
+  private def createRootAccount(wallet: Wallet, coin: HDCoin)(implicit
       ec: ExecutionContext
   ): DBIOAction[AccountDb, NoStream, Effect.Read & Effect.Write] = {
     val keyManager = wallet.keyManager
-    val coinType = HDUtil.getCoinType(keyManager.kmParams.network)
-    val coin =
-      HDCoin(purpose = keyManager.kmParams.purpose, coinType = coinType)
     val account = HDAccount(coin = coin, index = 0)
     // safe since we're deriving from a priv
     val xpub = keyManager.deriveXPub(account).get
@@ -388,8 +384,7 @@ object Wallet extends WalletLogger {
   }
 
   def initialize(
-      wallet: Wallet,
-      accountHandling: AccountHandlingApi
+      wallet: Wallet
   ): Future[Wallet] = {
     import wallet.walletConfig.ec
     val createMasterXpubF =
@@ -403,29 +398,20 @@ object Wallet extends WalletLogger {
       val accounts = HDPurpose.singleSigPurposes.map { purpose =>
         // we need to create key manager params for each purpose
         // and then initialize a key manager to derive the correct xpub
-        val wAppConfig = wallet.walletConfig
-        val purposeConfig =
-          s"bitcoin-s.wallet.purpose=${HDPurpose.toString(purpose)}"
-
-        val walletConf: Config =
-          ConfigFactory
-            .parseString(
-              Vector(purposeConfig)
-                .filter(_.nonEmpty)
-                .mkString("\n"))
-
-        val kmConf = wallet.walletConfig.kmConf
-        val kmConfOverrides = kmConf.configOverrides
-        val overrides =
-          (walletConf +: (wallet.walletConfig.configOverrides ++ kmConfOverrides))
-            .foldLeft(ConfigFactory.empty())(_.withFallback(_))
-        val kmAppConfig =
-          kmConf.withOverrides(Vector(overrides.resolve()))
-        val walletAppConfig = wallet.walletConfig.copy(kmConfOpt =
-          Some(kmAppConfig))(wAppConfig.system)
-        val w = Wallet(nodeApi = wallet.nodeApi,
-                       chainQueryApi = wallet.chainQueryApi)(walletAppConfig)
-        createRootAccount(w).map((w, _))
+        val keyManager = wallet.keyManager
+        val coinType = HDUtil.getCoinType(keyManager.kmParams.network)
+        val coin =
+          HDCoin(purpose = purpose, coinType = coinType)
+        createRootAccount(wallet, coin).map { account =>
+          // need to re-create the wallet object
+          // because keymanager is cached at the wallet level
+          // see: https://github.com/bitcoin-s/bitcoin-s/pull/6242
+          val w = Wallet(
+            nodeApi = wallet.nodeApi,
+            chainQueryApi = wallet.chainQueryApi
+          )(wallet.walletConfig)
+          (w, account)
+        }
 
       }
       accounts
@@ -444,7 +430,7 @@ object Wallet extends WalletLogger {
         .get
       // start the config we are actually using
       // we need this for fee rate scheduler
-      _ <- initializedWallet.walletConfig.start()
+      // _ <- initializedWallet.walletConfig.start()
       _ = accounts.foreach { a =>
         logger.info(s"Created account=${a} to DB")
       }
@@ -455,7 +441,7 @@ object Wallet extends WalletLogger {
         val threshold = Instant.now().minus(1, ChronoUnit.HOURS)
         val isOldCreationTime = creationTime.compareTo(threshold) <= 0
         if (isOldCreationTime) {
-          accountHandling
+          wallet.accountHandling
             .generateScriptPubKeys(
               account = wallet.walletConfig.defaultAccount,
               addressBatchSize = wallet.walletConfig.discoveryBatchSize,

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -40,7 +40,7 @@ case class Wallet(
     val walletConfig: WalletAppConfig
 ) extends NeutrinoHDWalletApi
     with WalletLogger {
-  def keyManager: BIP39KeyManager = {
+  lazy val keyManager: BIP39KeyManager = {
     walletConfig.kmConf.toBip39KeyManager
   }
   def feeRateApi: FeeRateApi = walletConfig.feeRateApi

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.wallet
 
+import com.typesafe.config.ConfigFactory
 import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -241,7 +242,9 @@ case class Wallet(
     for {
       addressCount <- addressDAO.count()
       spendingInfoCount <- spendingInfoDAO.count()
-    } yield addressCount == 0 && spendingInfoCount == 0
+    } yield {
+      addressCount == 0 && spendingInfoCount == 0
+    }
 
   override def getBalance()(implicit
       ec: ExecutionContext
@@ -345,9 +348,10 @@ object Wallet extends WalletLogger {
   /** Creates the level 0 account for the given HD purpose, if the root account
     * exists do nothing
     */
-  private def createRootAccount(wallet: Wallet, keyManager: BIP39KeyManager)(
-      implicit ec: ExecutionContext
+  private def createRootAccount(wallet: Wallet)(implicit
+      ec: ExecutionContext
   ): DBIOAction[AccountDb, NoStream, Effect.Read & Effect.Write] = {
+    val keyManager = wallet.keyManager
     val coinType = HDUtil.getCoinType(keyManager.kmParams.network)
     val coin =
       HDCoin(purpose = keyManager.kmParams.purpose, coinType = coinType)
@@ -388,40 +392,41 @@ object Wallet extends WalletLogger {
       accountHandling: AccountHandlingApi,
       bip39PasswordOpt: Option[String]
   ): Future[Wallet] = {
-    implicit val walletAppConfig: WalletAppConfig = wallet.walletConfig
-    import walletAppConfig.ec
-    val passwordOpt = walletAppConfig.aesPasswordOpt
+    import wallet.walletConfig.ec
+    val passwordOpt = wallet.walletConfig.aesPasswordOpt
 
-    val createMasterXpubF = createMasterXPub(wallet.keyManager)
+    val createMasterXpubF =
+      createMasterXPub(wallet.keyManager)(wallet.walletConfig)
     // We want to make sure all level 0 accounts are created,
     // so the user can change the default account kind later
     // and still have their wallet work
     val createAccountActions: Vector[
-      DBIOAction[AccountDb, NoStream, Effect.Read & Effect.Write]
+      DBIOAction[(Wallet, AccountDb), NoStream, Effect.Read & Effect.Write]
     ] = {
       val accounts = HDPurpose.singleSigPurposes.map { purpose =>
         // we need to create key manager params for each purpose
         // and then initialize a key manager to derive the correct xpub
-        val kmParams = wallet.keyManager.kmParams.copy(purpose = purpose)
-        val kmE = {
-          BIP39KeyManager.fromParams(
-            kmParams = kmParams,
-            passwordOpt = passwordOpt,
-            bip39PasswordOpt = bip39PasswordOpt
-          )
-        }
-        kmE match {
-          case Right(km) =>
-            createRootAccount(wallet = wallet, keyManager = km)
-          case Left(err) =>
-            // probably means you haven't initialized the key manager via the
-            // 'CreateKeyManagerApi'
-            DBIOAction.failed(
-              new RuntimeException(
-                s"Failed to create keymanager with params=$kmParams err=$err"
-              )
-            )
-        }
+        val wAppConfig = wallet.walletConfig
+        val aesPwConfig =
+          passwordOpt
+            .map(p => s"bitcoin-s.keymanager.aesPassword=$p")
+            .getOrElse("")
+        val bip39PwConfig = bip39PasswordOpt
+          .map(p => s"bitcoin-s.keymanager.bip39password=$p")
+          .getOrElse("")
+        val purposeConfig =
+          s"bitcoin-s.wallet.purpose=${HDPurpose.toString(purpose)}"
+        val conf =
+          ConfigFactory.parseString(
+            Vector(aesPwConfig, bip39PwConfig, purposeConfig)
+              .filter(_.nonEmpty)
+              .mkString("\n"))
+        val kmAppConfig = wallet.walletConfig.kmConf.withOverrides(conf)
+        val walletAppConfig = wallet.walletConfig.copy(kmConfOpt =
+          Some(kmAppConfig))(wAppConfig.system)
+        val w = Wallet(nodeApi = wallet.nodeApi,
+                       chainQueryApi = wallet.chainQueryApi)(walletAppConfig)
+        createRootAccount(w).map((w, _))
 
       }
       accounts
@@ -429,23 +434,29 @@ object Wallet extends WalletLogger {
     for {
       _ <- createMasterXpubF
       actions = createAccountActions
-      accounts <- wallet.accountDAO.safeDatabase.runVec(
+      walletAndAccounts <- wallet.accountDAO.safeDatabase.runVec(
         DBIOAction.sequence(actions)
       )
+      accounts = walletAndAccounts.map(_._2)
+      initializedWallet = walletAndAccounts
+        .map(_._1)
+        .find(
+          _.walletConfig.defaultPurpose == wallet.walletConfig.defaultPurpose)
+        .get
       _ = accounts.foreach { a =>
         logger.info(s"Created account=${a} to DB")
       }
       _ <- {
         // check if creationTime is well in the past, if so generate a pool of addresses
         // see: https://github.com/bitcoin-s/bitcoin-s/issues/5033
-        val creationTime = wallet.keyManager.creationTime
+        val creationTime = initializedWallet.keyManager.creationTime
         val threshold = Instant.now().minus(1, ChronoUnit.HOURS)
         val isOldCreationTime = creationTime.compareTo(threshold) <= 0
         if (isOldCreationTime) {
           accountHandling
             .generateScriptPubKeys(
-              account = walletAppConfig.defaultAccount,
-              addressBatchSize = walletAppConfig.discoveryBatchSize,
+              account = wallet.walletConfig.defaultAccount,
+              addressBatchSize = wallet.walletConfig.discoveryBatchSize,
               forceGenerateSpks = true
             )
             .map(_ => ())
@@ -455,8 +466,9 @@ object Wallet extends WalletLogger {
         }
       }
     } yield {
-      logger.debug(s"Created root level accounts for wallet")
-      wallet
+      logger.debug(
+        s"Created root level accounts for wallet=${initializedWallet.walletConfig.walletName}")
+      initializedWallet
     }
   }
 }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.wallet
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.pekko.actor.ActorSystem
 import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.feeprovider.FeeRateApi
@@ -389,11 +389,9 @@ object Wallet extends WalletLogger {
 
   def initialize(
       wallet: Wallet,
-      accountHandling: AccountHandlingApi,
-      bip39PasswordOpt: Option[String]
+      accountHandling: AccountHandlingApi
   ): Future[Wallet] = {
     import wallet.walletConfig.ec
-    val passwordOpt = wallet.walletConfig.aesPasswordOpt
 
     val createMasterXpubF =
       createMasterXPub(wallet.keyManager)(wallet.walletConfig)
@@ -407,21 +405,28 @@ object Wallet extends WalletLogger {
         // we need to create key manager params for each purpose
         // and then initialize a key manager to derive the correct xpub
         val wAppConfig = wallet.walletConfig
-        val aesPwConfig =
-          passwordOpt
-            .map(p => s"bitcoin-s.keymanager.aesPassword=$p")
-            .getOrElse("")
-        val bip39PwConfig = bip39PasswordOpt
-          .map(p => s"bitcoin-s.keymanager.bip39password=$p")
-          .getOrElse("")
+//        val aesPwConfig =
+//          passwordOpt
+//            .map(p => s"bitcoin-s.keymanager.aesPassword=$p")
+//            .getOrElse("")
+//        val bip39PwConfig = bip39PasswordOpt
+//          .map(p => s"bitcoin-s.keymanager.bip39password=$p")
+//          .getOrElse("")
         val purposeConfig =
           s"bitcoin-s.wallet.purpose=${HDPurpose.toString(purpose)}"
-        val conf =
-          ConfigFactory.parseString(
-            Vector(aesPwConfig, bip39PwConfig, purposeConfig)
-              .filter(_.nonEmpty)
-              .mkString("\n"))
-        val kmAppConfig = wallet.walletConfig.kmConf.withOverrides(conf)
+
+        val walletConf: Config =
+          ConfigFactory
+            .parseString(
+              Vector(purposeConfig)
+                .filter(_.nonEmpty)
+                .mkString("\n"))
+
+        val overrides =
+          (walletConf +: wallet.walletConfig.configOverrides)
+            .foldLeft(ConfigFactory.empty())(_.withFallback(_))
+        val kmAppConfig =
+          wallet.walletConfig.kmConf.withOverrides(Vector(overrides.resolve()))
         val walletAppConfig = wallet.walletConfig.copy(kmConfOpt =
           Some(kmAppConfig))(wAppConfig.system)
         val w = Wallet(nodeApi = wallet.nodeApi,

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -213,10 +213,8 @@ case class WalletAppConfig(
   private def masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
 
   override def start(): Future[Unit] = {
-    logger.info(s"WalletAppConfig.start()")
     for {
       _ <- super.start()
-      _ = logger.info(s"Done super.start()")
       _ <- kmConf.start()
       masterXpub = kmConf.toBip39KeyManager.getRootXPub
       numMigrations = migrate()
@@ -233,7 +231,6 @@ case class WalletAppConfig(
           MasterXPubUtil.checkMasterXPub(masterXpub, masterXPubDAO)
         }
       }
-      _ = logger.info(s"Done checking seed and master xpub")
       _ = startFeeRateCallbackScheduler()
     } yield {
       logger.debug(s"Initializing wallet setup")
@@ -446,8 +443,7 @@ object WalletAppConfig
           Wallet(nodeApi, chainQueryApi)
 
         Wallet.initialize(
-          wallet = unInitializedWallet,
-          accountHandling = unInitializedWallet.accountHandling
+          wallet = unInitializedWallet
         )
       }
     }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -435,8 +435,6 @@ object WalletAppConfig
   ): Future[Wallet] = {
     import system.dispatcher
     val walletF = walletConf.hasWallet().flatMap { walletExists =>
-      val bip39PasswordOpt = walletConf.bip39PasswordOpt
-
       if (walletExists) {
         logger.info(s"Using pre-existing wallet")
         val wallet =
@@ -449,8 +447,7 @@ object WalletAppConfig
 
         Wallet.initialize(
           wallet = unInitializedWallet,
-          accountHandling = unInitializedWallet.accountHandling,
-          bip39PasswordOpt = bip39PasswordOpt
+          accountHandling = unInitializedWallet.accountHandling
         )
       }
     }


### PR DESCRIPTION
fixes #6192

The performance hit we see in #6192 comes from reading the seed file from disk multiple times when processing a transaction in the wallet that is gossiped across the network. Now that we cache the keymanager, we just don't have to read the seed file from disk.

This takes processing a single transaction from ~100-200ms -> ~1ms.