### PR TITLE
build: Re-add `{wallet,oracle}-server-extra-startup-script.sh` and `DISABLE_JLINK` flag

### DIFF
--- a/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
+++ b/app/oracle-server/src/universal/oracle-server-extra-startup-script.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
+  fi
+
+
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
+  fi
+fi
+
+get_java_no_jlink() {
+  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
+
+if [[ -n "$DISABLE_JLINK" ]]; then
+  echo "jlink disabled by the DISABLE_JLINK environment variable, defaulting to JAVA_HOME for java"
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi
+
+
+chip=$(uname -m)
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  # see https://github.com/bitcoin-s/bitcoin-s/issues/4369!
+  echo "Removing ARM jre as its not linked correctly, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/app/server/src/universal/wallet-server-extra-startup-script.sh
+++ b/app/server/src/universal/wallet-server-extra-startup-script.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+if [[ -z "$DISABLE_JLINK" ]]; then
+  if test -f "jre/bin/java"; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine jre/bin/java
+    fi
+    chmod +x jre/bin/java #make sure java is executable
+  fi
+
+  if test -f "../jre/bin/java" ; then
+    if [[ "$OS" == "OSX" ]]; then
+      #mac doesn't allow random binaries to be executable
+      #remove the quarantine attribute so java is executable on mac
+      xattr -d com.apple.quarantine ../jre/bin/java
+    fi
+    chmod +x ../jre/bin/java #make sure java is executable
+  fi
+fi
+
+chip=$(uname -m)
+
+get_java_no_jlink() {
+  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
+
+if [[ -n "$DISABLE_JLINK" ]]; then
+  echo "jlink disabled by the DISABLE_JLINK environment variable, defaulting to JAVA_HOME for java"
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi
+
+if [[ $chip == "arm64" || $chip == "aarch64" ]]; then
+  # This is needed as a hack for now
+  # This replaces overrides how sbt native packager finds java
+  # on users machines when the user is running arm64.
+  # This is needed because we don't have access to a CI environment with arm64
+  # and the jlink jre we ship is broken because its built against x86
+  # this simply copies the 'get_java` bash function and removes the first
+  # check to see if there is a bundled_jvm built by jlink if the detected
+  # computer arch is arm64 or aarch64. This means a user if they are running
+  # arm64 / aarch64 will need to provide their own jre
+  echo "Removing jre as its not linked correctly on ARM machines, see https://github.com/bitcoin-s/bitcoin-s/issues/4369!"
+
+  # java_cmd is overrode in process_args when -java-home is used
+  declare java_cmd=$(get_java_no_jlink)
+
+  # if configuration files exist, prepend their contents to $@ so it can be processed by this runner
+  [[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+  run "$@"
+fi

--- a/build.sbt
+++ b/build.sbt
@@ -385,6 +385,7 @@ lazy val oracleServer = project
   .settings(jlinkModules --= CommonSettings.rmJlinkModules)
   .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.oracleServerJlinkIgnore)
+  .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "oracle-server-extra-startup-script.sh"))
   .dependsOn(
     dlcOracle,
     serverRoutes
@@ -421,6 +422,7 @@ lazy val appServer = project
   .settings(jlinkModules --= CommonSettings.rmJlinkModules)
   .settings(jlinkOptions ++= CommonSettings.jlinkOptions)
   .settings(jlinkIgnoreMissingDependency := CommonSettings.appServerJlinkIgnore)
+  .settings(bashScriptExtraDefines ++= IO.readLines(baseDirectory.value / "src" / "universal" / "wallet-server-extra-startup-script.sh"))
   .dependsOn(
     serverRoutes,
     appCommons,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   web:
     image: bitcoinscala/wallet-server-ui:latest


### PR DESCRIPTION
fixes broken jlink jre on arm64 machines. Undoes part of #6201 . Related to #4369 

The problem is that the jlink step runs on the host (CI/amd64) before Docker even starts, so both the amd64 and arm64 images end up with the same amd64 JRE baked in. Buildx handles the OS/arch layers correctly, but sbt's jlink artifact is pre-built and just copied in — so the ARM image is broken.

https://github.com/bitcoin-s/bitcoin-s/blob/d29b2440ab48e877ef16739824c194aa05bf76f2/.github/workflows/docker-publish.yml#L9

This means that the `jre/` runtime that gets copied into the docker image is also a x86 jre - NOT an arm64 jre. While the container infrastructure itself is compatible with arm64 as per `docker buildx` (#3649).

This PR restores the `DISABLE_JLINK` flag so the the container's base image `jre` installation (`eclipse-temurin:21`) will be used.

https://github.com/bitcoin-s/bitcoin-s/blob/59317dc3614aa87a9fa6f81ea785369132adc9fc/project/CommonSettings.scala#L181