### PR TITLE
Refactor ServerGrpc test fixtures to run against a real chain/node rather than mock

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/util/ChainUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/ChainUtil.scala
@@ -1,8 +1,7 @@
-package org.bitcoins.server.util
+package org.bitcoins.commons.util
 
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
-import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.api.chain.Blockchain
+import org.bitcoins.core.api.chain.{Blockchain, ChainApi}
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util.NumberUtil
@@ -64,7 +63,7 @@ object ChainUtil {
       headers <- headersF
       bestHeight <- bestHeightF
     } yield {
-      headers.map(hOpt => hOpt.map(h => (h, bestHeight - h.height)))
+      headers.map(hOpt => hOpt.map(h => (h, bestHeight - h.height + 1)))
     }
 
     for {

--- a/app-commons/src/main/scala/org/bitcoins/commons/util/ChainUtil.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/util/ChainUtil.scala
@@ -74,15 +74,15 @@ object ChainUtil {
           case Some(blockchain) =>
             getBestBlockHeaderResults(headersWithConfs, blockchain, chain)
           case None =>
-            Future.failed(
-              new RuntimeException(
-                "Could not fetch best block header or blockchain for median time past calculation"
-              ))
+            // If we can't get a blockchain,
+            // we can't calculate median time past
+            // so we return nothing
+            Future.successful(Vector(None))
         }
 
       }
     } yield {
-      results
+      results.flatten
     }
   }
 
@@ -90,13 +90,10 @@ object ChainUtil {
       headersWithConfs: Vector[Option[(BlockHeaderDb, Int)]],
       blockchain: Blockchain,
       chain: ChainApi)(implicit
-      ec: ExecutionContext): Future[Vector[GetBlockHeaderResult]] = {
+      ec: ExecutionContext): Future[Vector[Option[GetBlockHeaderResult]]] = {
     Future.traverse(headersWithConfs) {
       case None =>
-        Future.failed(
-          new RuntimeException(
-            "Could not find block header or confirmations for the header"
-          ))
+        Future.successful(None)
       case Some((header, confs)) =>
         getMedianTimePast(header, blockchain, chain).map { medianTimePastOpt =>
           val chainworkStr = {
@@ -107,7 +104,7 @@ object ChainUtil {
 
             padded.toHex
           }
-          GetBlockHeaderResult(
+          val g = GetBlockHeaderResult(
             hash = header.hashBE,
             confirmations = confs,
             height = header.height,
@@ -125,6 +122,7 @@ object ChainUtil {
             nextblockhash = None,
             target = Some(NumberUtil.serializeTargetHex(header.target))
           )
+          Some(g)
         }
     }
   }

--- a/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/ChainGrpcRoutesTest.scala
+++ b/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/ChainGrpcRoutesTest.scala
@@ -1,9 +1,7 @@
 package org.bitcoins.server.grpc
 
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.testkit.chain.MockChainApi
 import org.bitcoins.testkit.fixtures.ServerGrpcFixture
-import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 
 class ChainGrpcRoutesTest extends ServerGrpcFixture {
@@ -17,12 +15,16 @@ class ChainGrpcRoutesTest extends ServerGrpcFixture {
 
   it must "getinfo" in { case clientServer =>
     val client = clientServer.client
-    client.getInfo(GetInfoRequest()).map { response =>
+
+    for {
+      response <- client.getInfo(GetInfoRequest())
+      bitcoind <- cachedBitcoindWithFundsF
+      expectedHash <- bitcoind.getBestBlockHash()
+      height <- bitcoind.getBlockCount()
+    } yield {
       assert(response.network == RegTest.name)
-      assert(
-        response.blockHeight == ChainTestUtil.regTestGenesisHeaderDb.height)
-      assert(
-        response.blockHash == ChainTestUtil.regTestGenesisHeaderDb.hashBE.hex)
+      assert(response.blockHeight == height)
+      assert(response.blockHash == expectedHash.hex)
       assert(response.torStarted)
       assert(!response.syncing)
       assert(!response.isInitialBlockDownload)
@@ -31,22 +33,34 @@ class ChainGrpcRoutesTest extends ServerGrpcFixture {
 
   it must "getblockcount" in { case clientServer =>
     val client = clientServer.client
-    client.getBlockCount(GetBlockCountRequest()).map { response =>
-      assert(response.count == 0)
+    for {
+      response <- client.getBlockCount(GetBlockCountRequest())
+      bitcoind <- cachedBitcoindWithFundsF
+      expectedCount <- bitcoind.getBlockCount()
+    } yield {
+      assert(response.count == expectedCount)
     }
   }
 
   it must "getfiltercount" in { case clientServer =>
     val client = clientServer.client
-    client.getFilterCount(GetFilterCountRequest()).map { response =>
-      assert(response.count == 0)
+    for {
+      response <- client.getFilterCount(GetFilterCountRequest())
+      bitcoind <- cachedBitcoindWithFundsF
+      expectedCount <- bitcoind.getFilterCount()
+    } yield {
+      assert(response.count == expectedCount)
     }
   }
 
   it must "getfilterheadercount" in { case clientServer =>
     val client = clientServer.client
-    client.getFilterHeaderCount(GetFilterHeaderCountRequest()).map { response =>
-      assert(response.count == 0)
+    for {
+      response <- client.getFilterHeaderCount(GetFilterHeaderCountRequest())
+      bitcoind <- cachedBitcoindWithFundsF
+      expectedCount <- bitcoind.getFilterCount()
+    } yield {
+      assert(response.count == expectedCount)
     }
   }
 
@@ -54,7 +68,8 @@ class ChainGrpcRoutesTest extends ServerGrpcFixture {
     val client = clientServer.client
     for {
       response <- client.getBestBlockHash(GetBestBlockHashRequest())
-      expectedHash <- MockChainApi.getBestBlockHash()
+      bitcoind <- cachedBitcoindWithFundsF
+      expectedHash <- bitcoind.getBestBlockHash()
     } yield {
       assert(response.hash == expectedHash.hex)
     }
@@ -62,16 +77,41 @@ class ChainGrpcRoutesTest extends ServerGrpcFixture {
 
   it must "getblockheader" in { case clientServer =>
     val client = clientServer.client
-    val hash = ChainTestUtil.regTestGenesisHeaderDb.hashBE.hex
-    client.getBlockHeader(GetBlockHeaderRequest(hash = hash)).map { response =>
-      assert(response.header.isEmpty)
+    for {
+      bitcoind <- cachedBitcoindWithFundsF
+      bestHash <- bitcoind.getBestBlockHash()
+      expected <- bitcoind.getBlockHeader(bestHash)
+      response <- client.getBlockHeader(
+        GetBlockHeaderRequest(hash = bestHash.hex))
+    } yield {
+      assert(response.header.isDefined)
+      val header = response.header.get
+      assert(header.hash == expected.hash.hex)
+      assert(header.confirmations == expected.confirmations)
+      assert(header.height == expected.height)
+      assert(header.version == expected.version)
+      assert(header.versionHex == expected.versionHex.hex)
+      assert(header.merkleroot == expected.merkleroot.hex)
+      assert(header.time == expected.time.toInt)
+      assert(header.mediantime == expected.mediantime.toInt)
+      assert(header.nonce == expected.nonce.toInt)
+      assert(header.bits == expected.bits.hex)
+      assert(header.chainwork == expected.chainwork)
+      assert(header.previousblockhash == expected.previousblockhash.map(_.hex))
+      assert(header.nextblockhash == expected.nextblockhash.map(_.hex))
+      assert(BigDecimal(header.difficulty) == expected.difficulty)
+      assert(header.target == expected.target)
     }
   }
 
   it must "getmediantimepast" in { case clientServer =>
     val client = clientServer.client
-    client.getMedianTimePast(GetMedianTimePastRequest()).map { response =>
-      assert(response.mediantimepast == 0L)
+    for {
+      response <- client.getMedianTimePast(GetMedianTimePastRequest())
+      bitcoind <- cachedBitcoindWithFundsF
+      expected <- bitcoind.getMedianTimePast()
+    } yield {
+      assert(response.mediantimepast == expected)
     }
   }
 }

--- a/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/ChainGrpcRoutesTest.scala
+++ b/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/ChainGrpcRoutesTest.scala
@@ -93,14 +93,14 @@ class ChainGrpcRoutesTest extends ServerGrpcFixture {
       assert(header.versionHex == expected.versionHex.hex)
       assert(header.merkleroot == expected.merkleroot.hex)
       assert(header.time == expected.time.toInt)
+      assert(header.target == expected.target)
       assert(header.mediantime == expected.mediantime.toInt)
       assert(header.nonce == expected.nonce.toInt)
       assert(header.bits == expected.bits.hex)
       assert(header.chainwork == expected.chainwork)
       assert(header.previousblockhash == expected.previousblockhash.map(_.hex))
       assert(header.nextblockhash == expected.nextblockhash.map(_.hex))
-      assert(BigDecimal(header.difficulty) == expected.difficulty)
-      assert(header.target == expected.target)
+
     }
   }
 

--- a/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/NodeGrpcRoutesTest.scala
+++ b/app/server-grpc-test/src/test/scala/org/bitcoins/server/grpc/NodeGrpcRoutesTest.scala
@@ -15,7 +15,7 @@ class NodeGrpcRoutesTest extends ServerGrpcFixture {
   it must "getconnectioncount" in { case clientServer =>
     val client = clientServer.client
     client.getConnectionCount(GetConnectionCountRequest()).map { response =>
-      assert(response.count == 0)
+      assert(response.count == 1)
     }
   }
 }

--- a/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
+++ b/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
@@ -1,10 +1,10 @@
 package org.bitcoins.server.grpc
 
 import io.grpc.Status
+import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
+import org.bitcoins.commons.util.ChainUtil
 import org.bitcoins.core.api.chain.ChainApi
-import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.config.BitcoinNetwork
-import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import scodec.bits.ByteVector
 
@@ -73,14 +73,21 @@ class ChainGrpcRoutes(
             .withDescription(s"Invalid block hash: $err")
             .asRuntimeException())
       case Right(hash) =>
-        chainApi.getHeader(hash).flatMap {
-          case None => Future.successful(GetBlockHeaderResponse(header = None))
-          case Some(headerDb) =>
-            chainApi.getBestBlockHeader().map { bestHeader =>
-              val confirmations = bestHeader.height - headerDb.height + 1
-              val header = toBlockHeaderResult(headerDb, confirmations)
+        val getBlockHeaderResultF = ChainUtil.getBlockHeaderResult(
+          Vector(hash),
+          chainApi
+        )
+
+        for {
+          getBlockHeaderResult <- getBlockHeaderResultF
+          result = getBlockHeaderResult.headOption
+        } yield {
+          result match {
+            case None => GetBlockHeaderResponse(header = None)
+            case Some(getBlockHeaderResult) =>
+              val header = toBlockHeaderResult(getBlockHeaderResult)
               GetBlockHeaderResponse(header = Some(header))
-            }
+          }
         }
     }
   }
@@ -93,32 +100,23 @@ class ChainGrpcRoutes(
   }
 
   private def toBlockHeaderResult(
-      header: BlockHeaderDb,
-      confirmations: Int): BlockHeaderResult = {
-    val chainworkStr = {
-      val bytes = ByteVector(header.chainWork.toByteArray)
-      val padded = if (bytes.length <= 32) {
-        bytes.padLeft(32)
-      } else bytes
-
-      padded.toHex
-    }
+      header: GetBlockHeaderResult): BlockHeaderResult = {
 
     BlockHeaderResult(
-      hash = header.hashBE.hex,
-      confirmations = confirmations,
+      hash = header.hash.hex,
+      confirmations = header.confirmations,
       height = header.height,
-      version = header.version.toInt,
-      versionHex = header.version.hex,
-      merkleroot = header.merkleRootHashBE.hex,
+      version = header.version,
+      versionHex = ByteVector.fromInt(header.version).toHex,
+      merkleroot = header.merkleroot.hex,
       time = header.time.toLong.toInt,
-      mediantime = header.time.toLong.toInt,
+      mediantime = header.mediantime.toInt,
       nonce = header.nonce.toLong.toInt,
-      bits = header.nBits.hex,
-      chainwork = chainworkStr,
-      previousblockhash = Some(header.previousBlockHashBE.hex),
+      bits = header.bits.hex,
+      chainwork = header.chainwork,
+      previousblockhash = header.previousblockhash.map(_.hex),
       nextblockhash = None,
-      target = Some(NumberUtil.serializeTargetHex(header.target))
+      target = header.target
     )
   }
 }

--- a/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
+++ b/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
@@ -4,6 +4,7 @@ import io.grpc.Status
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.config.BitcoinNetwork
+import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import scodec.bits.ByteVector
 
@@ -76,7 +77,7 @@ class ChainGrpcRoutes(
           case None => Future.successful(GetBlockHeaderResponse(header = None))
           case Some(headerDb) =>
             chainApi.getBestBlockHeader().map { bestHeader =>
-              val confirmations = bestHeader.height - headerDb.height
+              val confirmations = bestHeader.height - headerDb.height + 1
               val header = toBlockHeaderResult(headerDb, confirmations)
               GetBlockHeaderResponse(header = Some(header))
             }
@@ -117,7 +118,11 @@ class ChainGrpcRoutes(
       chainwork = chainworkStr,
       previousblockhash = Some(header.previousBlockHashBE.hex),
       nextblockhash = None,
-      target = None
+      target = Some(
+        ByteVector
+          .fromBigInt(NumberUtil.targetExpansion(header.nBits).difficulty,
+                      size = Some(32))
+          .toHex)
     )
   }
 }

--- a/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
+++ b/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
@@ -118,11 +118,7 @@ class ChainGrpcRoutes(
       chainwork = chainworkStr,
       previousblockhash = Some(header.previousBlockHashBE.hex),
       nextblockhash = None,
-      target = Some(
-        ByteVector
-          .fromBigInt(NumberUtil.targetExpansion(header.nBits).difficulty,
-                      size = Some(32))
-          .toHex)
+      target = Some(NumberUtil.serializeTargetHex(header.target))
     )
   }
 }

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -390,7 +390,7 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         assert(
           responseAs[
             String
-          ] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":0,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${medianTimePast.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":null,"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null,"target":"${NumberUtil
+          ] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":1,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${medianTimePast.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":null,"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null,"target":"${NumberUtil
               .serializeTargetHex(blockHeader.target)}"},"error":null}"""
         )
       }

--- a/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/ChainRoutes.scala
@@ -7,10 +7,10 @@ import org.bitcoins.commons.jsonmodels.BitcoinSServerInfo
 import org.bitcoins.commons.rpc.GetBlockHeader
 import org.bitcoins.commons.serializers.Picklers
 import org.bitcoins.commons.serializers.Picklers._
+import org.bitcoins.commons.util.ChainUtil
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.config.BitcoinNetwork
 import org.bitcoins.server.routes.{Server, ServerCommand, ServerRoute}
-import org.bitcoins.server.util.ChainUtil
 
 import scala.concurrent.Future
 

--- a/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/WebsocketUtil.scala
@@ -23,7 +23,7 @@ import org.bitcoins.commons.jsonmodels.ws.{
   WalletWsType,
   WsNotification
 }
-import org.bitcoins.commons.util.BitcoinSLogger
+import org.bitcoins.commons.util.{BitcoinSLogger, ChainUtil}
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.{CompactFilterDb, CompactFilterHeaderDb}
 import org.bitcoins.core.api.dlc.wallet.db.IncomingDLCOfferDb

--- a/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/BroadcastTransactionTest.scala
@@ -34,7 +34,6 @@ class BroadcastTransactionTest extends NodeTestWithCachedBitcoindNewest {
       _ <- torClientF
       bitcoind <- cachedBitcoindWithFundsF
       outcome = withNeutrinoNodeConnectedToBitcoindCached(test, bitcoind)(
-        using system,
         getFreshConfig
       )
       f <- outcome.toFuture

--- a/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
+++ b/node-test/src/test/scala/org/bitcoins/node/networking/peer/DataMessageHandlerTest.scala
@@ -43,7 +43,6 @@ class DataMessageHandlerTest extends NodeTestWithCachedBitcoindNewest {
     val outcome: Future[Outcome] = for {
       bitcoind <- cachedBitcoindWithFundsF
       outcome = withNeutrinoNodeConnectedToBitcoindCached(test, bitcoind)(
-        using system,
         getFreshConfig
       )
       f <- outcome.toFuture

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
@@ -1,8 +1,11 @@
 package org.bitcoins.testkit.fixtures
 import org.apache.pekko.grpc.GrpcClientSettings
 import org.apache.pekko.grpc.scaladsl.PekkoGrpcClient
+import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.config.{BitcoinNetwork, RegTest}
+import org.bitcoins.node.Node
 import org.bitcoins.rpc.util.RpcUtil
+import org.bitcoins.server.BitcoinSAppConfig
 import org.bitcoins.server.grpc.{
   ChainRoutesClient,
   CommonRoutesClient,
@@ -10,64 +13,92 @@ import org.bitcoins.server.grpc.{
   NodeRoutesClient,
   ServerGrpc
 }
+import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.FileUtil
-import org.bitcoins.testkit.PostgresTestDatabase
 import org.bitcoins.testkit.chain.MockChainApi
 import org.bitcoins.testkit.dlc.MockDLCNodeApi
-import org.bitcoins.testkit.node.MockNodeApi
+import org.bitcoins.testkit.node.NodeTestWithCachedBitcoind
+import org.bitcoins.testkit.rpc.CachedBitcoindNewest
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
-trait ServerGrpcFixture extends BitcoinSFixture with PostgresTestDatabase {
+trait ServerGrpcFixture
+    extends NodeTestWithCachedBitcoind
+    with CachedBitcoindNewest {
   lazy val network: BitcoinNetwork = RegTest
   case class GrpcClientServerFixture[T <: PekkoGrpcClient](
       client: T,
-      server: ServerGrpc)
+      server: ServerGrpc,
+      chainApi: ChainApi,
+      nodeApi: Node,
+      appConfig: BitcoinSAppConfig)
 
   type GrpcClient <: PekkoGrpcClient
   final override type FixtureParam = GrpcClientServerFixture[GrpcClient]
 
-  private def buildClient[T](
+  override protected def getFreshConfig: BitcoinSAppConfig = {
+    BitcoinSTestAppConfig.getMultiPeerNeutrinoWithEmbeddedDbTestConfig(
+      postgresOpt,
+      Vector.empty
+    )
+  }
+  private def buildClient[T <: PekkoGrpcClient](
       host: String,
       port: Int,
-      build: GrpcClientSettings => T): Future[T] = {
+      build: GrpcClientSettings => T,
+      serverPackageF: Future[(ServerGrpc, ChainApi, Node, BitcoinSAppConfig)])
+      : Future[GrpcClientServerFixture[T]] = {
     val clientSettings = GrpcClientSettings
       .connectToServiceAt(host, port)
       .withTls(false)
-    val client = build(clientSettings)
-    Future.successful(client)
+    val client: T = build(clientSettings)
+    for {
+      (server, chainApi, nodeApi, appConfig) <- serverPackageF
+      _ <- server.start()
+    } yield GrpcClientServerFixture(client,
+                                    server,
+                                    chainApi,
+                                    nodeApi,
+                                    appConfig)
   }
 
   private def buildGrpcServer(
       tmpDir: java.io.File,
       host: String,
       port: Int,
-      rpcPassword: String = ""): ServerGrpc = {
+      rpcPassword: String = "")(implicit appConfig: BitcoinSAppConfig)
+      : Future[(ServerGrpc, ChainApi, Node, BitcoinSAppConfig)] = {
     val dlcNode = MockDLCNodeApi.fresh()
-    val server = new ServerGrpc(
-      tmpDir.toPath,
-      host,
-      port,
-      rpcPassword = rpcPassword,
-      chainApi = MockChainApi,
-      network = network,
-      startedTorConfigF = Future.unit,
-      nodeApiF = Future.successful(MockNodeApi),
-      dlcNodeF = Future.successful(dlcNode)
-    )
-    server
+    val neutrinoNodeF = cachedBitcoindWithFundsF
+      .flatMap(createNeutrinoNodeConnectedToBitcoindCached(_)(appConfig))
+    for {
+      neutrinoNode <- neutrinoNodeF
+      server = new ServerGrpc(
+        tmpDir.toPath,
+        host,
+        port,
+        rpcPassword = rpcPassword,
+        chainApi = MockChainApi,
+        network = network,
+        startedTorConfigF = Future.unit,
+        nodeApiF = neutrinoNodeF.map(_.node),
+        dlcNodeF = Future.successful(dlcNode)
+      )
+      chainApi <- neutrinoNode.node.chainApiFromDb()
+    } yield (server, chainApi, neutrinoNode.node, appConfig)
   }
 
   def withCommonRoutesClient(test: OneArgAsyncTest): FutureOutcome = {
     val port = RpcUtil.randomPort
     val host = "localhost"
-    val server = buildGrpcServer(FileUtil.tmpDir(), host, port)
+    val config = getFreshConfig
+    val serverPackageF =
+      buildGrpcServer(FileUtil.tmpDir(), host, port)(config)
     val build: () => Future[GrpcClientServerFixture[CommonRoutesClient]] =
-      () =>
-        buildClient(host, port, CommonRoutesClient.apply).flatMap { client =>
-          server.start().map(_ => GrpcClientServerFixture(client, server))
-        }
+      () => {
+        buildClient(host, port, CommonRoutesClient.apply, serverPackageF)
+      }
 
     makeDependentFixture[GrpcClientServerFixture[CommonRoutesClient]](
       build,
@@ -77,13 +108,10 @@ trait ServerGrpcFixture extends BitcoinSFixture with PostgresTestDatabase {
   def withChainRoutesClient(test: OneArgAsyncTest): FutureOutcome = {
     val port = RpcUtil.randomPort
     val host = "localhost"
-    val server = buildGrpcServer(FileUtil.tmpDir(), host, port)
+    val serverPackageF =
+      buildGrpcServer(FileUtil.tmpDir(), host, port)(getFreshConfig)
     val build: () => Future[GrpcClientServerFixture[ChainRoutesClient]] =
-      () =>
-        buildClient(host, port, ChainRoutesClient.apply).flatMap { client =>
-          server.start().map(_ => GrpcClientServerFixture(client, server))
-        }
-
+      () => buildClient(host, port, ChainRoutesClient.apply, serverPackageF)
     makeDependentFixture[GrpcClientServerFixture[ChainRoutesClient]](
       build,
       destroyClientServer)(test)
@@ -92,12 +120,10 @@ trait ServerGrpcFixture extends BitcoinSFixture with PostgresTestDatabase {
   def withNodeRoutesClient(test: OneArgAsyncTest): FutureOutcome = {
     val port = RpcUtil.randomPort
     val host = "localhost"
-    val server = buildGrpcServer(FileUtil.tmpDir(), host, port)
+    val serverPackageF =
+      buildGrpcServer(FileUtil.tmpDir(), host, port)(getFreshConfig)
     val build: () => Future[GrpcClientServerFixture[NodeRoutesClient]] =
-      () =>
-        buildClient(host, port, NodeRoutesClient.apply).flatMap { client =>
-          server.start().map(_ => GrpcClientServerFixture(client, server))
-        }
+      () => buildClient(host, port, NodeRoutesClient.apply, serverPackageF)
 
     makeDependentFixture[GrpcClientServerFixture[NodeRoutesClient]](
       build,
@@ -107,12 +133,10 @@ trait ServerGrpcFixture extends BitcoinSFixture with PostgresTestDatabase {
   def withDLCRoutesClient(test: OneArgAsyncTest): FutureOutcome = {
     val port = RpcUtil.randomPort
     val host = "localhost"
-    val server = buildGrpcServer(FileUtil.tmpDir(), host, port)
+    val serverPackageF =
+      buildGrpcServer(FileUtil.tmpDir(), host, port)(getFreshConfig)
     val build: () => Future[GrpcClientServerFixture[DLCRoutesClient]] =
-      () =>
-        buildClient(host, port, DLCRoutesClient.apply).flatMap { client =>
-          server.start().map(_ => GrpcClientServerFixture(client, server))
-        }
+      () => buildClient(host, port, DLCRoutesClient.apply, serverPackageF)
 
     makeDependentFixture[GrpcClientServerFixture[DLCRoutesClient]](
       build,
@@ -122,9 +146,11 @@ trait ServerGrpcFixture extends BitcoinSFixture with PostgresTestDatabase {
   private def destroyClientServer[T <: PekkoGrpcClient](
       cs: GrpcClientServerFixture[T]): Future[Unit] = {
     val (client, server) = (cs.client, cs.server)
+    val node = cs.nodeApi
     for {
       _ <- client.close()
       _ <- server.stop()
+      _ <- tearDownNode(node, cs.appConfig)
     } yield ()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
@@ -15,9 +15,8 @@ import org.bitcoins.server.grpc.{
 }
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.FileUtil
-import org.bitcoins.testkit.chain.MockChainApi
 import org.bitcoins.testkit.dlc.MockDLCNodeApi
-import org.bitcoins.testkit.node.NodeTestWithCachedBitcoind
+import org.bitcoins.testkit.node.{NodeTestUtil, NodeTestWithCachedBitcoind}
 import org.bitcoins.testkit.rpc.CachedBitcoindNewest
 import org.scalatest.FutureOutcome
 
@@ -74,18 +73,20 @@ trait ServerGrpcFixture
       .flatMap(createNeutrinoNodeConnectedToBitcoindCached(_)(appConfig))
     for {
       neutrinoNode <- neutrinoNodeF
+      chainApi <- neutrinoNode.node.chainApiFromDb()
       server = new ServerGrpc(
         tmpDir.toPath,
         host,
         port,
         rpcPassword = rpcPassword,
-        chainApi = MockChainApi,
+        chainApi = chainApi,
         network = network,
         startedTorConfigF = Future.unit,
         nodeApiF = neutrinoNodeF.map(_.node),
         dlcNodeF = Future.successful(dlcNode)
       )
-      chainApi <- neutrinoNode.node.chainApiFromDb()
+      bitcoind <- cachedBitcoindWithFundsF
+      _ <- NodeTestUtil.awaitAllSync(neutrinoNode.node, bitcoind)
     } yield (server, chainApi, neutrinoNode.node, appConfig)
   }
 
@@ -151,6 +152,7 @@ trait ServerGrpcFixture
       _ <- client.close()
       _ <- server.stop()
       _ <- tearDownNode(node, cs.appConfig)
+      _ <- cs.appConfig.stop()
     } yield ()
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/fixtures/ServerGrpcFixture.scala
@@ -16,15 +16,15 @@ import org.bitcoins.server.grpc.{
 import org.bitcoins.testkit.BitcoinSTestAppConfig
 import org.bitcoins.testkit.util.FileUtil
 import org.bitcoins.testkit.dlc.MockDLCNodeApi
-import org.bitcoins.testkit.node.{NodeTestUtil, NodeTestWithCachedBitcoind}
-import org.bitcoins.testkit.rpc.CachedBitcoindNewest
+import org.bitcoins.testkit.node.{
+  NodeTestUtil,
+  NodeTestWithCachedBitcoindNewest
+}
 import org.scalatest.FutureOutcome
 
 import scala.concurrent.Future
 
-trait ServerGrpcFixture
-    extends NodeTestWithCachedBitcoind
-    with CachedBitcoindNewest {
+trait ServerGrpcFixture extends NodeTestWithCachedBitcoindNewest {
   lazy val network: BitcoinNetwork = RegTest
   case class GrpcClientServerFixture[T <: PekkoGrpcClient](
       client: T,

--- a/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/node/NodeTestWithCachedBitcoind.scala
@@ -33,25 +33,11 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
       test: OneArgAsyncTest,
       bitcoind: BitcoindRpcClient
   )(implicit
-      system: ActorSystem,
       appConfig: BitcoinSAppConfig
   ): FutureOutcome = {
     val nodeWithBitcoindBuilder
         : () => Future[NeutrinoNodeConnectedWithBitcoind] = { () =>
-      require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
-      for {
-        peer <- NodeUnitTest.createPeer(bitcoind)
-        node <- NodeUnitTest.createNeutrinoNode(peer, None)(
-          using system,
-          appConfig.chainConf,
-          appConfig.nodeConf
-        )
-        started <- node.start()
-        _ <- NodeTestUtil.awaitConnectionCount(
-          node = node,
-          expectedConnectionCount = 1
-        )
-      } yield NeutrinoNodeConnectedWithBitcoind(started, bitcoind)
+      createNeutrinoNodeConnectedToBitcoindCached(bitcoind)
     }
 
     makeDependentFixture[NeutrinoNodeConnectedWithBitcoind](
@@ -60,6 +46,22 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
         NodeUnitTest.destroyNode(x.node, appConfig)
       }
     )(test)
+  }
+
+  def createNeutrinoNodeConnectedToBitcoindCached(bitcoind: BitcoindRpcClient)(
+      implicit appConfig: BitcoinSAppConfig)
+      : Future[NeutrinoNodeConnectedWithBitcoind] = {
+    require(appConfig.nodeConf.nodeType == NodeType.NeutrinoNode)
+    for {
+      _ <- appConfig.walletConf.kmConf.start()
+      node <- NodeUnitTest.createNeutrinoNode(bitcoind, None)(
+        using system,
+        appConfig.chainConf,
+        appConfig.nodeConf
+      )
+      startedNode <- node.start()
+      _ <- NodeTestUtil.awaitConnectionCount(node, 1)
+    } yield NeutrinoNodeConnectedWithBitcoind(startedNode, bitcoind)
   }
 
   def withNeutrinoNodeUnstarted(
@@ -222,7 +224,7 @@ trait NodeTestWithCachedBitcoind extends BaseNodeTest with CachedTor {
     } yield ()
   }
 
-  private def tearDownNode(
+  protected def tearDownNode(
       node: Node,
       appConfig: BitcoinSAppConfig
   ): Future[Unit] = {


### PR DESCRIPTION
… connected

Use neturino node connectedto cached bitcoind data, instead of mock-only node/chain wiring.

- make ServerGrpcFixture use NodeTestWithCachedBitcoind + CachedBitcoindNewest
- build server packages with real node/chain instances and app config context
- create/start clients from a shared server package future for consistent setup
- expose and use node teardown hooks in fixture cleanup
- use fresh multi-peer neutrino embedded-db test config in fixture setup
- update NodeGrpcRoutesTest connection-count expectation to match real node state
- apply small testkit/node test cleanups from the fixture integration)