### PR TITLE
cliGrpc: Implement bitcoin-s-cli-grpc

### DIFF
--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -34,4 +34,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-app-chain-core-tests-cache
       - name: run tests
-        run: sbt coverage dbCommonsTest/test chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test serverGrpcTest/test
+        run: sbt coverage dbCommonsTest/test chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test serverGrpcTest/test cliGrpcTest/test

--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -32,4 +32,4 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-wallet-node-dlc-test-cache
       - name: run tests
-        run: sbt coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test chainTest/test dlcNodeTest/test appServerTest/test serverGrpcTest/test
+        run: sbt coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test chainTest/test dlcNodeTest/test appServerTest/test serverGrpcTest/test cliGrpcTest/test

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -37,5 +37,5 @@ jobs:
             ~/.bitcoin-s/binaries
           key: ${{ runner.os }}-cache
       - name: Windows Crypto, Core, and Database tests
-        run: sbt cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test appServerTest/test serverGrpcTest/test
+        run: sbt cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test appServerTest/test serverGrpcTest/test cliGrpcTest/test
         shell: bash

--- a/app/cli-grpc-test/cli-grpc-test.sbt
+++ b/app/cli-grpc-test/cli-grpc-test.sbt
@@ -1,0 +1,3 @@
+name := "bitcoin-s-cli-grpc-test"
+
+publish / skip := true

--- a/app/cli-grpc-test/src/test/resources/reference.conf
+++ b/app/cli-grpc-test/src/test/resources/reference.conf
@@ -1,0 +1,1 @@
+pekko.http.server.preview.enable-http2 = on

--- a/app/cli-grpc-test/src/test/scala/org/bitcoins/cli/grpc/ConsoleCliGrpcTest.scala
+++ b/app/cli-grpc-test/src/test/scala/org/bitcoins/cli/grpc/ConsoleCliGrpcTest.scala
@@ -1,0 +1,77 @@
+package org.bitcoins.cli.grpc
+
+import org.bitcoins.core.util.EnvUtil
+import org.bitcoins.rpc.util.RpcUtil
+import org.bitcoins.server.grpc.ServerGrpc
+import org.bitcoins.testkit.PostgresTestDatabase
+import org.bitcoins.testkit.fixtures.BitcoinSFixture
+import org.bitcoins.testkit.util.FileUtil
+import org.scalatest.FutureOutcome
+
+import java.nio.file.Files
+import scala.concurrent.{ExecutionContext, Future}
+
+class ConsoleCliGrpcTest extends BitcoinSFixture with PostgresTestDatabase {
+
+  override type FixtureParam = (Int, ServerGrpc)
+
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  override def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    val builder: () => Future[(Int, ServerGrpc)] = () => {
+      val tmpDir = FileUtil.tmpDir()
+      val port = RpcUtil.randomPort
+      val server = new ServerGrpc(tmpDir.toPath, "localhost", port)
+
+      server.start().map(_ => (port, server))
+    }
+
+    val destroyF: ((Int, ServerGrpc)) => Future[Unit] = { case (_, server) =>
+      server.stop()
+    }
+
+    makeDependentFixture[(Int, ServerGrpc)](builder, destroyF)(test)
+  }
+
+  behavior of "ConsoleCliGrpc"
+
+  it must "execute getversion" in { case (port, _) =>
+    val expected =
+      ujson
+        .Obj(
+          "version" -> Option(EnvUtil.getVersion)
+            .map(ujson.Str.apply)
+            .getOrElse(ujson.Null)
+        )
+        .render(2)
+
+    ConsoleCliGrpc
+      .exec(Vector("--rpcport", port.toString, "getversion"))
+      .map { response =>
+        assert(response == expected)
+      }
+  }
+
+  it must "execute zipdatadir" in { case (port, _) =>
+    val fileName = FileUtil.randomDirName
+    val dirName = FileUtil.randomDirName
+    val dir = FileUtil.tmpDir().toPath
+    val target = dir.resolve(dirName).resolve(fileName)
+
+    assert(!Files.exists(target))
+    assert(!Files.exists(target.getParent))
+
+    ConsoleCliGrpc
+      .exec(
+        Vector(
+          "--rpcport",
+          port.toString,
+          "zipdatadir",
+          target.toString
+        ))
+      .map { response =>
+        assert(response.isEmpty)
+        assert(Files.exists(target))
+      }
+  }
+}

--- a/app/cli-grpc/cli-grpc.sbt
+++ b/app/cli-grpc/cli-grpc.sbt
@@ -1,0 +1,7 @@
+name := "bitcoin-s-cli-grpc"
+
+Universal / packageName := CommonSettings.buildPackageName((Universal / packageName).value)
+
+libraryDependencies ++= Deps.cliGrpc
+
+mainClass := Some("org.bitcoins.cli.grpc.CliGrpc")

--- a/app/cli-grpc/src/main/resources/application.conf
+++ b/app/cli-grpc/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+pekko {
+  loglevel = "ERROR"
+  stdout-loglevel = "OFF"
+}

--- a/app/cli-grpc/src/main/resources/logback.xml
+++ b/app/cli-grpc/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration scan="true" scanPeriod="15 seconds" >
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601,UTC}UTC %level [%logger{0}] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/CliGrpc.scala
+++ b/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/CliGrpc.scala
@@ -1,0 +1,30 @@
+package org.bitcoins.cli.grpc
+
+import org.apache.pekko.actor.ActorSystem
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.control.NonFatal
+
+object CliGrpc extends App {
+  System.setProperty("slf4j.internal.verbosity", "WARN")
+  import System.err.{println => printerr}
+
+  implicit val system: ActorSystem = ActorSystem("bitcoin-s-cli-grpc")
+
+  val exitCode =
+    try {
+      val output = Await.result(ConsoleCliGrpc.exec(args.toVector), 30.seconds)
+      println(output)
+      0
+    } catch {
+      case NonFatal(err) =>
+        printerr(err.getMessage)
+        1
+    } finally {
+      Await.result(system.terminate(), 10.seconds)
+      ()
+    }
+
+  sys.exit(exitCode)
+}

--- a/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
+++ b/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
@@ -1,0 +1,134 @@
+package org.bitcoins.cli.grpc
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.grpc.GrpcClientSettings
+import org.bitcoins.server.grpc.{
+  CommonRoutesClient,
+  GetVersionRequest,
+  GetVersionResponse,
+  ZipDataDirRequest
+}
+import ujson.{Null, Num, Str}
+
+import java.io.File
+import java.nio.file.Path
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+object ConsoleCliGrpc {
+
+  private val usage =
+    """bitcoin-s-cli-grpc [--host <host>] [--rpcport <port>] getversion
+      |bitcoin-s-cli-grpc [--host <host>] [--rpcport <port>] zipdatadir <path>""".stripMargin
+
+  def exec(args: Vector[String])(implicit
+      system: ActorSystem): Future[String] = {
+    parseArgs(args) match {
+      case Success(conf) => exec(conf.command, conf)
+      case Failure(err)  => Future.failed(err)
+    }
+  }
+
+  private def parseArgs(args: Vector[String]): Try[Config] = {
+    def loop(remaining: Vector[String], conf: Config): Try[Config] = {
+      remaining match {
+        case Vector() =>
+          conf.command match {
+            case NoCommand =>
+              Failure(
+                new IllegalArgumentException("You need to provide a command!"))
+            case _ => Success(conf)
+          }
+        case Vector("-h") | Vector("--help") =>
+          Success(conf.copy(command = Help))
+        case "--host" +: host +: tail =>
+          loop(tail, conf.copy(host = host))
+        case "--rpcport" +: port +: tail =>
+          Try(port.toInt).transform(
+            p => loop(tail, conf.copy(rpcPortOpt = Some(p))),
+            _ =>
+              Failure(new IllegalArgumentException(s"Invalid rpcport: $port"))
+          )
+        case "getversion" +: Vector() =>
+          Success(conf.copy(command = GetVersion))
+        case "zipdatadir" +: path +: Vector() =>
+          Success(conf.copy(command = ZipDataDir(new File(path).toPath)))
+        case "zipdatadir" +: Vector() =>
+          Failure(new IllegalArgumentException("Missing path argument"))
+        case unknown +: _ =>
+          Failure(new IllegalArgumentException(s"Unknown argument '$unknown'"))
+        case _ =>
+          Failure(new IllegalArgumentException("Failed to parse arguments"))
+      }
+    }
+
+    loop(args, Config())
+  }
+
+  private def jsValueToString(value: ujson.Value): String = {
+    value match {
+      case Str(string)             => string
+      case Num(num) if num.isWhole => num.toLong.toString
+      case Num(num)                => num.toString
+      case rest: ujson.Value       => rest.render(2)
+    }
+  }
+
+  def exec(command: CliGrpcCommand, config: Config)(implicit
+      system: ActorSystem
+  ): Future[String] = {
+    import system.dispatcher
+
+    val clientSettings = GrpcClientSettings
+      .connectToServiceAt(config.host, config.rpcPort)
+      .withTls(false)
+
+    val client = CommonRoutesClient(clientSettings)
+
+    val responseF = command match {
+      case Help =>
+        Future.successful(usage)
+      case GetVersion =>
+        client.getVersion(GetVersionRequest()).map(formatGetVersion)
+      case ZipDataDir(path) =>
+        client.zipDataDir(ZipDataDirRequest(path = path.toString)).map(_ => "")
+      case NoCommand =>
+        Future.failed(
+          new IllegalArgumentException("You need to provide a command!"))
+    }
+
+    responseF.transformWith {
+      case Success(result) =>
+        client.close().map(_ => result)
+      case Failure(err) =>
+        client.close().flatMap(_ => Future.failed(err))
+    }
+  }
+
+  private def formatGetVersion(response: GetVersionResponse): String = {
+    val version =
+      response.version.map(Str.apply).getOrElse(Null)
+
+    jsValueToString(ujson.Obj("version" -> version))
+  }
+}
+
+sealed trait CliGrpcCommand {
+  def defaultPort: Int = 8980
+}
+
+case object NoCommand extends CliGrpcCommand
+
+case object Help extends CliGrpcCommand
+
+case object GetVersion extends CliGrpcCommand
+
+case class ZipDataDir(path: Path) extends CliGrpcCommand
+
+case class Config(
+    command: CliGrpcCommand = NoCommand,
+    host: String = "localhost",
+    rpcPortOpt: Option[Int] = None
+) {
+  val rpcPort: Int = rpcPortOpt.getOrElse(command.defaultPort)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,8 @@ lazy val `bitcoin-s` = project
     chainTest,
     cli,
     cliTest,
+    cliGrpc,
+    cliGrpcTest,
     coreJVM,
     coreJS,
     coreTestJVM,
@@ -241,6 +243,8 @@ lazy val `bitcoin-s` = project
     chainTest,
     cli,
     cliTest,
+    cliGrpc,
+    cliGrpcTest,
     coreJVM,
     coreJS,
     coreTestJVM,
@@ -491,6 +495,23 @@ lazy val cliTest = project
     testkit
   )
 
+lazy val cliGrpc = project
+  .in(file("app/cli-grpc"))
+  .settings(CommonSettings.prodSettings: _*)
+  .settings(scalacOptions += "-Xsource:3")
+  .dependsOn(serverGrpc)
+  .enablePlugins(JavaAppPackaging)
+
+lazy val cliGrpcTest = project
+  .in(file("app/cli-grpc-test"))
+  .settings(scalacOptions += "-Xsource:3")
+  .settings(CommonSettings.testSettings: _*)
+  .settings(libraryDependencies ++= Deps.cliGrpcTest)
+  .dependsOn(
+    cliGrpc,
+    testkit
+  )
+
 lazy val chain = project
   .in(file("chain"))
   .settings(scalacOptions += "-Xsource:3")
@@ -694,6 +715,7 @@ lazy val testkit = project
     appServer,
     chain,
     cli,
+    serverGrpc,
     bitcoindRpc,
     eclairRpc,
     lndRpc,

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -529,6 +529,16 @@ object Deps {
     )
   }
 
+  val cliGrpc = List(
+    Compile.akkaSlf4j,
+    Compile.logback,
+    Compile.slf4j
+  )
+
+  val cliGrpcTest = List(
+    Compile.typesafeConfig
+  )
+
   val server = Def.setting {
     Vector(
       Compile.newMicroPickle.value,


### PR DESCRIPTION
fixes #6309 

Supersedes #6310 as copilot wasn't able to easily figure out how to remove unneeded files. 

This implements cli commands to hit `CommonGrpcRoutes`, namely 2 endpoints

- `getversion`
- `zipdatadir`