### PR TITLE
refactor(core): move chain API types into core

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BlockchainTest.scala
@@ -1,12 +1,13 @@
 package org.bitcoins.chain.blockchain
 
-import org.bitcoins.chain.validation.TipUpdateResult
-import org.bitcoins.core.api.chain.db.BlockHeaderDb
-import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.blockchain.{
-  BlockHeader,
-  RegTestNetChainParams
+import org.bitcoins.chain.validation.TipValidation
+import org.bitcoins.core.api.chain.{
+  Blockchain,
+  BlockchainUpdate,
+  TipUpdateResult
 }
+import org.bitcoins.core.api.chain.db.BlockHeaderDb
+import org.bitcoins.core.protocol.blockchain.{RegTestNetChainParams}
 import org.bitcoins.testkit.chain.BlockHeaderHelper
 import org.bitcoins.testkit.util.BitcoinSAsyncTest
 import org.bitcoins.testkitcore.chain.ChainTestUtil
@@ -25,28 +26,6 @@ class BlockchainTest extends BitcoinSAsyncTest {
     assert(chain.toString == s"BaseBlockchain(tip=$headerDb,length=2)")
   }
 
-  it must "connect a new header to the current tip of a blockchain" in {
-    val blockchain = Blockchain.fromHeaders(
-      headers = Vector(ChainTestUtil.regTestGenesisHeaderDb)
-    )
-
-    val newHeader =
-      BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
-
-    val connectTip =
-      Blockchain.connectTip(header = newHeader.blockHeader,
-                            blockchain = blockchain,
-                            chainParams = RegTestNetChainParams)
-
-    connectTip match {
-      case ConnectTipResult.ExtendChain(_, newChain) =>
-        assert(newHeader == newChain.tip)
-
-      case _ @(_: ConnectTipResult.Reorg | _: ConnectTipResult.BadTip) =>
-        fail()
-    }
-  }
-
   it must "reconstruct a blockchain given a child header correctly" in {
     val accum = new mutable.ArrayBuffer[BlockHeaderDb](5)
     accum.+=(ChainTestUtil.regTestGenesisHeaderDb)
@@ -63,6 +42,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
     val reconstructed = Blockchain.reconstructFromHeaders(
       childHeader = tip,
       ancestors = headers,
+      tipValidationApi = TipValidation,
       chainParams = RegTestNetChainParams
     )
 
@@ -84,6 +64,7 @@ class BlockchainTest extends BitcoinSAsyncTest {
       Blockchain.reconstructFromHeaders(
         thirdHeader,
         Vector(ChainTestUtil.regTestGenesisHeaderDb),
+        tipValidationApi = TipValidation,
         chainParams = RegTestNetChainParams
       )
 
@@ -115,24 +96,4 @@ class BlockchainTest extends BitcoinSAsyncTest {
     assert(updated.height == chain.height)
   }
 
-  it must "correctly identify a bad tip" in {
-    val genesis = ChainTestUtil.regTestGenesisHeaderDb
-    val chain = Blockchain(Vector(genesis))
-
-    val goodHeader = BlockHeaderHelper.buildNextHeader(genesis).blockHeader
-    val badHeader = BlockHeader(
-      version = goodHeader.version,
-      previousBlockHash = goodHeader.previousBlockHash,
-      merkleRootHash = goodHeader.merkleRootHash,
-      time = goodHeader.time,
-      nBits = UInt32.zero,
-      nonce = goodHeader.nonce
-    )
-
-    val result = Blockchain.connectTip(header = badHeader,
-                                       blockchain = chain,
-                                       chainParams = RegTestNetChainParams)
-
-    assert(result.isInstanceOf[ConnectTipResult.BadTip])
-  }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/MainnetChainHandlerTest.scala
@@ -2,6 +2,7 @@ package org.bitcoins.chain.blockchain
 
 import org.bitcoins.chain.config.ChainAppConfig
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.ChainUnitTest

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/BlockHeaderDAOTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.chain.models
 
-import org.bitcoins.chain.blockchain.Blockchain
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.BlockHeader

--- a/chain-test/src/test/scala/org/bitcoins/chain/models/PopulatedBlockHeaderDAOTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/models/PopulatedBlockHeaderDAOTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.chain.models
 
-import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.protocol.blockchain.MainNetChainParams
 import org.bitcoins.core.util.FutureUtil
 import org.bitcoins.testkit.chain.ChainUnitTest

--- a/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/pow/BitcoinPowTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.chain.pow
 
-import org.bitcoins.chain.blockchain.Blockchain
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.protocol.blockchain.{
   MainNetChainParams,
   RegTestNetChainParams,

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationMainNetTest.scala
@@ -2,13 +2,13 @@ package org.bitcoins.chain.validation
 
 import org.bitcoins.chain.models.BlockHeaderDAO
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.{Blockchain, TipUpdateResult}
 import org.bitcoins.core.api.chain.db.BlockHeaderDbHelper
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
 import org.scalatest.{Assertion, FutureOutcome}
 
 class TipValidationMainNetTest extends ChainUnitTest {
-  import org.bitcoins.chain.blockchain.Blockchain
   import org.bitcoins.chain.config.ChainAppConfig
 
   override type FixtureParam = BlockHeaderDAO

--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -1,10 +1,19 @@
 package org.bitcoins.chain.validation
 
-import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.models.BlockHeaderDAO
+import org.bitcoins.core.api.chain.{
+  Blockchain,
+  ConnectTipResult,
+  TipUpdateResult
+}
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.blockchain.{
+  BlockHeader,
+  RegTestNetChainParams
+}
 import org.bitcoins.testkit.chain.{BlockHeaderHelper, ChainUnitTest}
+import org.bitcoins.testkitcore.chain.ChainTestUtil
 import org.scalatest.FutureOutcome
 
 import java.time.Instant
@@ -112,6 +121,49 @@ class TipValidationTest extends ChainUnitTest {
         tipValidationResultValid == TipUpdateResult.Success(
           newHeaderTime2hoursDb)
       )
+    }
+  }
+
+  it must "correctly identify a bad tip" in { _ =>
+    val genesis = ChainTestUtil.regTestGenesisHeaderDb
+    val chain = Blockchain(Vector(genesis))
+
+    val goodHeader = BlockHeaderHelper.buildNextHeader(genesis).blockHeader
+    val badHeader = BlockHeader(
+      version = goodHeader.version,
+      previousBlockHash = goodHeader.previousBlockHash,
+      merkleRootHash = goodHeader.merkleRootHash,
+      time = goodHeader.time,
+      nBits = UInt32.zero,
+      nonce = goodHeader.nonce
+    )
+
+    val result = TipValidation.connectTip(header = badHeader,
+                                          blockchain = chain,
+                                          chainParams = RegTestNetChainParams)
+
+    assert(result.isInstanceOf[ConnectTipResult.BadTip])
+  }
+
+  it must "connect a new header to the current tip of a blockchain" in { _ =>
+    val blockchain = Blockchain.fromHeaders(
+      headers = Vector(ChainTestUtil.regTestGenesisHeaderDb)
+    )
+
+    val newHeader =
+      BlockHeaderHelper.buildNextHeader(ChainTestUtil.regTestGenesisHeaderDb)
+
+    val connectTip =
+      TipValidation.connectTip(header = newHeader.blockHeader,
+                               blockchain = blockchain,
+                               chainParams = RegTestNetChainParams)
+
+    connectTip match {
+      case ConnectTipResult.ExtendChain(_, newChain) =>
+        assert(newHeader == newChain.tip)
+
+      case _ @(_: ConnectTipResult.Reorg | _: ConnectTipResult.BadTip) =>
+        fail()
     }
   }
 }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -2,11 +2,17 @@ package org.bitcoins.chain.blockchain
 
 import org.bitcoins.chain.ChainVerificationLogger
 import org.bitcoins.chain.config.ChainAppConfig
-import org.bitcoins.chain.models._
+import org.bitcoins.chain.models.*
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.chain.validation.TipValidation
 import org.bitcoins.core.api.chain.ChainQueryApi.FilterResponse
-import org.bitcoins.core.api.chain.db._
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.db.*
+import org.bitcoins.core.api.chain.{
+  Blockchain,
+  BlockchainUpdate,
+  ChainApi,
+  FilterSyncMarker
+}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.p2p.CompactFilterMessage
@@ -16,7 +22,7 @@ import org.bitcoins.core.util.{FutureUtil, NetworkUtil}
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256DigestBE}
 
 import scala.annotation.tailrec
-import scala.concurrent._
+import scala.concurrent.*
 
 /** Chain Handler is meant to be the reference implementation of
   * [[ChainApi ChainApi]], this is the entry point in to the chain project.
@@ -136,6 +142,7 @@ class ChainHandler(
         Blockchain.connectHeadersToChains(
           headers = filteredHeaders,
           blockchains = blockchains,
+          tipValidationApi = TipValidation,
           chainParams = chainConfig.chain
         )
       }

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandlerCached.scala
@@ -8,7 +8,7 @@ import org.bitcoins.chain.models.{
   CompactFilterHeaderDAO
 }
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, CompactFilterHeaderDb}
-import org.bitcoins.core.api.chain.{ChainApi}
+import org.bitcoins.core.api.chain.{Blockchain, ChainApi}
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 import org.bitcoins.crypto.DoubleSha256DigestBE
 

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/CheckHeaderResult.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/CheckHeaderResult.scala
@@ -1,5 +1,0 @@
-package org.bitcoins.chain.blockchain
-
-import org.bitcoins.chain.validation.TipUpdateResult
-
-case class CheckHeaderResult(result: TipUpdateResult, chain: Blockchain)

--- a/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/models/BlockHeaderDAO.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.chain.models
 
-import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.config.ChainAppConfig
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.crypto.DoubleSha256DigestBE

--- a/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/pow/Pow.scala
@@ -1,9 +1,9 @@
 package org.bitcoins.chain.pow
 
-import org.bitcoins.chain.blockchain.Blockchain
+import org.bitcoins.core.api.chain.Blockchain
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.blockchain._
+import org.bitcoins.core.protocol.blockchain.*
 import org.bitcoins.core.util.NumberUtil
 
 /** Implements functions found inside of bitcoin core's

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -1,8 +1,13 @@
 package org.bitcoins.chain.validation
 
 import org.bitcoins.chain.ChainVerificationLogger
-import org.bitcoins.chain.blockchain.Blockchain
 import org.bitcoins.chain.pow.Pow
+import org.bitcoins.core.api.chain.{
+  Blockchain,
+  ConnectTipResult,
+  TipUpdateResult,
+  TipValidationApi
+}
 import org.bitcoins.core.api.chain.db.{BlockHeaderDb, BlockHeaderDbHelper}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.{BitcoinChainParams, BlockHeader}
@@ -12,7 +17,9 @@ import org.bitcoins.core.util.NumberUtil
   * blockchain. The checks things like proof of work difficulty, if it
   * references the previous block header correctly etc.
   */
-sealed abstract class TipValidation extends ChainVerificationLogger {
+sealed abstract class TipValidation
+    extends TipValidationApi
+    with ChainVerificationLogger {
 
   /** Checks if the given header can be connected to the current tip This is the
     * method where a
@@ -65,6 +72,89 @@ sealed abstract class TipValidation extends ChainVerificationLogger {
 
     logTipResult(connectTipResult, currentTip)
     connectTipResult
+  }
+
+  override def connectTip(
+      header: BlockHeader,
+      blockchain: Blockchain,
+      chainParams: BitcoinChainParams): ConnectTipResult = {
+    logger.debug(
+      s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain"
+    )
+
+    val tipResult: ConnectTipResult = {
+      findPrevBlockHeaderIdx(header, blockchain) match {
+        case None =>
+          logger.debug(
+            s"No common ancestor found in the chain with tip=${blockchain.tip.hashBE.hex} to connect to hash=${header.hashBE.hex} prevHash=${header.previousBlockHashBE.hex}. This may be because we have a competing reorg!"
+          )
+          val err = TipUpdateResult.BadPreviousBlockHash(header)
+          val failed = ConnectTipResult.BadTip(err)
+          failed
+
+        case Some(prevHeaderIdx) =>
+          // found a header to connect to!
+          val prevBlockHeader = blockchain.headers(prevHeaderIdx)
+          logger.debug(
+            s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain of ${blockchain.length} headers with tip ${blockchain.tip.hashBE.hex}"
+          )
+          val chain = blockchain.fromValidHeader(prevBlockHeader)
+          val tipResult =
+            TipValidation.checkNewTip(newPotentialTip = header,
+                                      chain,
+                                      chainParams)
+
+          tipResult match {
+            case success: TipUpdateResult.Success =>
+              logger.debug(
+                s"Successfully verified=${success.header.hashBE.hex}, connecting to chain"
+              )
+              val connectionIdx = blockchain.length - prevHeaderIdx
+
+              // we construct a new blockchain by prepending the headers vector from the old one with the new tip
+              // in order to avoid creating unnecessary hidden copies of the blockchain here
+              if (connectionIdx != blockchain.length) {
+                val newChain = Blockchain(
+                  success.headerDb +: blockchain.headers.takeRight(
+                    connectionIdx
+                  )
+                )
+                // means we have a reorg, since we aren't connecting to latest tip
+                ConnectTipResult.Reorg(success, newChain)
+              } else {
+                val olderChain = if (blockchain.size < 2016) {
+                  blockchain.headers
+                } else blockchain.headers.take(2015)
+                val newChain = Blockchain(success.headerDb +: olderChain)
+                // we just extended the latest tip
+                ConnectTipResult.ExtendChain(success, newChain)
+              }
+            case fail: TipUpdateResult.Failure =>
+              logger.warn(
+                s"Could not verify header=${header.hashBE.hex}, reason=$fail"
+              )
+              ConnectTipResult.BadTip(fail)
+          }
+      }
+    }
+    tipResult
+  }
+
+  /** Finds the parent's index of the given header
+    */
+  private def findPrevBlockHeaderIdx(
+      header: BlockHeader,
+      blockchain: Blockchain
+  ): Option[Int] = {
+    // Let's see if we are lucky and the latest tip is the parent.
+    val latestTip = blockchain.tip
+    if (latestTip.hashBE == header.previousBlockHashBE) {
+      // Yes we are.
+      Some(0)
+    } else {
+      // No. Scanning the blockchain to find the parent.
+      blockchain.findHeaderIdx(header.previousBlockHashBE)
+    }
   }
 
   /** Logs the result of

--- a/core/src/main/scala/org/bitcoins/core/api/chain/BaseBlockChain.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/BaseBlockChain.scala
@@ -1,7 +1,5 @@
-package org.bitcoins.chain.blockchain
+package org.bitcoins.core.api.chain
 
-import org.bitcoins.chain.ChainVerificationLogger
-import org.bitcoins.chain.validation.{TipUpdateResult, TipValidation}
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.protocol.blockchain.{BitcoinChainParams, BlockHeader}
 import org.bitcoins.core.util.SeqWrapper
@@ -28,7 +26,7 @@ import scala.annotation.tailrec
   *   headers.map(h => println(h))
   * }}}
   */
-private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
+private[chain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
   require(headers.nonEmpty, s"Cannot have empty Blockchain")
   require(
     headers.size == 1 || headers(1).height == tip.height - 1,
@@ -94,84 +92,10 @@ private[blockchain] trait BaseBlockChain extends SeqWrapper[BlockHeaderDb] {
   }
 }
 
-private[blockchain] trait BaseBlockChainCompObject
-    extends ChainVerificationLogger {
-
+private[chain] trait BaseBlockChainCompObject {
   def fromHeaders(
       headers: scala.collection.immutable.Seq[BlockHeaderDb]
   ): Blockchain
-
-  /** Attempts to connect the given block header with the given blockchain
-    * @param header
-    *   the block header to connect to our chain
-    * @param blockchain
-    *   the blockchain we are attempting to connect to
-    */
-  def connectTip(
-      header: BlockHeader,
-      blockchain: Blockchain,
-      chainParams: BitcoinChainParams): ConnectTipResult = {
-    logger.debug(
-      s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain"
-    )
-
-    val tipResult: ConnectTipResult = {
-      findPrevBlockHeaderIdx(header, blockchain) match {
-        case None =>
-          logger.debug(
-            s"No common ancestor found in the chain with tip=${blockchain.tip.hashBE.hex} to connect to hash=${header.hashBE.hex} prevHash=${header.previousBlockHashBE.hex}. This may be because we have a competing reorg!"
-          )
-          val err = TipUpdateResult.BadPreviousBlockHash(header)
-          val failed = ConnectTipResult.BadTip(err)
-          failed
-
-        case Some(prevHeaderIdx) =>
-          // found a header to connect to!
-          val prevBlockHeader = blockchain.headers(prevHeaderIdx)
-          logger.debug(
-            s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain of ${blockchain.length} headers with tip ${blockchain.tip.hashBE.hex}"
-          )
-          val chain = blockchain.fromValidHeader(prevBlockHeader)
-          val tipResult =
-            TipValidation.checkNewTip(newPotentialTip = header,
-                                      chain,
-                                      chainParams)
-
-          tipResult match {
-            case success: TipUpdateResult.Success =>
-              logger.debug(
-                s"Successfully verified=${success.header.hashBE.hex}, connecting to chain"
-              )
-              val connectionIdx = blockchain.length - prevHeaderIdx
-
-              // we construct a new blockchain by prepending the headers vector from the old one with the new tip
-              // in order to avoid creating unnecessary hidden copies of the blockchain here
-              if (connectionIdx != blockchain.length) {
-                val newChain = Blockchain(
-                  success.headerDb +: blockchain.headers.takeRight(
-                    connectionIdx
-                  )
-                )
-                // means we have a reorg, since we aren't connecting to latest tip
-                ConnectTipResult.Reorg(success, newChain)
-              } else {
-                val olderChain = if (blockchain.size < 2016) {
-                  blockchain.headers
-                } else blockchain.headers.take(2015)
-                val newChain = Blockchain(success.headerDb +: olderChain)
-                // we just extended the latest tip
-                ConnectTipResult.ExtendChain(success, newChain)
-              }
-            case fail: TipUpdateResult.Failure =>
-              logger.warn(
-                s"Could not verify header=${header.hashBE.hex}, reason=$fail"
-              )
-              ConnectTipResult.BadTip(fail)
-          }
-      }
-    }
-    tipResult
-  }
 
   /** Iterates through each given blockchains attempting to connect the given
     * headers to that chain
@@ -182,11 +106,9 @@ private[blockchain] trait BaseBlockChainCompObject
   def connectHeadersToChains(
       headers: Vector[BlockHeader],
       blockchains: Vector[Blockchain],
+      tipValidationApi: TipValidationApi,
       chainParams: BitcoinChainParams
   ): Vector[BlockchainUpdate] = {
-    logger.debug(
-      s"Attempting to connect ${headers.length} headers to ${blockchains.length} blockchains"
-    )
 
     val initUpdates: Vector[BlockchainUpdate] = blockchains.map { blockchain =>
       BlockchainUpdate.Successful(blockchain, Vector.empty)
@@ -196,7 +118,7 @@ private[blockchain] trait BaseBlockChainCompObject
       lastUpdates
         .flatMap { lastUpdate =>
           val connectTipResult =
-            Blockchain.connectTip(
+            tipValidationApi.connectTip(
               header = h,
               blockchain = lastUpdate.blockchain,
               chainParams
@@ -247,23 +169,6 @@ private[blockchain] trait BaseBlockChainCompObject
 
   }
 
-  /** Finds the parent's index of the given header
-    */
-  private def findPrevBlockHeaderIdx(
-      header: BlockHeader,
-      blockchain: Blockchain
-  ): Option[Int] = {
-    // Let's see if we are lucky and the latest tip is the parent.
-    val latestTip = blockchain.tip
-    if (latestTip.hashBE == header.previousBlockHashBE) {
-      // Yes we are.
-      Some(0)
-    } else {
-      // No. Scanning the blockchain to find the parent.
-      blockchain.findHeaderIdx(header.previousBlockHashBE)
-    }
-  }
-
   /** Walks backwards from the current header searching through ancestors if
     * [[current.previousBlockHashBE]] is in [[ancestors]] This does not validate
     * other things such as POW.
@@ -305,6 +210,7 @@ private[blockchain] trait BaseBlockChainCompObject
   def reconstructFromHeaders(
       childHeader: BlockHeaderDb,
       ancestors: Vector[BlockHeaderDb],
+      tipValidationApi: TipValidationApi,
       chainParams: BitcoinChainParams
   ): Vector[Blockchain] = {
     // now all hashes are connected correctly forming a
@@ -331,6 +237,7 @@ private[blockchain] trait BaseBlockChainCompObject
       Blockchain.connectHeadersToChains(
         headers = orderedHeaders.tail.map(_.blockHeader),
         blockchains = Vector(initBlockchain),
+        tipValidationApi = tipValidationApi,
         chainParams = chainParams
       )
     }

--- a/core/src/main/scala/org/bitcoins/core/api/chain/Blockchain.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/Blockchain.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.chain.blockchain
+package org.bitcoins.core.api.chain
 
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/BlockchainUpdate.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/BlockchainUpdate.scala
@@ -1,6 +1,5 @@
-package org.bitcoins.chain.blockchain
+package org.bitcoins.core.api.chain
 
-import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ConnectTipResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ConnectTipResult.scala
@@ -1,6 +1,5 @@
-package org.bitcoins.chain.blockchain
+package org.bitcoins.core.api.chain
 
-import org.bitcoins.chain.validation.TipUpdateResult
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.protocol.blockchain.BlockHeader
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/TipUpdateResult.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/TipUpdateResult.scala
@@ -1,4 +1,4 @@
-package org.bitcoins.chain.validation
+package org.bitcoins.core.api.chain
 
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
 import org.bitcoins.core.protocol.blockchain.BlockHeader

--- a/core/src/main/scala/org/bitcoins/core/api/chain/TipValidationApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/TipValidationApi.scala
@@ -1,0 +1,16 @@
+package org.bitcoins.core.api.chain
+import org.bitcoins.core.protocol.blockchain.{BitcoinChainParams, BlockHeader}
+
+trait TipValidationApi {
+
+  /** Attempts to connect the given block header with the given blockchain
+    * @param header
+    *   the block header to connect to our chain
+    * @param blockchain
+    *   the blockchain we are attempting to connect to
+    */
+  def connectTip(
+      header: BlockHeader,
+      blockchain: Blockchain,
+      chainParams: BitcoinChainParams): ConnectTipResult
+}


### PR DESCRIPTION
Extract shared chain API/domain types from `chain` into `core` so they can be consumed without depending on chain implementation packages.

- move `BaseBlockChain`, `Blockchain`, `BlockchainUpdate`, and `ConnectTipResult` to `core/src/main/scala/org/bitcoins/core/api/chain`
- move `TipUpdateResult` to `core/api/chain`
- add `TipValidationApi` in `core/api/chain`
- remove obsolete `CheckHeaderResult` from `chain` package