### PR TITLE
Fix missing default parameter in `DLCAppConfig`

### DIFF
--- a/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
+++ b/dlc-wallet/src/main/scala/org/bitcoins/dlc/wallet/DLCAppConfig.scala
@@ -61,7 +61,7 @@ case class DLCAppConfig(
   override protected[bitcoins] def newConfigOfType(
       configs: Vector[Config]
   ): DLCAppConfig =
-    DLCAppConfig(baseDatadir, configs)
+    DLCAppConfig(baseDatadir, configs, walletConfigOpt = walletConfigOpt)
 
   override def appConfig: DLCAppConfig = this
 


### PR DESCRIPTION
`KeyManagerAppConfig` was also missing some default parameters but that is fixed in #6242 