### PR TITLE
core: Refactor BlockHeader.difficulty -> BlockHeader.target

### DIFF
--- a/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/jsonmodels/bitcoind/BlockchainResult.scala
@@ -219,7 +219,7 @@ case class GetBlockHeaderResult(
     mediantime: UInt32,
     nonce: UInt32,
     bits: UInt32,
-    difficulty: BigDecimal,
+    difficulty: Option[BigDecimal],
     chainwork: String,
     previousblockhash: Option[DoubleSha256DigestBE],
     nextblockhash: Option[DoubleSha256DigestBE],

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -1618,7 +1618,12 @@ object Picklers {
       PicklerKeys.mediantimeKey -> Num(header.mediantime.toLong.toDouble),
       PicklerKeys.nonceKey -> Num(header.nonce.toBigInt.toDouble),
       PicklerKeys.bitsKey -> Str(header.bits.hex),
-      PicklerKeys.difficultyKey -> ujson.Null,
+      PicklerKeys.difficultyKey -> {
+        header.difficulty match {
+          case Some(difficulty) => Num(difficulty.toDouble)
+          case None             => ujson.Null
+        }
+      },
       PicklerKeys.chainworkKey -> Str(header.chainwork),
       PicklerKeys.previousblockhashKey -> {
         header.previousblockhash.map(_.hex) match {

--- a/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
+++ b/app-commons/src/main/scala/org/bitcoins/commons/serializers/Picklers.scala
@@ -1574,7 +1574,7 @@ object Picklers {
     val mediantime = UInt32(obj(PicklerKeys.mediantimeKey).num.toLong)
     val nonce = UInt32(obj(PicklerKeys.nonceKey).num.toLong)
     val bits = UInt32.fromHex(obj(PicklerKeys.bitsKey).str)
-    val difficulty = obj(PicklerKeys.difficultyKey).num
+    val difficulty = obj(PicklerKeys.difficultyKey).numOpt.map(BigDecimal.apply)
     val chainWork = obj(PicklerKeys.chainworkKey).str
     val previousBlockHash = obj(PicklerKeys.previousblockhashKey).strOpt.map {
       str =>
@@ -1618,7 +1618,7 @@ object Picklers {
       PicklerKeys.mediantimeKey -> Num(header.mediantime.toLong.toDouble),
       PicklerKeys.nonceKey -> Num(header.nonce.toBigInt.toDouble),
       PicklerKeys.bitsKey -> Str(header.bits.hex),
-      PicklerKeys.difficultyKey -> Num(header.difficulty.toDouble),
+      PicklerKeys.difficultyKey -> ujson.Null,
       PicklerKeys.chainworkKey -> Str(header.chainwork),
       PicklerKeys.previousblockhashKey -> {
         header.previousblockhash.map(_.hex) match {

--- a/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
+++ b/app/cli-grpc/src/main/scala/org/bitcoins/cli/grpc/ConsoleCliGrpc.scala
@@ -343,7 +343,7 @@ object ConsoleCliGrpc {
           mediantime = UInt32(header.mediantime.toLong & 0xffffffffL),
           nonce = UInt32(header.nonce.toLong & 0xffffffffL),
           bits = UInt32.fromHex(header.bits),
-          difficulty = BigDecimal(header.difficulty),
+          difficulty = None,
           chainwork = header.chainwork,
           previousblockhash =
             header.previousblockhash.map(DoubleSha256DigestBE.fromHex),

--- a/app/server-grpc/src/main/protobuf/chain_routes.proto
+++ b/app/server-grpc/src/main/protobuf/chain_routes.proto
@@ -68,7 +68,6 @@ message BlockHeaderResult {
   uint32 mediantime = 8;
   uint32 nonce = 9;
   string bits = 10;
-  string difficulty = 11;
   string chainwork = 12;
   optional string previousblockhash = 13;
   optional string nextblockhash = 14;

--- a/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
+++ b/app/server-grpc/src/main/scala/org/bitcoins/server/grpc/ChainGrpcRoutes.scala
@@ -114,7 +114,6 @@ class ChainGrpcRoutes(
       mediantime = header.time.toLong.toInt,
       nonce = header.nonce.toLong.toInt,
       bits = header.nBits.hex,
-      difficulty = header.difficulty.toString,
       chainwork = chainworkStr,
       previousblockhash = Some(header.previousBlockHashBE.hex),
       nextblockhash = None,

--- a/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
+++ b/app/server-test/src/test/scala/org/bitcoins/server/RoutesSpec.scala
@@ -42,7 +42,7 @@ import org.bitcoins.core.protocol.{
 }
 import org.bitcoins.core.psbt.InputPSBTRecord.PartialSignature
 import org.bitcoins.core.psbt.PSBT
-import org.bitcoins.core.util.FutureUtil
+import org.bitcoins.core.util.{FutureUtil, NumberUtil}
 import org.bitcoins.core.util.sorted.OrderedSchnorrSignatures
 import org.bitcoins.core.wallet.fee.{FeeUnit, SatoshisPerVirtualByte}
 import org.bitcoins.core.wallet.rescan.RescanState
@@ -354,7 +354,8 @@ class RoutesSpec extends AnyWordSpec with ScalatestRouteTest with MockFactory {
         assert(
           responseAs[
             String
-          ] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":0,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${blockHeaderDb.time.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":${blockHeader.difficulty.toDouble},"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null,"target":null},"error":null}"""
+          ] == s"""{"result":{"raw":"${blockHeader.hex}","hash":"${blockHeader.hashBE.hex}","confirmations":0,"height":1899697,"version":${blockHeader.version.toLong},"versionHex":"${blockHeader.version.hex}","merkleroot":"${blockHeader.merkleRootHashBE.hex}","time":${blockHeader.time.toLong},"mediantime":${blockHeaderDb.time.toLong},"nonce":${blockHeader.nonce.toLong},"bits":"${blockHeader.nBits.hex}","difficulty":null,"chainwork":"$chainworkStr","previousblockhash":"${blockHeader.previousBlockHashBE.hex}","nextblockhash":null,"target":"${NumberUtil
+              .serializeTargetHex(blockHeader.target)}"},"error":null}"""
         )
       }
     }

--- a/app/server/src/main/scala/org/bitcoins/server/util/ChainUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/util/ChainUtil.scala
@@ -3,6 +3,7 @@ package org.bitcoins.server.util
 import org.bitcoins.commons.jsonmodels.bitcoind.GetBlockHeaderResult
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
+import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import scodec.bits.ByteVector
 
@@ -52,11 +53,11 @@ object ChainUtil {
             mediantime = header.time, // can't get this?
             nonce = header.nonce,
             bits = header.nBits,
-            difficulty = BigDecimal(header.difficulty),
+            difficulty = None,
             chainwork = chainworkStr,
             previousblockhash = Some(header.previousBlockHashBE),
             nextblockhash = None,
-            target = None
+            target = Some(NumberUtil.serializeTargetHex(header.target))
           )
           result
       }

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -122,9 +122,9 @@ sealed abstract class Pow {
       var bnNew = chainParams match {
         case MainNetChainParams | TestNetChainParams | RegTestNetChainParams |
             SigNetChainParams(_) =>
-          NumberUtil.targetExpansion(currentTip.nBits).difficulty
+          NumberUtil.targetExpansion(currentTip.nBits).target
         case TestNet4ChainParams =>
-          NumberUtil.targetExpansion(firstBlock.nBits).difficulty
+          NumberUtil.targetExpansion(firstBlock.nBits).target
       }
       bnNew = bnNew * actualTimespan
 

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -102,7 +102,7 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
     if (headerWork <= 0 || NumberUtil.isNBitsOverflow(nBits = header.nBits)) {
       true
     } else {
-      headerWork > header.difficulty
+      headerWork > header.target
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
@@ -29,7 +29,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected1 = BigInteger.valueOf(0)
     val diffHelper1 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected1,
+        target = expected1,
         isNegative = false,
         isOverflow = false
       )
@@ -40,7 +40,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected2 = BigInteger.valueOf(18)
     val diffHelper2 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected2,
+        target = expected2,
         isNegative = false,
         isOverflow = false
       )
@@ -51,7 +51,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected3 = BigInteger.valueOf(128)
     val diffHelper3 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected3,
+        target = expected3,
         isNegative = false,
         isOverflow = false
       )
@@ -62,7 +62,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected4 = BigInteger.valueOf(2452881408L)
     val diffHelper4 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected4,
+        target = expected4,
         isNegative = false,
         isOverflow = false
       )
@@ -73,7 +73,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected6 = BigInteger.valueOf(305419776)
     val diffHelper6 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected6,
+        target = expected6,
         isNegative = false,
         isOverflow = false
       )
@@ -84,7 +84,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     val expected5 = BigInteger.valueOf(305419776)
     val diffHelper5 = {
       BlockHeader.TargetDifficultyHelper(
-        difficulty = expected5,
+        target = expected5,
         isNegative = true,
         isOverflow = false
       )
@@ -175,7 +175,7 @@ class NumberUtilTest extends BitcoinSUnitTest {
     ) must be(UInt32.fromHex("02008000"))
     val expanded11 = NumberUtil.targetExpansion(UInt32.fromHex("01fedcba"))
 
-    expanded11.difficulty must be(126)
+    expanded11.target must be(126)
     expanded11.isNegative must be(true)
     NumberUtil.targetCompression(expanded11) must be(UInt32.fromHex("01fe0000"))
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/db/BlockHeaderDb.scala
@@ -31,7 +31,10 @@ case class BlockHeaderDb(
     blockHeader
   }
 
-  lazy val difficulty: BigInt = blockHeader.difficulty
+  @deprecated("Use target", "1.9.13")
+  def difficulty: BigInt = target
+
+  lazy val target: BigInt = blockHeader.target
 
   lazy val hash: DoubleSha256Digest = hashBE.flip
 

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -94,6 +94,9 @@ sealed trait BlockHeader extends NetworkElement {
     */
   def nBits: UInt32
 
+  @deprecated("Use target", "1.9.13")
+  def difficulty: BigInt = target
+
   /** This is the decoded version of [[nBits]]. nBits is used to compactly
     * represent the difficulty target for the bitcoin network. This field is the
     * expanded version that is the _actual_ requirement needed for the network.
@@ -104,8 +107,8 @@ sealed trait BlockHeader extends NetworkElement {
     * The hash of this block needs to be _less than_ this difficulty to be
     * considered a valid block on the network
     */
-  def difficulty: BigInt = {
-    NumberUtil.targetExpansion(nBits = nBits).difficulty
+  def target: BigInt = {
+    NumberUtil.targetExpansion(nBits = nBits).target
   }
 
   /** An arbitrary number miners change to modify the header hash in order to
@@ -190,12 +193,12 @@ object BlockHeader extends Factory[BlockHeader] {
     * it being an overflow or negative which is returned by
     * [[https://github.com/bitcoin/bitcoin/blob/2068f089c8b7b90eb4557d3f67ea0f0ed2059a23/src/arith_uint256.cpp#L206 arith_uint256#SetCompact()]]
     * in bitcoin core
-    * @param difficulty
+    * @param target
     * @param isNegative
     * @param isOverflow
     */
   case class TargetDifficultyHelper(
-      difficulty: BigInt,
+      target: BigInt,
       isNegative: Boolean,
       isOverflow: Boolean)
 
@@ -205,7 +208,7 @@ object BlockHeader extends Factory[BlockHeader] {
     if (target.isNegative || target.isOverflow) {
       BigInt(0)
     } else {
-      (BigInt(1) << 256) / (target.difficulty + BigInt(1))
+      (BigInt(1) << 256) / (target.target + BigInt(1))
     }
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -104,7 +104,7 @@ sealed trait BlockHeader extends NetworkElement {
     * more information on how this is constructed
     * [[https://bitcoin.org/en/developer-reference#target-nbits documentation]]
     *
-    * The hash of this block needs to be _less than_ this difficulty to be
+    * The hash of this block needs to be _less than_ this target to be
     * considered a valid block on the network
     */
   def target: BigInt = {

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -269,7 +269,14 @@ sealed abstract class NumberUtil extends CryptoNumberUtil {
   }
 
   def targetCompression(difficultyHelper: TargetDifficultyHelper): UInt32 = {
-    targetCompression(difficultyHelper.difficulty, difficultyHelper.isNegative)
+    targetCompression(difficultyHelper.target, difficultyHelper.isNegative)
+  }
+
+  /** Serializes the target difficulty to a hex string, padding it to the given
+    * size. Useful for RPC interfaces
+    */
+  def serializeTargetHex(target: BigInt, padding: Int = 32): String = {
+    ByteVector.fromBigInt(target, size = Some(padding)).toHex
   }
 
   /** Implements this check for overflowing for


### PR DESCRIPTION
## Description

This PR renames the misnamed `difficulty` field in block header internals to `target`, which better reflects Bitcoin semantics: the expanded `nBits` value is the **target threshold**, not the human-readable network difficulty ratio.

## Motivation

The previous naming (`difficulty`) made code paths around PoW validation and target expansion harder to reason about, and could be confused with RPC’s normalized `difficulty` value. This refactor aligns naming with Bitcoin Core concepts and improves readability/maintainability.

## Changes

- Core model/API updates:
  - Renamed `BlockHeader.difficulty` → `BlockHeader.target`
  - Renamed `TargetDifficultyHelper.difficulty` → `TargetDifficultyHelper.target`
  - Updated PoW/validation usage to compare against `target`
- Backward compatibility:
  - Added deprecated compatibility accessors where needed (e.g. `difficulty` delegating to `target`) to avoid immediate breakage
- Serialization / RPC surface alignment:
  - Updated block header JSON model/picklers to handle this more explicitly
  - Added target hex serialization helper (`NumberUtil.serializeTargetHex`)
  - Updated gRPC chain route protobuf/route mapping to reflect renamed semantics
- Tests updated to match the new terminology and behavior (including `targetExpansion` assertions)

## Notable behavior/API notes

- Internally, “target” now represents the expanded threshold from `nBits`
- RPC `difficulty` handling was adjusted in touched call sites; target is now surfaced explicitly where applicable
- Some compatibility shims are deprecated and intended for later cleanup
