### PR TITLE
dbCommons: config: Add BUSY_TIMEOUT configuration setting for sqlite databases

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ bitcoin-s {
       queueSize=5000
       connectionPool = "HikariCP"
       registerMbeans = true
+
+      # timeout for waiting for the database to be free
+      # only applies to sqlite databases, as they do not support concurrent database operations
+      busy-timeout = 5s
     }
     hikari-logging = false
     hikari-logging-interval = 10 minute

--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -25,6 +25,15 @@ abstract class DbAppConfig extends AppConfig {
   lazy val dbPassword: String =
     config.getString(s"bitcoin-s.$moduleName.db.password")
 
+  private lazy val busyTimeout: FiniteDuration = {
+    val durationOpt =
+      config.getDurationOpt(s"bitcoin-s.$moduleName.db.busy-timeout")
+    durationOpt match {
+      case Some(d) => FiniteDuration(d.toMillis, TimeUnit.MILLISECONDS)
+      case None    => FiniteDuration(5, TimeUnit.SECONDS)
+    }
+  }
+
   lazy val driver: DatabaseDriver = {
     val driverStr =
       getConfigString(s"bitcoin-s.$moduleName.db.driver").toLowerCase
@@ -48,7 +57,9 @@ abstract class DbAppConfig extends AppConfig {
 
         s""""jdbc:sqlite:${AppConfig
             .safePathToString(dbPath)
-            .replace("\"", "")}/$dbName?journal_mode=WAL""""
+            .replace(
+              "\"",
+              "")}/$dbName?journal_mode=WAL&busy_timeout=${busyTimeout.toMillis}""""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -84,16 +84,19 @@ called [flyway](https://flywaydb.org/). To find your projects migraitons, you ne
 the path `chain/src/main/resources/chaindb/migration/V1__chain_db_baseline.sql`.
 
 Migrations can be executed by calling
-the [`DbManagement.migrate()`](https://github.com/bitcoin-s/bitcoin-s/blob/e387d075b0ff2e0a0fec15788fcb48e4ddc4d9d5/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala#L92)
+the [
+`DbManagement.migrate()`](https://github.com/bitcoin-s/bitcoin-s/blob/e387d075b0ff2e0a0fec15788fcb48e4ddc4d9d5/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala#L92)
 method. Migrations are applied by default on server startup, via
-the [`AppConfig.start()`](https://github.com/bitcoin-s/bitcoin-s/blob/master/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala#L49)
+the [
+`AppConfig.start()`](https://github.com/bitcoin-s/bitcoin-s/blob/master/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala#L49)
 method.
 
 These migrations are setup so that project's databases and migrations are independent of each other. Therefore if you
 want to use the `bitcoin-s-chain` project, but not the `bitcoin-s-wallet` project, wallet migrations are not applied. It
 should be noted if you are using a module as a library, you are responsible for configuring the database via
 [slick's configuration](https://scala-slick.org/doc/3.3.1/database.html#using-typesafe-config) and calling
-[`AppConfig.start()`](https://github.com/bitcoin-s/bitcoin-s/blob/master/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala#L49)
+[
+`AppConfig.start()`](https://github.com/bitcoin-s/bitcoin-s/blob/master/db-commons/src/main/scala/org/bitcoins/db/AppConfig.scala#L49)
 to ensure the entire module is initialized correctly.
 
 ## Example Configuration File
@@ -391,6 +394,10 @@ bitcoin-s {
         queueSize=5000
         connectionPool = "HikariCP"
         registerMbeans = true
+        
+      # timeout for waiting for the database to be free
+      # only applies to sqlite databases, as they do not support concurrent database operations
+        busy-timeout = 5s
       }
       hikari-logging = false
       hikari-logging-interval = 10 minute


### PR DESCRIPTION
## Add Configurable SQLite `BUSY_TIMEOUT` & Reuse Connection Pool for Flyway

### Problem
We have observed [`SQLITE_BUSY`](https://sqlite.org/rescode.html#busy) errors during concurrent database access, particularly when using WAL (#3704 #6246 ) mode. Additionally, Flyway migrations were creating ad-hoc connections to the database instead of reusing the existing connection pool, which exacerbated locking issues on SQLite during startup.

### Solution

1.  **Configurable `BUSY_TIMEOUT`:**
    - Introduced a new configuration parameter `busy-timeout` for SQLite database connections.
    - Appends `&busy_timeout=<milliseconds>` to the SQLite JDBC URL.
    - Defaults to **5 seconds** if not specified.
    - This allows SQLite to block and wait for a lock to clear instead of immediately failing with `SQLITE_BUSY`.

2.  **Flyway Connection Reuse:**
    - Updated `DbManagement.scala` to reuse the existing `HikariCP` data source for Flyway migrations.
    - This prevents multiple connections/locks on the SQLite database file during the migration phase, reducing the likelihood of contention.

### Configuration

The `busy-timeout` can be configured in your `application.conf` under the `db` section for any module.

**Example `application.conf`:**

```hocon
bitcoin-s {
  chain {
    db {
      # Wait up to 30 seconds for the database lock to clear
      busy-timeout = 30s
    }
  }
}
```

Related to #6245 #1840 