### PR TITLE
dbCommons: sqlite: Change `transaction_mode` to `IMMEDIATE` for sqlite

### DIFF
--- a/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbAppConfig.scala
@@ -59,7 +59,7 @@ abstract class DbAppConfig extends AppConfig {
             .safePathToString(dbPath)
             .replace(
               "\"",
-              "")}/$dbName?journal_mode=WAL&busy_timeout=${busyTimeout.toMillis}""""
+              "")}/$dbName?journal_mode=WAL&transaction_mode=IMMEDIATE&busy_timeout=${busyTimeout.toMillis}""""
       case PostgreSQL =>
         s""""jdbc:postgresql://$dbHost:$dbPort/$dbName""""
     }

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeUnitTest.scala
@@ -191,13 +191,13 @@ object NodeUnitTest extends P2PLogger {
   def destroyNode(node: Node, appConfig: BitcoinSAppConfig)(implicit
       ec: ExecutionContext
   ): Future[Unit] = {
-
     for {
       _ <- node.stop()
+      _ = cleanTables(appConfig)
       _ <- node.nodeAppConfig.stop()
       _ <- node.chainAppConfig.stop()
     } yield {
-      cleanTables(appConfig)
+      ()
     }
   }
 


### PR DESCRIPTION
### SQLite `transaction_mode=IMMEDIATE`

SQLite’s default transaction mode is **DEFERRED** (`BEGIN`). In this mode, no locks are acquired when a transaction starts. The database only attempts to acquire a write lock **when the first write occurs**. If another connection already holds a write lock at that point, the transaction fails with `SQLITE_BUSY`.

With multiple connections (e.g., via a connection pool) this can create a race condition:

```
Conn A: BEGIN
Conn B: BEGIN
Conn A: SELECT ...
Conn B: INSERT ...
Conn A: INSERT → SQLITE_BUSY
```


Even though the transaction started successfully, it may fail later when it attempts to upgrade to a write lock.

Setting `transaction_mode=IMMEDIATE` changes transactions to start with `BEGIN IMMEDIATE`. This **acquires the write reservation at the start of the transaction** rather than when the first write occurs. If another writer is active, SQLite will wait (respecting `busy_timeout`) before the transaction begins.

This avoids mid-transaction lock upgrades and reduces `SQLITE_BUSY` errors in environments with multiple connections (e.g., Flyway migrations or pooled JDBC connections).

**Summary**

| Mode | Lock behavior |
|-----|---------------|
| `DEFERRED` (default) | Write lock acquired when the first write occurs |
| `IMMEDIATE` | Write lock reserved when the transaction begins |

The `IMMEDIATE` strategy trades slightly earlier lock contention for more predictable behavior and fewer write races in concurrent workloads.

Related to #6245 #2121 #6250 
