### PR TITLE
dbCommons: Fix setting WAL for sqlite connections, don't register mbeans

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -161,7 +161,9 @@ abstract class AppConfig extends StartStopAsync[Unit] with BitcoinSLogger {
 object AppConfig extends BitcoinSLogger {
 
   def safePathToString(path: Path): String = {
-    val pathStr = path.toString.replace("\\", "/")
+    val pathStr = path.toString
+      .replace("\\", "/")
+      .replace("\\", "\\\\")
 
     s""""$pathStr"""" // Add quotes around it
   }

--- a/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/config/AppConfig.scala
@@ -163,7 +163,6 @@ object AppConfig extends BitcoinSLogger {
   def safePathToString(path: Path): String = {
     val pathStr = path.toString
       .replace("\\", "/")
-      .replace("\\", "\\\\")
 
     s""""$pathStr"""" // Add quotes around it
   }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -45,10 +45,10 @@ abstract class DbAppConfig extends AppConfig {
         // disabled connection pool (plain JDBC) is in use.
         // connectionInitSql is HikariCP-specific and has no effect when
         // connectionPool = disabled.
-        // Backslashes in Windows paths must be escaped for HOCON embedding.
-        val escapedPath =
-          AppConfig.safePathToString(dbPath)
-        s""""jdbc:sqlite:$escapedPath/$dbName?journal_mode=WAL""""
+
+        s""""jdbc:sqlite:${AppConfig
+            .safePathToString(dbPath)
+            .replace("\"", "")}/$dbName?journal_mode=WAL""""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }
@@ -104,17 +104,15 @@ abstract class DbAppConfig extends AppConfig {
   }
 
   lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
-    // Create overrides if modules want to change their path or db name
-    // On Windows, Path.toString uses backslashes which are HOCON escape
-    // characters. We must escape them (\ → \\) before embedding in the
-    // config string, otherwise HOCON rejects sequences like \U, \A, \R etc.
-    val safePath = AppConfig.safePathToString(dbPath)
+    // Create overrides if modules want to change their path or db name.
+    // safePathToString returns a quoted, forward-slash-normalised string
+    // safe for embedding directly into HOCON on all platforms.
     val overrideConf = ConfigFactory.parseString {
       s"""
          |bitcoin-s {
          |  $moduleName {
          |     db {
-         |        path = "$safePath"
+         |        path = ${AppConfig.safePathToString(dbPath)}
          |        name = $dbName
          |        user = "$dbUsername"
          |        password = "$dbPassword"

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -40,7 +40,13 @@ abstract class DbAppConfig extends AppConfig {
   lazy val jdbcUrl: String = {
     driver match {
       case SQLite =>
-        s""""jdbc:sqlite:"${AppConfig.safePathToString(dbPath)}/$dbName"""
+        // journal_mode=WAL is set in the URL so it applies at the JDBC driver
+        // level on every connection, regardless of whether HikariCP or Slick's
+        // disabled connection pool (plain JDBC) is in use.
+        // connectionInitSql is HikariCP-specific and has no effect when
+        // connectionPool = disabled.
+        s""""jdbc:sqlite:${AppConfig.safePathToString(
+            dbPath)}/$dbName?journal_mode=WAL""""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }
@@ -97,16 +103,6 @@ abstract class DbAppConfig extends AppConfig {
 
   lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
     // Create overrides if modules want to change their path or db name
-
-    // For SQLite, set WAL journal mode on every new HikariCP connection.
-    // connectionInitSql must NOT be set for PostgreSQL — PRAGMA is
-    // SQLite-only syntax and Postgres will reject it with a syntax error,
-    // causing every new pool connection to fail.
-    val connectionInitSqlLine = driver match {
-      case SQLite     => """connectionInitSql = "PRAGMA journal_mode=WAL;""""
-      case PostgreSQL => ""
-    }
-
     val overrideConf = ConfigFactory.parseString {
       s"""
          |bitcoin-s {
@@ -119,7 +115,6 @@ abstract class DbAppConfig extends AppConfig {
          |        url = $jdbcUrl
          |        # cannot put in testkit/reference.conf due to https://github.com/bitcoin-s/bitcoin-s/issues/5391
          |        registerMbeans = false
-         |        $connectionInitSqlLine
          |     }
          |  }
          |}

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -112,7 +112,7 @@ abstract class DbAppConfig extends AppConfig {
          |        name = $dbName
          |        user = "$dbUsername"
          |        password = "$dbPassword"
-         |        url = $jdbcUrl
+         |        url = "$jdbcUrl"
          |        # cannot put in testkit/reference.conf due to issue 5391
          |        registerMbeans = false
          |     }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -112,8 +112,7 @@ abstract class DbAppConfig extends AppConfig {
          |        name = $dbName
          |        user = "$dbUsername"
          |        password = "$dbPassword"
-         |        url = "$jdbcUrl"
-         |        # cannot put in testkit/reference.conf due to issue 5391
+         |        url = $jdbcUrl
          |        registerMbeans = false
          |     }
          |  }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -113,7 +113,7 @@ abstract class DbAppConfig extends AppConfig {
          |        user = "$dbUsername"
          |        password = "$dbPassword"
          |        url = $jdbcUrl
-         |        # cannot put in testkit/reference.conf due to https://github.com/bitcoin-s/bitcoin-s/issues/5391
+         |        # cannot put in testkit/reference.conf due to issue 5391
          |        registerMbeans = false
          |     }
          |  }

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -45,8 +45,10 @@ abstract class DbAppConfig extends AppConfig {
         // disabled connection pool (plain JDBC) is in use.
         // connectionInitSql is HikariCP-specific and has no effect when
         // connectionPool = disabled.
-        s""""jdbc:sqlite:${AppConfig.safePathToString(
-            dbPath)}/$dbName?journal_mode=WAL""""
+        // Backslashes in Windows paths must be escaped for HOCON embedding.
+        val escapedPath =
+          AppConfig.safePathToString(dbPath)
+        s""""jdbc:sqlite:$escapedPath/$dbName?journal_mode=WAL""""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }
@@ -103,12 +105,16 @@ abstract class DbAppConfig extends AppConfig {
 
   lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
     // Create overrides if modules want to change their path or db name
+    // On Windows, Path.toString uses backslashes which are HOCON escape
+    // characters. We must escape them (\ → \\) before embedding in the
+    // config string, otherwise HOCON rejects sequences like \U, \A, \R etc.
+    val safePath = AppConfig.safePathToString(dbPath)
     val overrideConf = ConfigFactory.parseString {
       s"""
          |bitcoin-s {
          |  $moduleName {
          |     db {
-         |        path = ${AppConfig.safePathToString(dbPath)}
+         |        path = "$safePath"
          |        name = $dbName
          |        user = "$dbUsername"
          |        password = "$dbPassword"

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -97,6 +97,16 @@ abstract class DbAppConfig extends AppConfig {
 
   lazy val slickDbConfig: DatabaseConfig[JdbcProfile] = {
     // Create overrides if modules want to change their path or db name
+
+    // For SQLite, set WAL journal mode on every new HikariCP connection.
+    // connectionInitSql must NOT be set for PostgreSQL — PRAGMA is
+    // SQLite-only syntax and Postgres will reject it with a syntax error,
+    // causing every new pool connection to fail.
+    val connectionInitSqlLine = driver match {
+      case SQLite     => """connectionInitSql = "PRAGMA journal_mode=WAL;""""
+      case PostgreSQL => ""
+    }
+
     val overrideConf = ConfigFactory.parseString {
       s"""
          |bitcoin-s {
@@ -107,6 +117,9 @@ abstract class DbAppConfig extends AppConfig {
          |        user = "$dbUsername"
          |        password = "$dbPassword"
          |        url = $jdbcUrl
+         |        # cannot put in testkit/reference.conf due to https://github.com/bitcoin-s/bitcoin-s/issues/5391
+         |        registerMbeans = false
+         |        $connectionInitSqlLine
          |     }
          |  }
          |}

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -20,8 +20,6 @@ trait DbManagement extends BitcoinSLogger {
     appConfig.driver match {
       case SQLite =>
         SQLiteUtil.createDbFileIfDNE(appConfig.dbPath, appConfig.dbName)
-        val jdbcUrl = appConfig.jdbcUrl.replace("\"", "")
-        SQLiteUtil.setJournalMode(jdbcUrl, "WAL")
       case PostgreSQL =>
         ()
     }

--- a/db-commons/src/main/scala/org/bitcoins/db/SQLiteUtil.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/SQLiteUtil.scala
@@ -61,16 +61,6 @@ object SQLiteUtil extends BitcoinSLogger {
     } finally conn.close()
   }
 
-  def setJournalMode(jdbcUrl: String, mode: String): Unit = {
-    val conn = java.sql.DriverManager.getConnection(jdbcUrl)
-    try {
-      val _ =
-        conn
-          .createStatement()
-          .executeUpdate(s"PRAGMA journal_mode=${mode.toUpperCase}")
-    } finally conn.close()
-  }
-
   def createDbFileIfDNE(dbPath: Path, dbName: String): Unit = {
     if (!Files.exists(dbPath)) {
       val _ = {

--- a/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
+++ b/dlc-oracle/src/main/scala/org/bitcoins/dlc/oracle/config/DLCOracleAppConfig.scala
@@ -168,7 +168,7 @@ case class DLCOracleAppConfig(
     initF
   }
 
-  private val masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
+  private def masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
 
   private lazy val masterXPubTable: TableQuery[Table[?]] = {
     masterXPubDAO.table

--- a/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
+++ b/key-manager-test/src/test/scala/org/bitcoins/keymanager/WalletStorageTest.scala
@@ -12,12 +12,12 @@ import org.bitcoins.testkit.wallet.BitcoinSWalletTest
 import org.bitcoins.testkitcore.Implicits._
 import org.bitcoins.testkitcore.gen.CryptoGenerators
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.scalatest.{BeforeAndAfterEach, FutureOutcome}
+import org.scalatest.FutureOutcome
 
 import java.nio.file.{Files, Path}
 import java.util.UUID
 
-class WalletStorageTest extends BitcoinSWalletTest with BeforeAndAfterEach {
+class WalletStorageTest extends BitcoinSWalletTest {
 
   override type FixtureParam = WalletAppConfig
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -20,6 +20,12 @@ bitcoin-s {
             numThreads = 1
             queueSize=5000
             connectionPool = disabled
+
+            # Disable JMX bean registration in tests. Pools are created and
+            # destroyed repeatedly per test with the same poolName, causing
+            # InstanceAlreadyExistsException when HikariCP tries to re-register
+            # a MBean that the previous pool's close() hasn't fully deregistered yet.
+            registerMbeans = false
         }
 
         #turn hikari logging off for tests

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/BitcoinSWalletTest.scala
@@ -50,10 +50,6 @@ trait BitcoinSWalletTest
   }
 
   override def afterAll(): Unit = {
-    Await.result(getFreshConfig.chainConf.stop(), 1.minute)
-    Await.result(getFreshConfig.nodeConf.stop(), 1.minute)
-    Await.result(getFreshConfig.walletConf.stop(), 1.minute)
-    Await.result(getFreshConfig.dlcConf.stop(), 1.minute)
     super[PostgresTestDatabase].afterAll()
     super[BitcoinSFixture].afterAll()
   }

--- a/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
+++ b/wallet/src/main/scala/org/bitcoins/wallet/config/WalletAppConfig.scala
@@ -207,7 +207,7 @@ case class WalletAppConfig(
         None
     }
   }
-  private val masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
+  private def masterXPubDAO: MasterXPubDAO = MasterXPubDAO()(ec, this)
 
   override def start(): Future[Unit] = {
     startFeeRateCallbackScheduler()


### PR DESCRIPTION
The `?journal_mode=WAL` query parameter is processed by the SQLite JDBC driver (org.sqlite.JDBC) when it opens a connection — before any pool logic runs. This avoids brittle sequencing of application code.

This PR also turns `registerMBeans = false` in the application code. We cannot set it in `testkit/reference.conf` because of #5391 