### PR TITLE
tests: Rework DBConfigTest to free resources after tests are complete

### DIFF
--- a/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/CommonRoutesSpec.scala
@@ -11,6 +11,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Files
+import scala.concurrent.Future
 
 class CommonRoutesSpec
     extends AnyWordSpec
@@ -58,10 +59,12 @@ class CommonRoutesSpec
           )
 
         Post() ~> route ~> check {
-          assert(contentType == ContentTypes.`application/json`)
-          val actualJson = ujson.read(responseAs[String])
-          assert(actualJson == expectedJson)
-          assert(Files.exists(target))
+          Future {
+            assert(contentType == ContentTypes.`application/json`)
+            val actualJson = ujson.read(responseAs[String])
+            assert(actualJson == expectedJson)
+            assert(Files.exists(target))
+          }
         }
       }
     }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
@@ -9,78 +9,88 @@ import org.bitcoins.testkit.BitcoinSTestAppConfig.ProjectType
 import org.bitcoins.testkit.util.{BitcoinSAsyncTest, FileUtil}
 import org.bitcoins.wallet.config.WalletAppConfig
 
-import java.io.File
-import java.nio.file._
+import java.nio.file.*
+import scala.concurrent.Future
 
 class DBConfigTest extends BitcoinSAsyncTest {
 
   it should "use sqlite as default database and set its connection pool size to 1" in {
     withTempDir { dataDir =>
-      val bytes = Files.readAllBytes(
-        new File("db-commons/src/main/resources/reference.conf").toPath
-      )
-      Files.write(
-        dataDir.resolve("bitcoin-s.conf"),
-        bytes,
-        StandardOpenOption.CREATE_NEW,
-        StandardOpenOption.WRITE
-      )
-
       val chainConfig = ChainAppConfig(dataDir, Vector.empty)
       val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
       val walletConfig = WalletAppConfig(dataDir, Vector.empty)
+      for {
+        _ <- chainConfig.start()
+        _ <- nodeConfig.start()
+        _ <- walletConfig.start()
+        slickChainConfig = chainConfig.slickDbConfig
+        _ = assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickChainConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickChainConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
 
-      val slickChainConfig = chainConfig.slickDbConfig
-      assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickChainConfig.config.hasPath("db.numThreads"))
-      assert(slickChainConfig.config.getInt("db.numThreads") == 1)
-      assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
+        slickNodeConfig = nodeConfig.slickDbConfig
+        _ = assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickNodeConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
 
-      val slickNodeConfig = nodeConfig.slickDbConfig
-      assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickNodeConfig.config.hasPath("db.numThreads"))
-      assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
-      assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
+        slickWalletConfig = walletConfig.slickDbConfig
+        _ = assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickWalletConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
 
-      val slickWalletConfig = walletConfig.slickDbConfig
-      assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickWalletConfig.config.hasPath("db.numThreads"))
-      assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
-      assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
+        _ <- chainConfig.stop()
+        _ <- nodeConfig.stop()
+        _ <- walletConfig.stop()
+      } yield {
+        succeed
+      }
+
     }
   }
 
   it should "use sqlite as default database and disable connection pool for tests" in {
     withTempDir { dataDir =>
       val chainConfig = ChainAppConfig(dataDir, Vector.empty)
-      val slickChainConfig = chainConfig.slickDbConfig
-      assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickChainConfig.config.hasPath("db.numThreads"))
-      assert(slickChainConfig.config.getInt("db.numThreads") == 1)
-      assert(
-        slickChainConfig.config.getString("db.connectionPool") == "disabled"
-      )
-      assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
-
       val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
-      val slickNodeConfig = nodeConfig.slickDbConfig
-      assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickNodeConfig.config.hasPath("db.numThreads"))
-      assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
-      assert(
-        slickNodeConfig.config.getString("db.connectionPool") == "disabled"
-      )
-      assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
-
       val walletConfig = WalletAppConfig(dataDir, Vector.empty)
-      val slickWalletConfig = walletConfig.slickDbConfig
-      assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
-      assert(slickWalletConfig.config.hasPath("db.numThreads"))
-      assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
-      assert(
-        slickWalletConfig.config.getString("db.connectionPool") == "disabled"
-      )
-      assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
+      for {
+        _ <- chainConfig.start()
+        _ <- nodeConfig.start()
+        _ <- walletConfig.start()
+        slickChainConfig = chainConfig.slickDbConfig
+        _ = assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickChainConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickChainConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(
+          slickChainConfig.config.getString("db.connectionPool") == "disabled"
+        )
+        _ = assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
+
+        slickNodeConfig = nodeConfig.slickDbConfig
+        _ = assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickNodeConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(
+          slickNodeConfig.config.getString("db.connectionPool") == "disabled"
+        )
+        _ = assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
+
+        slickWalletConfig = walletConfig.slickDbConfig
+        _ = assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
+        _ = assert(slickWalletConfig.config.hasPath("db.numThreads"))
+        _ = assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
+        _ = assert(
+          slickWalletConfig.config.getString("db.connectionPool") == "disabled"
+        )
+        _ = assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
+        _ <- chainConfig.stop()
+        _ <- nodeConfig.stop()
+        _ <- walletConfig.stop()
+      } yield succeed
+
     }
   }
 
@@ -102,6 +112,6 @@ class DBConfigTest extends BitcoinSAsyncTest {
     assert(mainNetChainAppConfig.network == MainNet)
   }
 
-  def withTempDir[T](f: Path => T): T =
+  def withTempDir[T](f: Path => Future[T]): Future[T] =
     FileUtil.withTempDir(getClass.getName)(f)
 }

--- a/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DbManagementTest.scala
@@ -2,19 +2,14 @@ package org.bitcoins.db
 
 import com.typesafe.config.Config
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.chain.db.ChainDbManagement
 import org.bitcoins.db.DatabaseDriver.*
 import org.bitcoins.dlc.oracle.config.DLCOracleAppConfig
-import org.bitcoins.dlc.wallet.{DLCAppConfig, DLCDbManagement}
+import org.bitcoins.dlc.wallet.DLCAppConfig
 import org.bitcoins.node.config.NodeAppConfig
-import org.bitcoins.node.db.NodeDbManagement
 import org.bitcoins.testkit.BitcoinSTestAppConfig.ProjectType
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.bitcoins.testkit.{BitcoinSTestAppConfig, PostgresTestDatabase}
 import org.bitcoins.wallet.config.WalletAppConfig
-import org.bitcoins.wallet.db.WalletDbManagement
-
-import scala.concurrent.ExecutionContext
 
 class DbManagementTest extends BitcoinSAsyncTest with PostgresTestDatabase {
 
@@ -22,87 +17,52 @@ class DbManagementTest extends BitcoinSAsyncTest with PostgresTestDatabase {
     BitcoinSTestAppConfig.configWithEmbeddedDb(Some(project), postgresOpt)
   }
 
-  def createChainDbManagement(
-      chainAppConfig: ChainAppConfig
-  ): ChainDbManagement =
-    new ChainDbManagement with JdbcProfileComponent[ChainAppConfig] {
-      override val ec: ExecutionContext = system.dispatcher
-
-      override def appConfig: ChainAppConfig = chainAppConfig
-    }
-
-  def createDLCDbManagement(dlcAppConfig: DLCAppConfig): DLCDbManagement =
-    new DLCDbManagement with JdbcProfileComponent[DLCAppConfig] {
-      override val ec: ExecutionContext = system.dispatcher
-
-      override def appConfig: DLCAppConfig = dlcAppConfig
-    }
-
-  def createWalletDbManagement(
-      walletAppConfig: WalletAppConfig
-  ): WalletDbManagement =
-    new WalletDbManagement with JdbcProfileComponent[WalletAppConfig] {
-      override val ec: ExecutionContext = system.dispatcher
-
-      override def appConfig: WalletAppConfig = walletAppConfig
-    }
-
-  def createNodeDbManagement(nodeAppConfig: NodeAppConfig): NodeDbManagement =
-    new NodeDbManagement with JdbcProfileComponent[NodeAppConfig] {
-      override val ec: ExecutionContext = system.dispatcher
-
-      override def appConfig: NodeAppConfig = nodeAppConfig
-    }
-
   it must "run migrations for chain db" in {
     val chainAppConfig = ChainAppConfig(
       BitcoinSTestAppConfig.tmpDir(),
       Vector(dbConfig(ProjectType.Chain))
     )
-    val chainDbManagement = createChainDbManagement(chainAppConfig)
-    val result = chainDbManagement.migrate()
-    chainAppConfig.driver match {
-      case SQLite =>
-        val expected = 7
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = chainDbManagement.info()
-        assert(flywayInfo.applied().length == expected)
-        assert(flywayInfo.pending().length == 0)
-      case PostgreSQL =>
-        val expected = 6
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = chainDbManagement.info()
-        // +1 for << Flyway Schema Creation >>
-        assert(flywayInfo.applied().length == expected + 1)
-        assert(flywayInfo.pending().length == 0)
-    }
-
+    for {
+      _ <- chainAppConfig.start()
+      _ = chainAppConfig.driver match {
+        case SQLite =>
+          val expected = 7
+          val flywayInfo = chainAppConfig.info()
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+        case PostgreSQL =>
+          val expected = 6
+          val flywayInfo = chainAppConfig.info()
+          // +1 for << Flyway Schema Creation >>
+          assert(flywayInfo.applied().length == expected + 1)
+          assert(flywayInfo.pending().length == 0)
+      }
+      _ <- chainAppConfig.stop()
+    } yield succeed
   }
 
   it must "run migrations for dlc db" in {
-    val dlcAppConfig =
-      DLCAppConfig(
-        BitcoinSTestAppConfig.tmpDir(),
-        Vector(dbConfig(ProjectType.DLC))
-      )
-    val dlcDbManagement = createDLCDbManagement(dlcAppConfig)
-    val result = dlcDbManagement.migrate()
-    dlcAppConfig.driver match {
-      case SQLite =>
-        val expected = 8
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = dlcAppConfig.info()
-        assert(flywayInfo.applied().length == expected)
-        assert(flywayInfo.pending().length == 0)
-      case PostgreSQL =>
-        val expected = 11
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = dlcAppConfig.info()
-
-        // +1 for << Flyway Schema Creation >>
-        assert(flywayInfo.applied().length == expected + 1)
-        assert(flywayInfo.pending().length == 0)
-    }
+    val dlcAppConfig = DLCAppConfig(
+      BitcoinSTestAppConfig.tmpDir(),
+      Vector(dbConfig(ProjectType.DLC))
+    )
+    for {
+      _ <- dlcAppConfig.start()
+      _ = dlcAppConfig.driver match {
+        case SQLite =>
+          val expected = 8
+          val flywayInfo = dlcAppConfig.info()
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+        case PostgreSQL =>
+          val expected = 11
+          val flywayInfo = dlcAppConfig.info()
+          // +1 for << Flyway Schema Creation >>
+          assert(flywayInfo.applied().length == expected + 1)
+          assert(flywayInfo.pending().length == 0)
+      }
+      _ <- dlcAppConfig.stop()
+    } yield succeed
   }
 
   it must "run migrations for wallet db" in {
@@ -110,52 +70,47 @@ class DbManagementTest extends BitcoinSAsyncTest with PostgresTestDatabase {
       BitcoinSTestAppConfig.tmpDir(),
       Vector(dbConfig(ProjectType.Wallet))
     )
-    val walletDbManagement = createWalletDbManagement(walletAppConfig)
-    val result = walletDbManagement.migrate()
-    walletAppConfig.driver match {
-      case SQLite =>
-        val expected = 18
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = walletDbManagement.info()
-        assert(flywayInfo.applied().length == expected)
-        assert(flywayInfo.pending().length == 0)
-      case PostgreSQL =>
-        val expected = 16
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = walletDbManagement.info()
-
-        // +1 for << Flyway Schema Creation >>
-        assert(flywayInfo.applied().length == expected + 1)
-        assert(flywayInfo.pending().length == 0)
-    }
-
+    for {
+      _ <- walletAppConfig.start()
+      _ = walletAppConfig.driver match {
+        case SQLite =>
+          val expected = 18
+          val flywayInfo = walletAppConfig.info()
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+        case PostgreSQL =>
+          val expected = 16
+          val flywayInfo = walletAppConfig.info()
+          // +1 for << Flyway Schema Creation >>
+          assert(flywayInfo.applied().length == expected + 1)
+          assert(flywayInfo.pending().length == 0)
+      }
+      _ <- walletAppConfig.stop()
+    } yield succeed
   }
 
   it must "run migrations for node db" in {
-    val nodeAppConfig =
-      NodeAppConfig(
-        BitcoinSTestAppConfig.tmpDir(),
-        Vector(dbConfig(ProjectType.Node))
-      )
-    val nodeDbManagement = createNodeDbManagement(nodeAppConfig)
-    val result = nodeDbManagement.migrate()
-    nodeAppConfig.driver match {
-      case SQLite =>
-        val expected = 5
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = nodeDbManagement.info()
-
-        assert(flywayInfo.applied().length == expected)
-        assert(flywayInfo.pending().length == 0)
-      case PostgreSQL =>
-        val expected = 5
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = nodeDbManagement.info()
-
-        // +1 for << Flyway Schema Creation >>
-        assert(flywayInfo.applied().length == expected + 1)
-        assert(flywayInfo.pending().length == 0)
-    }
+    val nodeAppConfig = NodeAppConfig(
+      BitcoinSTestAppConfig.tmpDir(),
+      Vector(dbConfig(ProjectType.Node))
+    )
+    for {
+      _ <- nodeAppConfig.start()
+      _ = nodeAppConfig.driver match {
+        case SQLite =>
+          val expected = 5
+          val flywayInfo = nodeAppConfig.info()
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+        case PostgreSQL =>
+          val expected = 5
+          val flywayInfo = nodeAppConfig.info()
+          // +1 for << Flyway Schema Creation >>
+          assert(flywayInfo.applied().length == expected + 1)
+          assert(flywayInfo.pending().length == 0)
+      }
+      _ <- nodeAppConfig.stop()
+    } yield succeed
   }
 
   it must "run migrations for oracle db" in {
@@ -164,23 +119,22 @@ class DbManagementTest extends BitcoinSAsyncTest with PostgresTestDatabase {
         BitcoinSTestAppConfig.tmpDir(),
         Vector(dbConfig(ProjectType.Oracle))
       )
-    val result = oracleAppConfig.migrate()
-    oracleAppConfig.driver match {
-      case SQLite =>
-        val expected = 6
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = oracleAppConfig.info()
-
-        assert(flywayInfo.applied().length == expected)
-        assert(flywayInfo.pending().length == 0)
-      case PostgreSQL =>
-        val expected = 6
-        assert(result.migrationsExecuted == expected)
-        val flywayInfo = oracleAppConfig.info()
-
-        // +1 for << Flyway Schema Creation >>
-        assert(flywayInfo.applied().length == expected + 1)
-        assert(flywayInfo.pending().length == 0)
-    }
+    for {
+      _ <- oracleAppConfig.start()
+      _ = oracleAppConfig.driver match {
+        case SQLite =>
+          val expected = 6
+          val flywayInfo = oracleAppConfig.info()
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+        case PostgreSQL =>
+          val expected = 7
+          val flywayInfo = oracleAppConfig.info()
+          // +1 for << Flyway Schema Creation >>
+          assert(flywayInfo.applied().length == expected)
+          assert(flywayInfo.pending().length == 0)
+      }
+      _ <- oracleAppConfig.stop()
+    } yield succeed
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -81,8 +81,8 @@ trait ChainUnitTest extends BitcoinSFixture {
   def withChainAppConfig(test: OneArgAsyncTest): FutureOutcome = {
     makeDependentFixture(
       build = () => {
-        Future.successful(
-          BitcoinSTestAppConfig.getNeutrinoTestConfig().chainConf)
+        val c = BitcoinSTestAppConfig.getNeutrinoTestConfig().chainConf
+        c.start().map(_ => c)
       },
       destroy = (chainAppConfig: ChainAppConfig) =>
         ChainUnitTest.destroyChainApi()(system, chainAppConfig)
@@ -676,11 +676,9 @@ object ChainUnitTest extends ChainVerificationLogger {
   def destroyAllTables()(implicit
       appConfig: ChainAppConfig,
       ec: ExecutionContext
-  ): Future[Unit] =
-    for {
-      _ <- appConfig.dropTable("flyway_schema_history")
-      _ <- appConfig.dropAll()
-    } yield ()
+  ): Future[Unit] = {
+    Future { appConfig.clean() }
+  }
 
   def setupHeaderTableWithGenesisHeader()(implicit
       ec: ExecutionContext,

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/fixture/ChainWithBitcoindUnitTest.scala
@@ -33,9 +33,13 @@ trait ChainWithBitcoindNewestCachedUnitTest
       bitcoindRpcClient: BitcoindRpcClient
   ): FutureOutcome = {
     val builder: () => Future[BitcoindBaseVersionChainHandlerViaRpc] = { () =>
-      ChainUnitTest.createChainApiWithBitcoindRpc(bitcoindRpcClient)(
-        executionContext,
-        chainAppConfig)
+      val c = chainAppConfig
+      for {
+        _ <- c.start()
+        chainApiBitcoind <- ChainUnitTest.createChainApiWithBitcoindRpc(
+          bitcoindRpcClient)(executionContext, c)
+      } yield chainApiBitcoind
+
     }
     val destroy: BitcoindBaseVersionChainHandlerViaRpc => Future[Unit] = {
       case b: BitcoindBaseVersionChainHandlerViaRpc =>

--- a/testkit/src/main/scala/org/bitcoins/testkit/util/FileUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/util/FileUtil.scala
@@ -5,6 +5,7 @@ import org.bitcoins.commons.util.BitcoinSLogger
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 import scala.annotation.tailrec
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Properties, Random}
 
 object FileUtil extends BitcoinSLogger {
@@ -61,14 +62,12 @@ object FileUtil extends BitcoinSLogger {
     f
   }
 
-  def withTempDir[T](prefix: String)(f: Path => T): T = {
+  def withTempDir[T](prefix: String)(f: Path => Future[T])(implicit
+      ec: ExecutionContext): Future[T] = {
     val dir = Files.createTempDirectory(prefix)
-    try {
-      f(dir)
-    } finally {
-      deleteTmpDir(dir)
-      ()
-    }
+    val resultF = f(dir)
+    resultF.onComplete(_ => deleteTmpDir(dir))
+    resultF
   }
 
 }


### PR DESCRIPTION
Pull this over from #6245 as a small independent change

this makes `DBConfigTest` safer and cleans up resources such as database connections  after itself.