### PR TITLE
cliGrpc: Refactor cliGrpc to use both the cli command line argument parser, and the CliCommand ADTs

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/rpc/Command.scala
@@ -41,7 +41,9 @@ trait AppServerCliCommand extends CliCommand {
   override def defaultPort: Int = 9999
 }
 
-trait Broadcastable extends CliCommand {
+trait CliGrpcCommand extends CliCommand
+
+trait Broadcastable extends AppServerCliCommand {
   override def defaultPort: Int = 9999
 }
 trait SignDLCCliCommand extends AppServerCliCommand
@@ -60,7 +62,7 @@ trait OracleServerCliCommand extends CliCommand {
 
 object CliCommand {
 
-  case object NoCommand extends CliCommand {
+  case object NoCommand extends CliCommand with CliGrpcCommand {
     override val defaultPort: Int = 9999
   }
 }
@@ -792,8 +794,7 @@ case class SendToAddress(
     amount: Bitcoins,
     satoshisPerVirtualByte: Option[SatoshisPerVirtualByte],
     noBroadcast: Boolean
-) extends CliCommand
-    with Broadcastable
+) extends Broadcastable
     with SendCliCommand
 
 object SendToAddress extends ServerJsonModels {
@@ -1305,8 +1306,7 @@ case class ExecuteDLC(
     contractId: ByteVector,
     oracleSigs: Vector[OracleAttestmentTLV],
     noBroadcast: Boolean
-) extends CliCommand
-    with Broadcastable
+) extends Broadcastable
 
 object ExecuteDLC extends ServerJsonModels {
 
@@ -1337,8 +1337,7 @@ object ExecuteDLC extends ServerJsonModels {
 }
 
 case class ExecuteDLCRefund(contractId: ByteVector, noBroadcast: Boolean)
-    extends CliCommand
-    with Broadcastable
+    extends Broadcastable
 
 object ExecuteDLCRefund extends ServerJsonModels {
 

--- a/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
+++ b/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
@@ -2,7 +2,10 @@ package org.bitcoins.cli.grpc
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.grpc.GrpcClientSettings
-import org.bitcoins.commons.config.AppConfig
+import org.bitcoins.cli.CliCommand.{GetVersion, ZipDataDir}
+import org.bitcoins.cli.{Config, ConsoleCli}
+import org.bitcoins.commons.rpc.CliCommand
+import org.bitcoins.commons.rpc.CliCommand.NoCommand
 import org.bitcoins.server.grpc.{
   CommonRoutesClient,
   GetVersionRequest,
@@ -13,52 +16,12 @@ import org.bitcoins.server.grpc.{
 import scopt.OParser
 import ujson.{Null, Num, Str}
 
-import java.io.File
-import java.nio.file.Path
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 object ConsoleCliGrpc {
 
-  def parser: OParser[Unit, Config] = {
-    val builder = OParser.builder[Config]
-    import builder._
-    OParser.sequence(
-      programName("bitcoin-s-cli-grpc"),
-      opt[String]("host")
-        .action((host, conf) => conf.copy(host = host))
-        .text("The hostname of the bitcoin-s gRPC server"),
-      opt[Int]("rpcport")
-        .action((port, conf) => conf.copy(rpcPortOpt = Some(port)))
-        .text("The port of the bitcoin-s gRPC server"),
-      opt[String]("password")
-        .action((password, conf) => conf.copy(rpcPassword = password))
-        .text("The password to authenticate to the bitcoin-s gRPC server"),
-      help('h', "help").text("Display this help message and exit"),
-      cmd("getversion")
-        .action((_, conf) => conf.copy(command = GetVersion))
-        .text("Returns the version of the bitcoin-s server"),
-      cmd("zipdatadir")
-        .action((_, conf) =>
-          conf.copy(command = ZipDataDir(AppConfig.DEFAULT_BITCOIN_S_DATADIR)))
-        .text("Zips the bitcoin-s data directory to the given path")
-        .children(
-          arg[File]("path")
-            .text("The destination path for the zipped data directory")
-            .required()
-            .action((file, conf) =>
-              conf.copy(command = conf.command match {
-                case _: ZipDataDir => ZipDataDir(file.toPath)
-                case other         => other
-              }))
-        ),
-      checkConfig {
-        case Config(NoCommand, _, _, _) =>
-          failure("You need to provide a command!")
-        case _ => success
-      }
-    )
-  }
+  def parser: OParser[Unit, Config] = ConsoleCli.parser
 
   // Global options that consume the following argument
   private val globalOptsWithArg: Set[String] =
@@ -87,10 +50,12 @@ object ConsoleCliGrpc {
 
   def exec(args: Vector[String])(implicit
       system: ActorSystem): Future[String] = {
-    OParser.parse(parser, normalizeArgs(args), Config()) match {
+    val normalized = normalizeArgs(args)
+    OParser.parse(parser, normalized, Config()) match {
       case None =>
         Future.failed(
-          new RuntimeException("Invalid arguments provided. See usage above."))
+          new RuntimeException(
+            s"Invalid arguments provided. See usage above. args=$normalized"))
       case Some(conf) => exec(conf.command, conf)
     }
   }
@@ -104,13 +69,13 @@ object ConsoleCliGrpc {
     }
   }
 
-  def exec(command: CliGrpcCommand, config: Config)(implicit
+  def exec(command: CliCommand, config: Config)(implicit
       system: ActorSystem
   ): Future[String] = {
     import system.dispatcher
 
     val baseSettings = GrpcClientSettings
-      .connectToServiceAt(config.host, config.rpcPort)
+      .connectToServiceAt("localhost", config.rpcPort)
       .withTls(false)
     val clientSettings =
       if (config.rpcPassword.isEmpty) {
@@ -131,6 +96,10 @@ object ConsoleCliGrpc {
       case NoCommand =>
         Future.failed(
           new IllegalArgumentException("You need to provide a command!"))
+      case x: CliCommand =>
+        Future.failed(
+          new IllegalArgumentException(
+            s"Command $x is not supported in gRPC mode"))
     }
 
     responseF.transformWith {
@@ -147,23 +116,4 @@ object ConsoleCliGrpc {
 
     jsValueToString(ujson.Obj("version" -> version))
   }
-}
-
-sealed trait CliGrpcCommand {
-  def defaultPort: Int = 8980
-}
-
-case object NoCommand extends CliGrpcCommand
-
-case object GetVersion extends CliGrpcCommand
-
-case class ZipDataDir(path: Path) extends CliGrpcCommand
-
-case class Config(
-    command: CliGrpcCommand = NoCommand,
-    host: String = "localhost",
-    rpcPortOpt: Option[Int] = None,
-    rpcPassword: String = ""
-) {
-  val rpcPort: Int = rpcPortOpt.getOrElse(command.defaultPort)
 }

--- a/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
+++ b/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
@@ -4,7 +4,13 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.grpc.GrpcClientSettings
 import org.bitcoins.cli.CliCommand.{GetVersion, ZipDataDir}
 import org.bitcoins.cli.{Config, ConsoleCli}
-import org.bitcoins.commons.rpc.CliCommand
+import org.bitcoins.commons.rpc.{
+  AppServerCliCommand,
+  CliCommand,
+  CliGrpcCommand,
+  OracleServerCliCommand,
+  ServerlessCliCommand
+}
 import org.bitcoins.commons.rpc.CliCommand.NoCommand
 import org.bitcoins.server.grpc.{
   CommonRoutesClient,
@@ -56,7 +62,17 @@ object ConsoleCliGrpc {
         Future.failed(
           new RuntimeException(
             s"Invalid arguments provided. See usage above. args=$normalized"))
-      case Some(conf) => exec(conf.command, conf)
+      case Some(conf) =>
+        conf.command match {
+          case c: CliGrpcCommand =>
+            exec(c, conf)
+          case _: AppServerCliCommand | _: ServerlessCliCommand |
+              _: OracleServerCliCommand =>
+            Future.failed(
+              new RuntimeException(
+                s"Command ${conf.command} is not supported in gRPC mode"))
+        }
+
     }
   }
 
@@ -69,13 +85,13 @@ object ConsoleCliGrpc {
     }
   }
 
-  def exec(command: CliCommand, config: Config)(implicit
+  def exec(command: CliGrpcCommand, config: Config)(implicit
       system: ActorSystem
   ): Future[String] = {
     import system.dispatcher
 
     val baseSettings = GrpcClientSettings
-      .connectToServiceAt("localhost", config.rpcPort)
+      .connectToServiceAt(ConsoleCli.host, config.rpcPort)
       .withTls(false)
     val clientSettings =
       if (config.rpcPassword.isEmpty) {

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -65,6 +65,9 @@ object ConsoleCli extends BitcoinSLogger {
       help('h', "help").text("Display this help message and exit"),
       note(sys.props("line.separator") + "Commands:"),
       note(sys.props("line.separator") + "===Blockchain ==="),
+      cmd("getversion")
+        .action((_, conf) => conf.copy(command = GetVersion))
+        .text(s"Returns basic info about the server's version"),
       cmd("getinfo")
         .action((_, conf) => conf.copy(command = GetInfo))
         .text(s"Returns basic info about the current chain"),

--- a/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
+++ b/app/cli/src/main/scala/org/bitcoins/cli/ConsoleCli.scala
@@ -5,6 +5,7 @@ import org.bitcoins.cli.CliReaders.*
 import org.bitcoins.cli.ConsoleCli.RequestParam
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
 import org.bitcoins.commons.rpc.*
+import org.bitcoins.commons.rpc.CliCommand.NoCommand
 import org.bitcoins.commons.serializers.Picklers.*
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.wallet.CoinSelectionAlgo
@@ -2626,14 +2627,14 @@ object CliCommand {
         RequestParam("offer-remove", args)
 
       case cmd @ (_: ServerlessCliCommand | _: AppServerCliCommand |
-          _: Broadcastable | _: OracleServerCliCommand) =>
+          _: Broadcastable | _: OracleServerCliCommand | _: CliGrpcCommand |
+          NoCommand) =>
         sys.error(s"Command $cmd unsupported")
-      case org.bitcoins.commons.rpc.CliCommand.NoCommand => ???
     }
     requestParam
   }
 
-  case object GetVersion extends ServerlessCliCommand
+  case object GetVersion extends ServerlessCliCommand with CliGrpcCommand
 
   case object GetInfo extends AppServerCliCommand
 
@@ -2706,7 +2707,9 @@ object CliCommand {
 
   // Util
 
-  case class ZipDataDir(path: Path) extends AppServerCliCommand
+  case class ZipDataDir(path: Path)
+      extends AppServerCliCommand
+      with CliGrpcCommand
 
   case object EstimateFee extends AppServerCliCommand
 

--- a/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ServerGrpc.scala
+++ b/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ServerGrpc.scala
@@ -96,7 +96,7 @@ class ServerGrpc(
       handler
     } else { request =>
       if (isAuthenticated(request)) {
-        handler(request)
+        handler.apply(request)
       } else {
         Future.successful(unauthenticatedResponse)
       }

--- a/build.sbt
+++ b/build.sbt
@@ -499,7 +499,7 @@ lazy val cliGrpc = project
   .in(file("app/cli-grpc"))
   .settings(CommonSettings.prodSettings: _*)
   .settings(scalacOptions += "-Xsource:3")
-  .dependsOn(serverGrpc)
+  .dependsOn(serverGrpc, cli)
   .enablePlugins(JavaAppPackaging)
 
 lazy val cliGrpcTest = project


### PR DESCRIPTION
The intention of `bitcoin-s-cli-grpc` is to change transport not the funcitonality of the cli. Therefore we should be able to re-use the cli command line parser and the `CliCommand` data types.