### PR TITLE
refactor: Move ServeJsonModels to app-commons

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/server/ServerJsonModels.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/server/ServerJsonModels.scala
@@ -1,24 +1,24 @@
-package org.bitcoins.server
+package org.bitcoins.commons.jsonmodels.server
 
 import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.LockUnspentOutputParameter
 import org.bitcoins.commons.serializers.JsonReaders
 import org.bitcoins.core.api.wallet.CoinSelectionAlgo
 import org.bitcoins.core.config.DLC
-import org.bitcoins.core.crypto._
+import org.bitcoins.core.crypto.*
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.BitcoinAddress
-import org.bitcoins.core.protocol.tlv._
+import org.bitcoins.core.protocol.tlv.*
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
-import org.bitcoins.crypto._
-import ujson._
+import org.bitcoins.crypto.*
+import ujson.*
 
 import java.io.File
 import java.net.{InetSocketAddress, URI}
 import java.nio.file.Path
-import scala.util._
+import scala.util.*
 
 case class DecodeAccept(accept: DLCAcceptTLV)
 

--- a/app/server/src/main/scala/org/bitcoins/server/CoreRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/CoreRoutes.scala
@@ -3,20 +3,25 @@ package org.bitcoins.server
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.server.Directives.complete
 import org.apache.pekko.http.scaladsl.server.Route
+import org.bitcoins.commons.jsonmodels.server.{
+  DecodeAccept,
+  DecodeAttestations,
+  DecodeSign
+}
 import org.bitcoins.commons.jsonmodels.{SerializedPSBT, SerializedTransaction}
-import org.bitcoins.commons.serializers.Picklers._
+import org.bitcoins.commons.serializers.Picklers.*
 import org.bitcoins.core.hd.AddressType
 import org.bitcoins.core.protocol.script.{
   MultiSignatureScriptPubKey,
   P2SHScriptPubKey,
   P2WSHWitnessSPKV0
 }
-import org.bitcoins.commons.rpc._
+import org.bitcoins.commons.rpc.*
 import org.bitcoins.core.protocol.{Bech32Address, P2SHAddress}
 import org.bitcoins.core.psbt.PSBT
 import org.bitcoins.server.routes.{Server, ServerCommand, ServerRoute}
-import ujson._
-import upickle.default._
+import ujson.*
+import upickle.default.*
 
 import scala.concurrent.Future
 

--- a/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/DLCRoutes.scala
@@ -3,7 +3,8 @@ package org.bitcoins.server
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.server.Directives.complete
 import org.apache.pekko.http.scaladsl.server.Route
-import org.bitcoins.commons.rpc._
+import org.bitcoins.commons.jsonmodels.server.{OfferAdd, OfferRemove, OfferSend}
+import org.bitcoins.commons.rpc.*
 import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.core.api.dlc.node.DLCNodeApi
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb
@@ -16,9 +17,9 @@ import org.bitcoins.core.protocol.tlv.{
   EnumEventDescriptorV0TLV,
   NumericEventDescriptorTLV
 }
-import org.bitcoins.server.routes._
-import ujson._
-import upickle.default._
+import org.bitcoins.server.routes.*
+import ujson.*
+import upickle.default.*
 
 import scala.concurrent.Future
 

--- a/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletRoutes.scala
@@ -5,6 +5,7 @@ import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.server.Directives.complete
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.stream.Materializer
+import org.bitcoins.commons.jsonmodels.server.{DLCDataFromFile, GetDLCOffer}
 import org.bitcoins.commons.rpc.*
 import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.commons.serializers.Picklers.*


### PR DESCRIPTION
Need in #6354 so we don't need to make server-grpc depend on server