### PR TITLE
Allow multiple database connection pools over the lifetime of `DbAppConfig`

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoinSAppConfig.scala
@@ -8,7 +8,6 @@ import org.bitcoins.commons.config.{AppConfig, ConfigOps}
 import org.bitcoins.commons.util.{BitcoinSLogger, ServerArgParser}
 import org.bitcoins.core.config.NetworkParameters
 import org.bitcoins.core.util.{StartStopAsync, TimeUtil}
-import org.bitcoins.db.DbManagement
 import org.bitcoins.dlc.node.config.DLCNodeAppConfig
 import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.keymanager.config.KeyManagerAppConfig
@@ -85,20 +84,8 @@ case class BitcoinSAppConfig(
     val torDependentConfigs: Vector[AppConfig] =
       Vector(nodeConf, bitcoindRpcConf, dlcNodeConf)
 
-    val dbConfigsDependentOnTor: Vector[DbManagement] =
-      Vector(nodeConf)
-
-    // run migrations here to avoid issues like: https://github.com/bitcoin-s/bitcoin-s/issues/4606
-    // since we don't require tor dependent configs
-    // to be fully started before completing the Future returned by this
-    // method, we need to run them on their own
-    val migrateTorDependentDbConfigsF =
-      Future.traverse(dbConfigsDependentOnTor)(dbConfig =>
-        Future(dbConfig.migrate()))
-
     val startedTorDependentConfigsF = for {
       _ <- torConfig
-      _ <- migrateTorDependentDbConfigsF
       _ <- Future.traverse(torDependentConfigs)(_.start())
     } yield ()
 
@@ -109,7 +96,7 @@ case class BitcoinSAppConfig(
     }
 
     for {
-      _ <- migrateTorDependentDbConfigsF
+      _ <- startedTorDependentConfigsF
       _ <- startedNonTorConfigsF
     } yield {
       logger.info(

--- a/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/config/ChainAppConfigTest.scala
@@ -20,20 +20,6 @@ class ChainAppConfigTest extends ChainUnitTest {
 
   behavior of "ChainAppConfig"
 
-  it must "initialize our chain project" in { c =>
-    val chainAppConfig = c.withOverrides(
-      ConfigFactory.parseString("bitcoin-s.logging.level=OFF")
-    )
-    val isInitF = chainAppConfig.isStarted()
-
-    for {
-      isInit <- isInitF
-      _ = assert(!isInit)
-      _ <- chainAppConfig.start()
-      isInitAgain <- chainAppConfig.isStarted()
-    } yield assert(isInitAgain)
-  }
-
   it must "be overridable" in { c =>
     assert(c.network == RegTest)
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -1,22 +1,51 @@
 package org.bitcoins.db
 
-import com.typesafe.config._
-import org.bitcoins.commons.config._
+import com.typesafe.config.*
+import org.bitcoins.commons.config.*
 import org.bitcoins.db.DatabaseDriver.{PostgreSQL, SQLite}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
 
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.TimeUnit
-import scala.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Failure, Success, Try}
 
 abstract class DbAppConfig extends AppConfig {
+  implicit def ec: ExecutionContext
+  private val isStarted: AtomicBoolean = new AtomicBoolean(false)
+
+  override def start(): Future[Unit] = {
+    super.start().map { _ =>
+      logger.info(s"Done super.start() DbAppConfig")
+      if (isStarted.compareAndSet(false, true)) {
+        logger.info(s"Starting DbAppConfig for module=${moduleName}")
+        // initialize the database connection pool
+        slickDbConfig
+      } else {
+        logger.info(s"${getClass.getSimpleName} was already started")
+      }
+    }
+  }
 
   /** Releases the thread pool associated with this AppConfig's DB */
   override def stop(): Future[Unit] = {
-    Future.successful(slickDbConfig.db.close())
+    if (isStarted.compareAndSet(true, false)) {
+      logger.info(s"Stopping DbAppConfig for module=${moduleName}")
+      slickDbConfigOpt match {
+        case None => Future.unit
+        case Some(c) =>
+          slickDbConfigOpt = None
+          Future {
+            blocking { c.db.close() }
+          }
+      }
+    } else {
+      logger.info(s"${getClass.getSimpleName} was already stopped")
+      Future.unit
+    }
   }
 
   lazy val dbUsername: String =
@@ -114,42 +143,54 @@ abstract class DbAppConfig extends AppConfig {
       None
   }
 
-  lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
-    // Create overrides if modules want to change their path or db name.
-    // safePathToString returns a quoted, forward-slash-normalised string
-    // safe for embedding directly into HOCON on all platforms.
-    val overrideConf = ConfigFactory.parseString {
-      s"""
-         |bitcoin-s {
-         |  $moduleName {
-         |     db {
-         |        path = ${AppConfig.safePathToString(dbPath)}
-         |        name = $dbName
-         |        user = "$dbUsername"
-         |        password = "$dbPassword"
-         |        url = $jdbcUrl
-         |        registerMbeans = false
-         |     }
-         |  }
-         |}
+  private var slickDbConfigOpt: Option[DatabaseConfig[JdbcProfile]] = None
+  def slickDbConfig: DatabaseConfig[JdbcProfile] = {
+    if (slickDbConfigOpt.isEmpty && isStarted.get()) {
+      logger.info(s"Starting database connection pool for module=$moduleName")
+
+      val overrideConf = ConfigFactory.parseString {
+        s"""
+           |bitcoin-s {
+           |  $moduleName {
+           |     db {
+           |        path = ${AppConfig.safePathToString(dbPath)}
+           |        name = $dbName
+           |        user = "$dbUsername"
+           |        password = "$dbPassword"
+           |        url = $jdbcUrl
+           |        registerMbeans = false
+           |     }
+           |  }
+           |}
       """.stripMargin
-    }
+      }
 
-    val usedConf = overrideConf.withFallback(config)
-    Try {
-      val c = DatabaseConfig.forConfig[JdbcProfile](path =
-                                                      s"bitcoin-s.$moduleName",
-                                                    config = usedConf)
-
-      logger.trace(s"Resolved DB config: ${ConfigOps(c.config).asReadableJson}")
-      c
-    } match {
-      case Success(value) =>
-        value
-      case Failure(exception) =>
-        logger.error(s"Error when loading database from config: $exception")
-        logger.error(s"Configuration: ${usedConf.asReadableJson}")
-        throw exception
+      val usedConf = overrideConf.withFallback(config)
+      Try {
+        val c =
+          DatabaseConfig.forConfig[JdbcProfile](path = s"bitcoin-s.$moduleName",
+                                                config = usedConf)
+        // don't log entire config in prod due to secrets such as password
+        // may be useful for debugging in dev, but be careful in prod
+//        logger.trace(
+//          s"Resolved DB config: ${ConfigOps(c.config).asReadableJson}")
+        slickDbConfigOpt = Some(c)
+        slickDbConfigOpt.get
+      } match {
+        case Success(value) =>
+          value
+        case Failure(exception) =>
+          logger.error(s"Error when loading database from config: $exception")
+          // don't log entire config in prod due to secrets such as password
+          // may be useful for debugging in dev, but be careful in prod
+//          logger.error(s"Configuration: ${usedConf.asReadableJson}")
+          throw exception
+      }
+    } else if (slickDbConfigOpt.isDefined && isStarted.get()) {
+      slickDbConfigOpt.get
+    } else {
+      sys.error(
+        s"Cannot get slickDbConfig for module=$moduleName because the config is not started yet")
     }
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -1,11 +1,12 @@
 package org.bitcoins.db
 
 import org.bitcoins.commons.util.BitcoinSLogger
-import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.db.DatabaseDriver._
+import org.bitcoins.db.DatabaseDriver.*
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.{CleanResult, MigrateResult}
 import org.flywaydb.core.api.{FlywayException, MigrationInfoService}
+import slick.jdbc.JdbcDataSource
+import slick.jdbc.hikaricp.HikariCPJdbcDataSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -15,7 +16,8 @@ trait DbManagement extends BitcoinSLogger {
 
   import scala.language.implicitConversions
 
-  protected lazy val flyway: Flyway = {
+  protected def flyway: Flyway = {
+    val jdbcUrl = appConfig.jdbcUrl.replace("\"", "")
     // create the database if it doesn't exist yet in sqlite3
     appConfig.driver match {
       case SQLite =>
@@ -44,11 +46,26 @@ trait DbManagement extends BitcoinSLogger {
       }
     }
 
-    // Remove "s needed for config
-    val url = appConfig.jdbcUrl.replace("\"", "")
-    config
-      .dataSource(url, appConfig.dbUsername, appConfig.dbPassword)
-      .load
+    // Reuse the already-running HikariCP DataSource from Slick rather than
+    // creating a second connection pool via .dataSource(url, user, password).
+    // slickDbConfig.db.source is a HikariCPJdbcDataSource whose .ds field is
+    // a com.zaxxer.hikari.HikariDataSource (extends javax.sql.DataSource).
+    appConfig.slickDbConfig.db.source match {
+      case h: HikariCPJdbcDataSource if h.ds.getMaximumPoolSize > 1 =>
+        // flyway requires 2 database connections to run migrations
+        logger.debug(
+          s"Using existing HikariCP connection pool for flyway with ${h.getClass.getSimpleName}")
+        config
+          .dataSource(h.ds)
+          .load()
+      case j: JdbcDataSource =>
+        logger.debug(
+          s"No connection pool found in slickDbConfig, falling back to adhoc connections for flyway ${j.getClass.getSimpleName}")
+        config
+          .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
+          .load()
+    }
+
   }
 
   /** Internally, slick defines the schema member as
@@ -76,18 +93,6 @@ trait DbManagement extends BitcoinSLogger {
   }
 
   def allTables: List[TableQuery[Table[?]]]
-
-  def dropAll()(implicit ec: ExecutionContext): Future[Unit] = {
-    val result =
-      FutureUtil
-        .foldLeftAsync((), allTables.reverse) { (_, table) =>
-          dropTable(table)
-        }
-    result.failed.foreach { e =>
-      e.printStackTrace()
-    }
-    result
-  }
 
   /** The query needed to create the given table */
   private def createTableQuery(
@@ -119,32 +124,6 @@ trait DbManagement extends BitcoinSLogger {
     val result = database.run(query)
     result
   }
-
-  def dropTable(tableName: String)(implicit
-      ec: ExecutionContext): Future[Int] = {
-    val fullTableName =
-      appConfig.schemaName.map(_ + ".").getOrElse("") + tableName
-    val sql = sqlu"""DROP TABLE IF EXISTS #$fullTableName"""
-    val result = database.run(sql)
-    result.failed.foreach { ex =>
-      ex.printStackTrace()
-    }
-    result
-  }
-
-  def createSchema(createIfNotExists: Boolean = true)(implicit
-      ec: ExecutionContext): Future[Unit] =
-    appConfig.schemaName match {
-      case None =>
-        Future.unit
-      case Some(schema) =>
-        val sql =
-          if (createIfNotExists)
-            sqlu"""CREATE SCHEMA IF NOT EXISTS #$schema"""
-          else
-            sqlu"""CREATE SCHEMA #$schema"""
-        database.run(sql).map(_ => ())
-    }
 
   /** Returns flyway information about the state of migrations
     * @see
@@ -183,6 +162,7 @@ trait DbManagement extends BitcoinSLogger {
         flyway.baseline()
         flyway.migrate()
     }
+
   }
 
   /** Runs flyway clean

--- a/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/JdbcProfileComponent.scala
@@ -13,7 +13,7 @@ trait JdbcProfileComponent[+ConfigType <: DbAppConfig] extends BitcoinSLogger {
   /** The configuration details for connecting/using the database for our
     * projects that require database connections
     */
-  lazy val dbConfig: DatabaseConfig[JdbcProfile] = {
+  def dbConfig: DatabaseConfig[JdbcProfile] = {
     appConfig.slickDbConfig
   }
 

--- a/db-commons/src/main/scala/org/bitcoins/db/SQLiteUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/SQLiteUtil.scala
@@ -62,14 +62,18 @@ object SQLiteUtil extends BitcoinSLogger {
   }
 
   def createDbFileIfDNE(dbPath: Path, dbName: String): Unit = {
+    // Ensure the database directory exists
     if (!Files.exists(dbPath)) {
-      val _ = {
-        logger.debug(s"Creating database directory=${dbPath}")
-        Files.createDirectories(dbPath)
-        val dbFilePath = dbPath.resolve(dbName)
-        logger.debug(s"Creating database file=$dbFilePath")
-        Files.createFile(dbFilePath)
-      }
+      logger.debug(s"Creating database directory=$dbPath")
+      Files.createDirectories(dbPath)
+    }
+
+    val dbFilePath = dbPath.resolve(dbName)
+    if (!Files.exists(dbFilePath)) {
+      logger.debug(s"Creating database file=$dbFilePath")
+      Files.createFile(dbFilePath)
+    } else {
+      logger.debug(s"Database file already exists: $dbFilePath")
     }
   }
 }

--- a/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfigTest.scala
+++ b/dlc-oracle-test/src/test/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfigTest.scala
@@ -49,6 +49,8 @@ class DLCOracleAppConfigTest extends DLCOracleAppConfigFixture {
       for {
         _ <- stoppedF
         pubKey2 <- dlcOracle2F.map(_.publicKey())
+        // start the old app config for fixture tear down
+        _ <- dlcOracleAppConfig.start()
       } yield {
         assert(pubKey1 == pubKey2)
       }

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -304,7 +304,6 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
         _ <- NodeTestUtil.disconnectNode(bitcoind, node)
         // fully functioning node no longer needed so shut it down
         _ <- node.stop()
-        _ <- node.nodeAppConfig.stop()
         hashes <- bitcoind.generate(2000)
         blockHeaders <- Source(hashes)
           .mapAsync(FutureUtil.getParallelism)(bitcoind.getBlockHeaderRaw)

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -25,8 +25,9 @@ bitcoin-s {
             # destroyed repeatedly per test with the same poolName, causing
             # InstanceAlreadyExistsException when HikariCP tries to re-register
             # a MBean that the previous pool's close() hasn't fully deregistered yet.
+
             registerMbeans = false
-        }
+         }
 
         #turn hikari logging off for tests
         hikari-logging = false

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/DbTestUtil.scala
@@ -7,7 +7,7 @@ import org.bitcoins.db.models.MasterXPubDAO
 import scodec.bits.ByteVector
 import slick.lifted.ProvenShape
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{Path}
 import scala.concurrent.{ExecutionContext, Future}
 
 object DbTestUtil {
@@ -60,11 +60,9 @@ case class TestAppConfig(baseDatadir: Path, configOverrides: Vector[Config])(
   override def appConfig: TestAppConfig = this
 
   override def start(): Future[Unit] = {
-    if (Files.notExists(datadir)) {
-      Files.createDirectories(datadir)
-    }
     for {
       _ <- super.start()
+      _ = migrate()
       _ = logger.debug(s"Initializing test setup")
       _ <- createTable(TestDAO()(ec, this).table)
     } yield ()

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/TestAppConfigFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/TestAppConfigFixture.scala
@@ -32,16 +32,14 @@ trait TestAppConfigFixture
     val config =
       TestAppConfig(BitcoinSTestAppConfig.tmpDir(), Vector(configOverride))
 
-    val _ = config.migrate()
     config.start().map { _ =>
       config
     }
   }
 
   def destroyTestConfig(testConfig: TestAppConfig): Future[Unit] = {
+    testConfig.clean()
     for {
-      _ <- testConfig.dropTable("flyway_schema_history")
-      _ <- testConfig.dropAll()
       _ <- testConfig.stop()
     } yield ()
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/db/TestDAOFixture.scala
@@ -37,20 +37,22 @@ sealed trait TestDAOFixture
     super.afterAll()
   }
 
-  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     makeFixture(
       build = () => testConfig.start().map(_ => TestDAO()),
-      destroy = () => dropAll()
+      destroy = () => dropAll()(testConfig)
     )(test)
   }
 
-  def dropAll(): Future[Unit] =
-    for {
-      _ <- testConfig.dropTable("flyway_schema_history")
-      _ <- testConfig.dropAll()
-    } yield ()
+  def dropAll()(testAppConfig: TestAppConfig): Future[Unit] = {
+    // these tables aren't managed by flyway so can't just call .clean()
+    import testAppConfig.profile.api.*
+    val testDAO = TestDAO()(executionContext, testAppConfig)
+    val action = testDAO.table.schema.dropIfExists
+    testDAO.safeDatabase.run(action)
+  }
 
-  val testDb: TestDb = TestDb("abc", hex"0054")
+  val testDb: TestDb = TestDb("abcd", hex"0054")
 
   val testDbs: Vector[TestDb] = Vector(
     TestDb("abc", hex"0050"),

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCDAOFixture.scala
@@ -6,7 +6,6 @@ import org.bitcoins.dlc.wallet.models.*
 import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, PostgresTestDatabase}
 import org.scalatest.*
-
 import java.nio.file.Files
 
 trait DLCDAOFixture extends BitcoinSFixture with PostgresTestDatabase {
@@ -56,6 +55,7 @@ trait DLCDAOFixture extends BitcoinSFixture with PostgresTestDatabase {
       },
       destroy = { (daos: DLCDAOs) =>
         val config = daos.dlcConf
+        val _ = config.clean()
         for {
           _ <- config.stop()
           _ = config.driver match {
@@ -67,7 +67,7 @@ trait DLCDAOFixture extends BitcoinSFixture with PostgresTestDatabase {
               Files.deleteIfExists(
                 config.dbPath.resolve(config.dbName + "-shm"))
             case PostgreSQL =>
-              config.clean()
+              ()
           }
         } yield ()
       }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleDAOFixture.scala
@@ -41,6 +41,7 @@ trait DLCOracleDAOFixture extends BitcoinSFixture with PostgresTestDatabase {
   }
 
   private def dropAll(config: DLCOracleAppConfig): Future[Unit] = {
+    config.clean()
     for {
       _ <- config.stop()
       _ = config.driver match {
@@ -49,7 +50,7 @@ trait DLCOracleDAOFixture extends BitcoinSFixture with PostgresTestDatabase {
           Files.deleteIfExists(config.dbPath.resolve(config.dbName + "-wal"))
           Files.deleteIfExists(config.dbPath.resolve(config.dbName + "-shm"))
         case PostgreSQL =>
-          config.clean()
+          ()
       }
     } yield ()
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/DLCOracleFixture.scala
@@ -16,7 +16,6 @@ trait DLCOracleFixture extends BitcoinSFixture with PostgresTestDatabase {
     val builder: () => Future[DLCOracle] = () => {
       val conf: DLCOracleAppConfig =
         BitcoinSTestAppConfig.getDLCOracleWithEmbeddedDbTestConfig(postgresOpt)
-      val _ = conf.migrate()
 
       val oracleConfF: Future[Unit] = conf.start()
 

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestUtil.scala
@@ -331,7 +331,7 @@ abstract class NodeTestUtil extends P2PLogger {
   ): Future[NeutrinoNode] = {
     val stoppedConfigF = for {
       _ <- initNode.stop()
-      _ <- initNode.nodeAppConfig.stop()
+//      _ <- initNode.nodeAppConfig.stop()
     } yield ()
     val newNodeAppConfigF =
       stoppedConfigF.map(_ => initNode.nodeAppConfig.withOverrides(config))

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -519,7 +519,7 @@ object NodeUnitTest extends P2PLogger {
     */
   private def cleanTables(appConfig: BitcoinSAppConfig): Unit = {
     appConfig.nodeConf.clean()
-    appConfig.walletConf.clean()
+    // appConfig.walletConf.clean()
     appConfig.chainConf.clean()
     ()
   }

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -8,7 +8,7 @@ import org.bitcoins.core.api.chain.ChainQueryApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.api.wallet.WalletApi
 import org.bitcoins.core.currency.*
-import org.bitcoins.dlc.wallet.{DLCAppConfig, DLCWallet}
+import org.bitcoins.dlc.wallet.DLCWallet
 import org.bitcoins.node.NodeCallbacks
 import org.bitcoins.rpc.client.common.{BitcoindRpcClient, BitcoindVersion}
 import org.bitcoins.server.{BitcoinSAppConfig, BitcoindRpcBackendUtil}
@@ -39,13 +39,7 @@ trait BitcoinSWalletTest
     with PostgresTestDatabase {
   import BitcoinSWalletTest._
 
-  implicit protected def getFreshDLCAppConfig: DLCAppConfig = {
-    getFreshConfig.dlcConf
-  }
-
   override def beforeAll(): Unit = {
-    AppConfig.throwIfDefaultDatadir(getFreshConfig.walletConf)
-    AppConfig.throwIfDefaultDatadir(getFreshConfig.dlcConf)
     super[PostgresTestDatabase].beforeAll()
   }
 
@@ -522,9 +516,8 @@ object BitcoinSWalletTest extends WalletLogger {
   def destroyWalletAppConfig(
       walletAppConfig: WalletAppConfig
   )(implicit ec: ExecutionContext): Future[Unit] = {
+    walletAppConfig.clean()
     for {
-      _ <- walletAppConfig.dropTable("flyway_schema_history")
-      _ <- walletAppConfig.dropAll()
       _ <- walletAppConfig.stop()
     } yield ()
   }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/TrezorAddressTest.scala
@@ -297,10 +297,8 @@ class TrezorAddressTest extends BitcoinSWalletTest with EmptyFixture {
     }
 
     assertionsF.flatMap { _ =>
-      for {
-        _ <- conf.dropAll()
-        _ = conf.clean()
-      } yield succeed
+      conf.clean()
+      conf.stop().map(_ => succeed)
     }
   }
 

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletAppConfigTest.scala
@@ -97,34 +97,46 @@ class WalletAppConfigTest extends BitcoinSWalletTest {
       assert(appConfig.network == TestNet3)
   }
 
-  // re-enable this test when https://github.com/bitcoin-s/bitcoin-s/pull/6245
-  // is merged with proper connection pool handling
-//  it must "fail to start the wallet app config if we have different seeds" in {
-//    (config: WalletAppConfig) =>
-//      val seedFile = config.seedPath
-//      val startedF = config.start()
-//
-//      // stop old oracle
-//      val stoppedF = for {
-//        _ <- startedF
-//        _ <- config.stop()
-//      } yield ()
-//
-//      val deletedF = for {
-//        _ <- stoppedF
-//      } yield {
-//        // delete the seed so we start with a new seed
-//        Files.delete(seedFile)
-//      }
-//
-//      val start2F = for {
-//        _ <- deletedF
-//        _ <- config.start()
-//      } yield ()
-//
-//      // start it again and except an exception
-//      recoverToSucceededIf[RuntimeException] {
-//        start2F
-//      }
-//  }
+  it must "fail to start the wallet app config if we have different seeds" in {
+    (config: WalletAppConfig) =>
+      val seedFile = config.seedPath
+      val startedF = config.start()
+
+      // stop old oracle
+      val stoppedF = for {
+        _ <- startedF
+        _ <- config.stop()
+      } yield ()
+
+      val deletedF = for {
+        _ <- stoppedF
+      } yield {
+        // delete the seed so we start with a new seed
+        Files.delete(seedFile)
+      }
+
+      val start2F = for {
+        _ <- deletedF
+        _ <- config.start()
+      } yield ()
+
+      // start it again and expect an exception
+      recoverToSucceededIf[RuntimeException] {
+        start2F
+      }
+  }
+
+  it must "be able to reuse database connections across after starting/stopping the app config" in {
+    (config: WalletAppConfig) =>
+      val stoppedF = for {
+        hasWallet <- config.hasWallet()
+        _ = assert(!hasWallet)
+        _ <- config.stop()
+        // fails because db connection pool not started
+        _ = assertThrows[RuntimeException](config.hasWallet())
+        _ <- config.start() // restart so fixture can tear it down correctly
+      } yield {}
+
+      stoppedF.map(_ => succeed)
+  }
 }

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -395,22 +395,17 @@ class WalletUnitTest extends BitcoinSWalletTest {
 
         // create a new wallet config so we get a fresh connection pool
         // we should be able to remove this once we have #6245
-        newWalletConfig = wallet.walletConfig.copy()
-
-        _ = newWalletConfig.migrate()
-
-        // create a new wallet using the new config with refreshed connection pool
-        newWallet = Wallet(wallet.nodeApi, wallet.chainQueryApi)(
-          newWalletConfig)
+        walletConfig = wallet.walletConfig
+        _ <- walletConfig.stop().flatMap(_ => walletConfig.start())
 
         // initialize it
         initOldWallet <- Wallet.initialize(
-          wallet = newWallet,
-          accountHandling = newWallet.accountHandling,
-          bip39PasswordOpt = newWalletConfig.bip39PasswordOpt
+          wallet = wallet,
+          accountHandling = wallet.accountHandling,
+          bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
         )
         isOldWalletEmpty <- initOldWallet.isEmpty()
-        _ <- newWalletConfig.stop()
+//        _ <- initOldWallet.stop()
       } yield assert(!isOldWalletEmpty)
 
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/Wallet.scala
@@ -54,27 +54,27 @@ case class Wallet(
 
   val networkParameters: BitcoinNetwork = walletConfig.network
 
-  private[bitcoins] val walletDAOs: WalletDAOs =
+  private[bitcoins] def walletDAOs: WalletDAOs =
     WalletDAOs.fromWalletConfig(walletConfig)
 
-  private[bitcoins] val addressDAO: AddressDAO = walletDAOs.addressDAO
-  private[bitcoins] val accountDAO: AccountDAO = walletDAOs.accountDAO
-  private[bitcoins] val spendingInfoDAO: SpendingInfoDAO = walletDAOs.utxoDAO
-  private[bitcoins] val transactionDAO: TransactionDAO =
+  private[bitcoins] def addressDAO: AddressDAO = walletDAOs.addressDAO
+  private[bitcoins] def accountDAO: AccountDAO = walletDAOs.accountDAO
+  private[bitcoins] def spendingInfoDAO: SpendingInfoDAO = walletDAOs.utxoDAO
+  private[bitcoins] def transactionDAO: TransactionDAO =
     walletDAOs.transactionDAO
-  private[bitcoins] val scriptPubKeyDAO: ScriptPubKeyDAO =
+  private[bitcoins] def scriptPubKeyDAO: ScriptPubKeyDAO =
     walletDAOs.scriptPubKeyDAO
 
-  private[bitcoins] val incomingTxDAO: IncomingTransactionDAO =
+  private[bitcoins] def incomingTxDAO: IncomingTransactionDAO =
     walletDAOs.incomingTxDAO
 
-  private[bitcoins] val outgoingTxDAO: OutgoingTransactionDAO =
+  private[bitcoins] def outgoingTxDAO: OutgoingTransactionDAO =
     walletDAOs.outgoingTxDAO
-  private[bitcoins] val addressTagDAO: AddressTagDAO = walletDAOs.addressTagDAO
+  private[bitcoins] def addressTagDAO: AddressTagDAO = walletDAOs.addressTagDAO
 
-  private[bitcoins] val stateDescriptorDAO: WalletStateDescriptorDAO =
+  private[bitcoins] def stateDescriptorDAO: WalletStateDescriptorDAO =
     walletDAOs.stateDescriptorDAO
-  protected lazy val safeDatabase: SafeDatabase = spendingInfoDAO.safeDatabase
+  protected def safeDatabase: SafeDatabase = spendingInfoDAO.safeDatabase
 
   val creationTime: Instant = keyManager.creationTime
 

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -90,13 +90,16 @@ case class WalletAppConfig(
   lazy val torConf: TorAppConfig =
     TorAppConfig(baseDatadir, Some(moduleName), configOverrides)
 
-  private[wallet] lazy val scheduler: ScheduledExecutorService = {
+  private var schedulerOpt: Option[ScheduledExecutorService] = None
+  private def makeScheduler: ScheduledExecutorService =
     Executors.newScheduledThreadPool(
       1,
       AsyncUtil.getNewThreadFactory(
         s"bitcoin-s-wallet-scheduler-${System.currentTimeMillis()}"
       )
     )
+  private[wallet] def scheduler: ScheduledExecutorService = {
+    schedulerOpt.get
   }
 
   override lazy val callbackFactory: WalletCallbacks.type = WalletCallbacks
@@ -210,10 +213,10 @@ case class WalletAppConfig(
   private def masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
 
   override def start(): Future[Unit] = {
-    startFeeRateCallbackScheduler()
-
+    logger.info(s"WalletAppConfig.start()")
     for {
       _ <- super.start()
+      _ = logger.info(s"Done super.start()")
       _ <- kmConf.start()
       masterXpub = kmConf.toBip39KeyManager.getRootXPub
       numMigrations = migrate()
@@ -230,6 +233,8 @@ case class WalletAppConfig(
           MasterXPubUtil.checkMasterXPub(masterXpub, masterXPubDAO)
         }
       }
+      _ = logger.info(s"Done checking seed and master xpub")
+      _ = startFeeRateCallbackScheduler()
     } yield {
       logger.debug(s"Initializing wallet setup")
       if (isHikariLoggingEnabled) {
@@ -257,7 +262,8 @@ case class WalletAppConfig(
       // this eagerly shuts down all scheduled tasks on the scheduler
       // in the future, we should actually cancel all things that are scheduled
       // manually, and then shutdown the scheduler
-      scheduler.shutdownNow()
+      schedulerOpt.map(_.shutdownNow())
+      schedulerOpt = None
       super.stop()
     }
 
@@ -272,22 +278,22 @@ case class WalletAppConfig(
   /** Checks if the following exist
     *   1. A seed exists 2. wallet exists 3. The account exists
     */
-  def hasWallet()(implicit
-      walletConf: WalletAppConfig,
-      ec: ExecutionContext
-  ): Future[Boolean] = {
+  def hasWallet(): Future[Boolean] = {
     if (kmConf.seedExists()) {
-      val hdCoin = walletConf.defaultAccount.coin
-      val walletDB = walletConf.dbPath `resolve` walletConf.dbName
-      walletConf.driver match {
+      val hdCoin = defaultAccount.coin
+      val walletDB = dbPath `resolve` dbName
+      driver match {
         case PostgreSQL =>
-          AccountDAO().read((hdCoin, 0)).map(_.isDefined)
+          logger.info(s"Reading postgres wallet database for account existence")
+          AccountDAO()(ec, this).read((hdCoin, 0)).map(_.isDefined)
         case SQLite =>
           if (Files.exists(walletDB))
-            AccountDAO().read((hdCoin, 0)).map(_.isDefined)
+            AccountDAO()(ec, this).read((hdCoin, 0)).map(_.isDefined)
           else Future.successful(false)
       }
     } else {
+      logger.info(
+        s"Seed file does not exist at path=${kmConf.seedPath}, wallet is not setup")
       Future.successful(false)
     }
   }
@@ -365,33 +371,41 @@ case class WalletAppConfig(
   }
 
   private def startFeeRateCallbackScheduler(): Unit = {
-    val feeRateChangedRunnable = new Runnable {
-      override def run(): Unit = {
-        feeRateApi
-          .getFeeRate()
-          .map(feeRate => Some(feeRate))
-          .recover { case NonFatal(_) =>
-            // logger.error("Cannot get fee rate ", ex)
-            None
-          }
-          .foreach { feeRateOpt =>
-            callBacks.executeOnFeeRateChanged(
-              feeRateOpt.getOrElse(SatoshisPerVirtualByte.negativeOne)
-            )
-          }
-        ()
+    if (schedulerOpt.isEmpty) {
+      logger.info(s"Starting wallet fee rate callback scheduler")
+      schedulerOpt = Some(makeScheduler)
+      val feeRateChangedRunnable = new Runnable {
+        override def run(): Unit = {
+          feeRateApi
+            .getFeeRate()
+            .map(feeRate => Some(feeRate))
+            .recover { case NonFatal(_) =>
+              // logger.error("Cannot get fee rate ", ex)
+              None
+            }
+            .foreach { feeRateOpt =>
+              callBacks.executeOnFeeRateChanged(
+                feeRateOpt.getOrElse(SatoshisPerVirtualByte.negativeOne)
+              )
+            }
+          ()
+        }
       }
+
+      val cancel: ScheduledFuture[?] = scheduler.scheduleAtFixedRate(
+        feeRateChangedRunnable,
+        feeRatePollDelay.toSeconds,
+        feeRatePollInterval.toSeconds,
+        TimeUnit.SECONDS
+      )
+      feeRateCancelOpt = Some(cancel)
+    } else {
+      logger.warn(
+        s"Wallet fee rate callback scheduler is already running, not starting another one")
+      ()
     }
-
-    val cancel: ScheduledFuture[?] = scheduler.scheduleAtFixedRate(
-      feeRateChangedRunnable,
-      feeRatePollDelay.toSeconds,
-      feeRatePollInterval.toSeconds,
-      TimeUnit.SECONDS
-    )
-    feeRateCancelOpt = Some(cancel)
-
   }
+
 }
 
 object WalletAppConfig


### PR DESCRIPTION
Allow more than one instance of `slickDbConfig` over the life time of a `DbAppConfig`. This allows us to call `DbAppConfig.{start(),stop()}` multiple times.