### PR TITLE
testkit: Renable hikari connection pool by default in test cases

### DIFF
--- a/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
+++ b/db-commons-test/src/test/scala/org/bitcoins/db/DBConfigTest.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Future
 
 class DBConfigTest extends BitcoinSAsyncTest {
 
-  it should "use sqlite as default database and set its connection pool size to 1" in {
+  it should "use sqlite as default database with a connection pool for tests" in {
     withTempDir { dataDir =>
       val chainConfig = ChainAppConfig(dataDir, Vector.empty)
       val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
@@ -25,65 +25,22 @@ class DBConfigTest extends BitcoinSAsyncTest {
         _ <- walletConfig.start()
         slickChainConfig = chainConfig.slickDbConfig
         _ = assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickChainConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickChainConfig.config.getInt("db.numThreads") == 1)
-        _ = assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
-
-        slickNodeConfig = nodeConfig.slickDbConfig
-        _ = assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickNodeConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
-        _ = assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
-
-        slickWalletConfig = walletConfig.slickDbConfig
-        _ = assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickWalletConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
-        _ = assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
-
-        _ <- chainConfig.stop()
-        _ <- nodeConfig.stop()
-        _ <- walletConfig.stop()
-      } yield {
-        succeed
-      }
-
-    }
-  }
-
-  it should "use sqlite as default database and disable connection pool for tests" in {
-    withTempDir { dataDir =>
-      val chainConfig = ChainAppConfig(dataDir, Vector.empty)
-      val nodeConfig = NodeAppConfig(dataDir, Vector.empty)
-      val walletConfig = WalletAppConfig(dataDir, Vector.empty)
-      for {
-        _ <- chainConfig.start()
-        _ <- nodeConfig.start()
-        _ <- walletConfig.start()
-        slickChainConfig = chainConfig.slickDbConfig
-        _ = assert(slickChainConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickChainConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickChainConfig.config.getInt("db.numThreads") == 1)
         _ = assert(
-          slickChainConfig.config.getString("db.connectionPool") == "disabled"
+          slickChainConfig.config.getString("db.connectionPool") == "HikariCP"
         )
         _ = assert(slickChainConfig.config.getInt("db.queueSize") == 5000)
 
         slickNodeConfig = nodeConfig.slickDbConfig
         _ = assert(slickNodeConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickNodeConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickNodeConfig.config.getInt("db.numThreads") == 1)
         _ = assert(
-          slickNodeConfig.config.getString("db.connectionPool") == "disabled"
+          slickNodeConfig.config.getString("db.connectionPool") == "HikariCP"
         )
         _ = assert(slickNodeConfig.config.getInt("db.queueSize") == 5000)
 
         slickWalletConfig = walletConfig.slickDbConfig
         _ = assert(slickWalletConfig.profileName == "slick.jdbc.SQLiteProfile")
-        _ = assert(slickWalletConfig.config.hasPath("db.numThreads"))
-        _ = assert(slickWalletConfig.config.getInt("db.numThreads") == 1)
         _ = assert(
-          slickWalletConfig.config.getString("db.connectionPool") == "disabled"
+          slickWalletConfig.config.getString("db.connectionPool") == "HikariCP"
         )
         _ = assert(slickWalletConfig.config.getInt("db.queueSize") == 5000)
         _ <- chainConfig.stop()

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -19,7 +19,7 @@ bitcoin-s {
             # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
             numThreads = 1
             queueSize=5000
-            connectionPool = disabled
+            connectionPool = "HikariCP"
 
             # Disable JMX bean registration in tests. Pools are created and
             # destroyed repeatedly per test with the same poolName, causing

--- a/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/wallet/FundWalletUtil.scala
@@ -228,9 +228,8 @@ object FundWalletUtil extends FundWalletUtil {
       )
       funded <- FundWalletUtil.fundWallet(wallet, config.walletConf)
     } yield {
-      FundedDLCWallet(funded.wallet.asInstanceOf[DLCWallet],
-                      config.walletConf,
-                      config.dlcConf)
+      val dlcWallet = funded.wallet.asInstanceOf[DLCWallet]
+      FundedDLCWallet(dlcWallet, dlcWallet.walletConfig, dlcWallet.dlcConfig)
     }
   }
 


### PR DESCRIPTION
Pulls over changes from #6245 to re-enable connection pooling in the `testkit/reference.conf`. This was originally disabled in #2121 due to `SQLITE_BUSY` errors. This should be fixed now with #6250 - so we should be able to re-enable connection pooling in tests to hopefully speed up the test suite. At minimum, this should make our test suite more like production environments leading to more production-like test suites.

