### PR TITLE
2026 03 11 Bump database connection pool size from `1` -> `4` by default

### DIFF
--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -16,9 +16,10 @@ bitcoin-s {
       host = localhost
       port = 5432
 
-      # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
-      # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
-      numThreads = 1
+      # numThreads is the number of threads in the connection pool,
+      # it should be at least as large as the number of concurrent database operations you expect to have.
+      # The default value is 4, which should be sufficient for most use cases.
+      numThreads = 4
       queueSize=5000
       connectionPool = "HikariCP"
       registerMbeans = true

--- a/db-commons/src/main/resources/reference.conf
+++ b/db-commons/src/main/resources/reference.conf
@@ -26,7 +26,7 @@ bitcoin-s {
 
       # timeout for waiting for the database to be free
       # only applies to sqlite databases, as they do not support concurrent database operations
-      busy-timeout = 5s
+      busy-timeout = 30s
     }
     hikari-logging = false
     hikari-logging-interval = 10 minute

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -2,10 +2,12 @@ package org.bitcoins.db
 
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.db.DatabaseDriver._
+import org.bitcoins.db.DatabaseDriver.*
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.{CleanResult, MigrateResult}
 import org.flywaydb.core.api.{FlywayException, MigrationInfoService}
+import slick.jdbc.JdbcDataSource
+import slick.jdbc.hikaricp.HikariCPJdbcDataSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -45,10 +47,30 @@ trait DbManagement extends BitcoinSLogger {
     }
 
     // Remove "s needed for config
-    val url = appConfig.jdbcUrl.replace("\"", "")
-    config
-      .dataSource(url, appConfig.dbUsername, appConfig.dbPassword)
-      .load
+    val jdbcUrl = appConfig.jdbcUrl.replace("\"", "")
+    // Reuse the already-running HikariCP DataSource from Slick rather than
+    // creating a second connection pool via .dataSource(url, user, password).
+    // slickDbConfig.db.source is a HikariCPJdbcDataSource whose .ds field is
+    // a com.zaxxer.hikari.HikariDataSource (extends javax.sql.DataSource).
+    appConfig.slickDbConfig.db.source match {
+      case h: HikariCPJdbcDataSource if h.ds.getMaximumPoolSize > 1 =>
+        config
+          .dataSource(h.ds)
+          .load()
+      case h: HikariCPJdbcDataSource =>
+        logger.warn(
+          s"Hikari pool size is too small (${h.ds.getMaximumPoolSize}) for Flyway to run with the pool (needs > 1). Falling back to adhoc connections.")
+        config
+          .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
+          .load()
+      case j: JdbcDataSource =>
+        logger.warn(
+          s"No connection pool found in slickDbConfig, falling back to adhoc connections for flyway ${j.getClass.getSimpleName}")
+        config
+          .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
+          .load()
+    }
+
   }
 
   /** Internally, slick defines the schema member as

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -2,12 +2,10 @@ package org.bitcoins.db
 
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.util.FutureUtil
-import org.bitcoins.db.DatabaseDriver.*
+import org.bitcoins.db.DatabaseDriver._
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.{CleanResult, MigrateResult}
 import org.flywaydb.core.api.{FlywayException, MigrationInfoService}
-import slick.jdbc.JdbcDataSource
-import slick.jdbc.hikaricp.HikariCPJdbcDataSource
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -47,31 +45,10 @@ trait DbManagement extends BitcoinSLogger {
     }
 
     // Remove "s needed for config
-    val jdbcUrl = appConfig.jdbcUrl.replace("\"", "")
-
-    // Reuse the already-running HikariCP DataSource from Slick rather than
-    // creating a second connection pool via .dataSource(url, user, password).
-    // slickDbConfig.db.source is a HikariCPJdbcDataSource whose .ds field is
-    // a com.zaxxer.hikari.HikariDataSource (extends javax.sql.DataSource).
-    appConfig.slickDbConfig.db.source match {
-      case h: HikariCPJdbcDataSource if h.ds.getMaximumPoolSize > 1 =>
-        config
-          .dataSource(h.ds)
-          .load()
-      case h: HikariCPJdbcDataSource =>
-        logger.debug(
-          s"Hikari pool size is too small (${h.ds.getMaximumPoolSize}) for Flyway to run with the pool (needs > 1). Falling back to adhoc connections.")
-        config
-          .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
-          .load()
-      case j: JdbcDataSource =>
-        logger.debug(
-          s"No connection pool found in slickDbConfig, falling back to adhoc connections for flyway ${j.getClass.getSimpleName}")
-        config
-          .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
-          .load()
-    }
-
+    val url = appConfig.jdbcUrl.replace("\"", "")
+    config
+      .dataSource(url, appConfig.dbUsername, appConfig.dbPassword)
+      .load
   }
 
   /** Internally, slick defines the schema member as

--- a/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
+++ b/db-commons/src/main/scala/org/bitcoins/db/DbManagement.scala
@@ -48,6 +48,7 @@ trait DbManagement extends BitcoinSLogger {
 
     // Remove "s needed for config
     val jdbcUrl = appConfig.jdbcUrl.replace("\"", "")
+
     // Reuse the already-running HikariCP DataSource from Slick rather than
     // creating a second connection pool via .dataSource(url, user, password).
     // slickDbConfig.db.source is a HikariCPJdbcDataSource whose .ds field is
@@ -58,13 +59,13 @@ trait DbManagement extends BitcoinSLogger {
           .dataSource(h.ds)
           .load()
       case h: HikariCPJdbcDataSource =>
-        logger.warn(
+        logger.debug(
           s"Hikari pool size is too small (${h.ds.getMaximumPoolSize}) for Flyway to run with the pool (needs > 1). Falling back to adhoc connections.")
         config
           .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)
           .load()
       case j: JdbcDataSource =>
-        logger.warn(
+        logger.debug(
           s"No connection pool found in slickDbConfig, falling back to adhoc connections for flyway ${j.getClass.getSimpleName}")
         config
           .dataSource(jdbcUrl, appConfig.dbUsername, appConfig.dbPassword)

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -390,14 +390,14 @@ bitcoin-s {
   
         # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
         # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
-        numThreads = 1
+        numThreads = 4
         queueSize=5000
         connectionPool = "HikariCP"
         registerMbeans = true
         
-      # timeout for waiting for the database to be free
-      # only applies to sqlite databases, as they do not support concurrent database operations
-        busy-timeout = 5s
+        # timeout for waiting for the database to be free
+        # only applies to sqlite databases, as they do not support concurrent database operations
+        busy-timeout = 30s
       }
       hikari-logging = false
       hikari-logging-interval = 10 minute

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -15,9 +15,6 @@ bitcoin-s {
             host = localhost
             port = 5432
 
-            # this needs to be set to 1 for SQLITE as it does not support concurrent database operations
-            # see: https://github.com/bitcoin-s/bitcoin-s/pull/1840
-            numThreads = 1
             queueSize=5000
             connectionPool = "HikariCP"
 

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -17,7 +17,10 @@ bitcoin-s {
 
             queueSize=5000
             connectionPool = "HikariCP"
-
+            # numThreads is the number of threads in the connection pool,
+            # it should be at least as large as the number of concurrent database operations you expect to have.
+            # The default value is 4, which should be sufficient for most use cases.
+            numThreads = 4
             # Disable JMX bean registration in tests. Pools are created and
             # destroyed repeatedly per test with the same poolName, causing
             # InstanceAlreadyExistsException when HikariCP tries to re-register

--- a/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
+++ b/wallet-test/src/test/scala/org/bitcoins/wallet/WalletUnitTest.scala
@@ -381,21 +381,36 @@ class WalletUnitTest extends BitcoinSWalletTest {
             // cannot delete database file if using postgres
             ()
           } else {
-            val path = wallet.walletConfig.datadir
+            val dbPath = wallet.walletConfig.datadir
               .resolve(wallet.walletConfig.walletName)
-              .resolve("walletdb.sqlite")
-            Files.delete(path)
+            val path = dbPath.resolve("walletdb.sqlite")
+            val walPath = dbPath.resolve("walletdb.sqlite-wal")
+            val shmPath = dbPath.resolve("walletdb.sqlite-shm")
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(walPath)
+            Files.deleteIfExists(shmPath)
           }
 
         }
-        _ = wallet.walletConfig.migrate()
+
+        // create a new wallet config so we get a fresh connection pool
+        // we should be able to remove this once we have #6245
+        newWalletConfig = wallet.walletConfig.copy()
+
+        _ = newWalletConfig.migrate()
+
+        // create a new wallet using the new config with refreshed connection pool
+        newWallet = Wallet(wallet.nodeApi, wallet.chainQueryApi)(
+          newWalletConfig)
+
         // initialize it
         initOldWallet <- Wallet.initialize(
-          wallet = wallet,
-          accountHandling = wallet.accountHandling,
-          bip39PasswordOpt = wallet.walletConfig.bip39PasswordOpt
+          wallet = newWallet,
+          accountHandling = newWallet.accountHandling,
+          bip39PasswordOpt = newWalletConfig.bip39PasswordOpt
         )
         isOldWalletEmpty <- initOldWallet.isEmpty()
+        _ <- newWalletConfig.stop()
       } yield assert(!isOldWalletEmpty)
 
   }


### PR DESCRIPTION
Built ontop of #6252 

This PR does 2 things

1. Lifts the number of database connections in the connection pool from `1` -> `4` by default.
2. ~If we the connection pool of size `maxConnections > 1`, re-use the database connection pool for applying flyway migrations.~ This cannot be done until we have #6245 as `DbAppConfig`'s can only represent 1 connection pool while the instance of `DbAppConfig` is allocated on the JVM.

Mostly pulled over from #6245 