### PR TITLE
docs: Update docker compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For a complete guide on how to get started with Bitcoin-S, see our website at [B
 In this repo, you can just run
 
 ```
-APP_PASSWORD=topsecret docker-compose up
+APP_PASSWORD=topsecret docker compose up
 ```
 
 which will spin up a docker environment that starts syncing the backend and will allow you to visit

--- a/docs/applications/web-ui.md
+++ b/docs/applications/web-ui.md
@@ -5,17 +5,19 @@ title: Application server and Web UI
 
 ## Application server and Web UI
 
-### docker-compose 
+### docker-compose
 
 To start the application server along with the Web UI you can use `docker-compose`.
 
-We provide a `docker-compose.yml` (https://github.com/bitcoin-s/bitcoin-s/blob/master/docker-compose.yml) file that uses the latest stable versions of the application server and the Web UI.
+We provide a `docker-compose.yml` (https://github.com/bitcoin-s/bitcoin-s/blob/master/docker-compose.yml) file that uses
+the latest stable versions of the application server and the Web UI.
 
-The application server requires a password to be set in order to start. You can use the `APP_PASSWORD` environment variable to do so.
+The application server requires a password to be set in order to start. You can use the `APP_PASSWORD` environment
+variable to do so.
 
 ```shell
-$ APP_PASSWORD=<your password> docker-compose up
+$ APP_PASSWORD=<your password> docker compose up
 ```
 
-The server is configured to work as a neutrino wallet, and it uses `neutrino.suredbits.com` as a peer. 
-If you want to connect to another peer change the `BITCOIN_S_NODE_PEERS` variable in the `docker-conpose.yml` file. 
+The server is configured to work as a neutrino wallet.
+If you want to connect to another peer change the `BITCOIN_S_NODE_PEERS` variable in the `docker-compose.yml` file.


### PR DESCRIPTION
This PR updates documentation examples to use the modern docker compose command instead of the deprecated standalone docker-compose script.

Motivation: Newer versions of Docker Engine (v25+) no longer return the ContainerConfig field in container inspection data. This causes the legacy python-based docker-compose tool to crash with KeyError: 'ContainerConfig' during recreation of containers. Switching to the built-in docker compose CLI plugin resolves this issue and aligns with current Docker best practices.