### PR TITLE
2026 05 23 add `getBlockchainFrom` methods to `ChainApi`

### DIFF
--- a/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
+++ b/bitcoind-rpc-test/src/test/scala/org/bitcoins/rpc/common/BlockchainRpcTest.scala
@@ -29,6 +29,7 @@ import org.bitcoins.testkit.rpc.{
   BitcoindFixturesCachedPairNewest,
   BitcoindRpcTestUtil
 }
+
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
@@ -450,5 +451,199 @@ class BlockchainRpcTest extends BitcoindFixturesCachedPairNewest {
       assert(hashes.head == wait.hash)
       assert(height + 1 == wait.height)
     }
+  }
+
+  it should "return a valid blockchain from a given header height" in {
+    nodePair =>
+      val client = nodePair.node1
+
+      for {
+        // Generate some blocks to work with
+        _ <- client.generate(10)
+
+        // Get the best block header
+        bestHeader <- client.getBestBlockHeader()
+        _ = assert(bestHeader.height >= 10, "Should have at least 10 blocks")
+
+        // Get blockchain from the best header (should use default difficulty interval)
+        blockchainOpt <- client.getBlockchainFrom(bestHeader)
+        _ = assert(blockchainOpt.isDefined, "Blockchain should be defined")
+
+        blockchain = blockchainOpt.get
+
+        // Validate the blockchain structure
+        _ = assert(
+          blockchain.headers.nonEmpty,
+          "Blockchain should have headers"
+        )
+        _ = assert(
+          blockchain.tip.hashBE == bestHeader.hashBE,
+          "Tip should match the best header"
+        )
+
+        // Verify consecutive headers are connected
+        _ = blockchain.headers.sliding(2).foreach {
+          case Vector(curr, prev) =>
+            assert(
+              curr.height == prev.height + 1,
+              s"Heights should be consecutive: ${prev.height} -> ${curr.height}"
+            )
+            assert(
+              curr.previousBlockHashBE == prev.hashBE,
+              s"Block at height ${curr.height} should reference previous block"
+            )
+          case _ => ()
+        }
+      } yield succeed
+  }
+
+  it should "return a valid blockchain when specifying a start height" in {
+    nodePair =>
+      val client = nodePair.node1
+
+      for {
+        _ <- client.generate(20)
+
+        // Get the best header and a header at mid-range height
+        bestHeader <- client.getBestBlockHeader()
+        startHeight = Math.max(0, bestHeader.height - 10)
+
+        // Get blockchain from best header with custom start height
+        blockchainOpt <- client.getBlockchainFrom(bestHeader, startHeight)
+        _ = assert(blockchainOpt.isDefined, "Blockchain should be defined")
+
+        blockchain = blockchainOpt.get
+
+        // Validate structure
+        _ = assert(
+          blockchain.headers.nonEmpty,
+          "Blockchain should have headers"
+        )
+        _ = assert(
+          blockchain.headers.head.height >= startHeight,
+          s"First header height ${blockchain.headers.head.height} should be >= start height $startHeight"
+        )
+        _ = assert(
+          blockchain.tip.hashBE == bestHeader.hashBE,
+          "Tip should match the best header"
+        )
+
+        // Verify size is reasonable (between start and best)
+        expectedRange = (bestHeader.height - startHeight) + 1
+        _ = assert(
+          blockchain.headers.length <= expectedRange,
+          s"Blockchain should have at most $expectedRange headers, got ${blockchain.headers.length}"
+        )
+      } yield succeed
+  }
+
+  it should "handle the genesis block correctly" in { nodePair =>
+    val client = nodePair.node1
+
+    for {
+      // Generate a few blocks
+      _ <- client.generate(5)
+
+      // Get a header and request blockchain from genesis
+      bestHeader <- client.getBestBlockHeader()
+      blockchainOpt <- client.getBlockchainFrom(bestHeader, startHeight = 0)
+      _ = assert(blockchainOpt.isDefined, "Blockchain should be defined")
+
+      blockchain = blockchainOpt.get
+
+      // Verify genesis block is included
+      _ = assert(
+        blockchain.headers.last.height == 0,
+        "First header should be genesis block (height 0)"
+      )
+      _ = assert(
+        blockchain.tip.hashBE == bestHeader.hashBE,
+        "Tip should match best header"
+      )
+    } yield succeed
+  }
+
+  it should "validate blockchain connectivity" in { nodePair =>
+    val client = nodePair.node1
+
+    for {
+      // Generate blocks to create a chain
+      _ <- client.generate(15)
+
+      // Get best header
+      bestHeader <- client.getBestBlockHeader()
+      startHeight = Math.max(0, bestHeader.height - 7)
+
+      // Get blockchain
+      blockchainOpt <- client.getBlockchainFrom(bestHeader, startHeight)
+      _ = assert(blockchainOpt.isDefined)
+
+      blockchain = blockchainOpt.get
+
+      // Verify via Blockchain's own validation logic
+      // Blockchain should be able to connect its headers if they're valid
+      headers = blockchain.headers
+      _ = assert(
+        headers.forall(header =>
+          header.height == startHeight || header.previousBlockHashBE == headers
+            .find(_.height ==
+              header.height - 1)
+            .get
+            .hashBE),
+        "All non-genesis headers should have valid previous block references"
+      )
+    } yield succeed
+  }
+
+  it should "return None for an invalid or unreachable blockchain" in {
+    nodePair =>
+      val client = nodePair.node1
+
+      for {
+        // Generate blocks
+        _ <- client.generate(5)
+        // Get a header
+        bestHeader <- client.getBestBlockHeader()
+
+        // Try to fetch blockchain with a future start height (should fail gracefully)
+        futureStart = bestHeader.height + 100
+        _ <- assertThrows[IllegalArgumentException](
+          client.getBlockchainFrom(bestHeader, futureStart))
+      } yield {
+        // Either None or exception handled is acceptable
+        succeed
+      }
+  }
+
+  it should "verify header sequence has strictly increasing heights" in {
+    nodePair =>
+      val client = nodePair.node1
+
+      for {
+        _ <- client.generate(12)
+
+        bestHeader <- client.getBestBlockHeader()
+        blockchainOpt <- client.getBlockchainFrom(bestHeader)
+        _ = assert(blockchainOpt.isDefined)
+
+        blockchain = blockchainOpt.get
+        headers = blockchain.headers
+
+        // Verify strictly increasing heights with no gaps
+        _ = headers.zipWithIndex.foreach {
+          case (_, idx) if idx == headers.length - 1 =>
+            () // First header is fine
+          case (header, idx) =>
+            val prevHeader = headers(idx + 1)
+            assert(
+              header.height == prevHeader.height + 1,
+              s"Gap at index $idx: ${prevHeader.height} -> ${header.height}"
+            )
+            assert(
+              header.previousBlockHashBE == prevHeader.hashBE,
+              s"Header at height ${header.height} does not link to previous"
+            )
+        }
+      } yield succeed
   }
 }

--- a/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
+++ b/bitcoind-rpc/src/main/scala/org/bitcoins/rpc/client/common/BitcoindRpcClient.scala
@@ -3,10 +3,10 @@ package org.bitcoins.rpc.client.common
 import org.apache.pekko.Done
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.scaladsl.{Keep, RunnableGraph, Sink, Source}
-import org.bitcoins.commons.jsonmodels.bitcoind.{GetNetworkInfoResultV28}
+import org.bitcoins.commons.jsonmodels.bitcoind.GetNetworkInfoResultV28
 import org.bitcoins.commons.util.BitcoinSLogger
 import org.bitcoins.core.api.chain.db.BlockHeaderDb
-import org.bitcoins.core.api.chain.{ChainApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.{Blockchain, ChainApi, FilterSyncMarker}
 import org.bitcoins.core.api.feeprovider.FeeRateApi
 import org.bitcoins.core.api.node.NodeApi
 import org.bitcoins.core.config.RegTest
@@ -215,8 +215,12 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
       to: BlockHeaderDb
   ): Future[Vector[BlockHeaderDb]] = {
     val range = from.height.to(to.height).toVector
-    val headerFs =
-      Future.traverse(range)(height => getHeaderAtHeight(height))
+    val headerFs = Source(range)
+      .mapAsync(FutureUtil.getParallelism) { height =>
+        getHeaderAtHeight(height)
+      }
+      .runWith(Sink.seq)
+      .map(_.toVector)
     headerFs
   }
 
@@ -241,6 +245,42 @@ class BitcoindRpcClient(override val instance: BitcoindInstance)(implicit
       hash <- getBestBlockHash()
       header <- getBlockHeader(hash)
     } yield header.blockHeaderDb
+
+  override def getBlockchainFrom(
+      header: BlockHeaderDb): Future[Option[Blockchain]] = {
+    val diffInterval = network.chainParams.difficultyChangeInterval
+    val startHeight = Math.max(0, header.height - diffInterval)
+    getBlockchainFrom(header, startHeight)
+  }
+
+  override def getBlockchainFrom(
+      header: BlockHeaderDb,
+      startHeight: Int): Future[Option[Blockchain]] = {
+    require(
+      startHeight >= 0,
+      s"Can only have positive  startHeight=$startHeight"
+    )
+    require(
+      startHeight <= header.height,
+      s"startHeight=$startHeight was not less than header.height=${header.height}")
+
+    for {
+      startHeader <- getHeaderAtHeight(startHeight)
+      headers <- getHeadersBetween(from = startHeader, to = header)
+      connected = Blockchain.connectWalkBackwards(header, headers)
+    } yield {
+      if (containsStartAndTip(startHeader, header, connected)) {
+        Some(Blockchain(connected.reverse))
+      } else None
+    }
+  }
+
+  private def containsStartAndTip(
+      startHeader: BlockHeaderDb,
+      tip: BlockHeaderDb,
+      headers: Vector[BlockHeaderDb]): Boolean = {
+    headers.headOption.contains(startHeader) && headers.lastOption.contains(tip)
+  }
 
   override def nextBlockHeaderBatchRange(
       prevStopHash: DoubleSha256DigestBE,

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -965,6 +965,15 @@ class ChainHandler(
         Future.failed(new RuntimeException(s"Not implemented: $blockTime"))
     }
 
+  override def getBlockchainFrom(
+      header: BlockHeaderDb): Future[Option[Blockchain]] =
+    blockHeaderDAO.getBlockchainFrom(header)
+
+  override def getBlockchainFrom(
+      header: BlockHeaderDb,
+      startHeight: Int): Future[Option[Blockchain]] =
+    blockHeaderDAO.getBlockchainFrom(header, startHeight)
+
   override def epochSecondToBlockHeight(time: Long): Future[Int] =
     blockHeaderDAO.findClosestToTime(time = UInt32(time)).map(_.height)
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/ChainApi.scala
@@ -186,6 +186,16 @@ trait ChainApi extends ChainQueryApi {
       from: BlockHeaderDb,
       to: BlockHeaderDb): Future[Vector[BlockHeaderDb]]
 
+  /** Retrieves a blockchain with the best tip being the given header */
+  def getBlockchainFrom(
+      header: BlockHeaderDb
+  ): Future[Option[Blockchain]]
+
+  /** Retrieves a blockchain from the given ehader to the given startHeight */
+  def getBlockchainFrom(
+      header: BlockHeaderDb,
+      startHeight: Int): Future[Option[Blockchain]]
+
   def isSyncing(): Future[Boolean]
 
   def isIBD(): Future[Boolean]

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/MockChainApi.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/MockChainApi.scala
@@ -5,7 +5,12 @@ import org.bitcoins.core.api.chain.db.{
   CompactFilterDb,
   CompactFilterHeaderDb
 }
-import org.bitcoins.core.api.chain.{ChainApi, ChainQueryApi, FilterSyncMarker}
+import org.bitcoins.core.api.chain.{
+  Blockchain,
+  ChainApi,
+  ChainQueryApi,
+  FilterSyncMarker
+}
 import org.bitcoins.core.gcs.FilterHeader
 import org.bitcoins.core.p2p.CompactFilterMessage
 import org.bitcoins.core.protocol.BlockStamp
@@ -135,6 +140,14 @@ object MockChainApi extends ChainApi {
       endHeight: Int
   ): Future[Vector[ChainQueryApi.FilterResponse]] =
     Future.successful(Vector.empty)
+
+  override def getBlockchainFrom(
+      header: BlockHeaderDb,
+      startHeight: Int): Future[Option[Blockchain]] = Future.successful(None)
+
+  override def getBlockchainFrom(
+      header: BlockHeaderDb): Future[Option[Blockchain]] =
+    Future.successful(None)
 
   override def epochSecondToBlockHeight(time: Long): Future[Int] =
     Future.successful(0)


### PR DESCRIPTION
Introduce two new `ChainApi` methods for reconstructing a connected blockchain
segment from a tip header:

- `getBlockchainFrom(header: BlockHeaderDb): Future[Option[Blockchain]]`
- `getBlockchainFrom(header: BlockHeaderDb, startHeight: Int): Future[Option[Blockchain]]`

This change establishes a common API for callers to fetch connected header ranges,
with `BitcoindRpcClient` implementing both variants and returning `None` when a
valid connected segment cannot be formed.

Also included:
- integration-style coverage in `BlockchainRpcTest` for both new methods
  (default interval + explicit `startHeight`)
- connectivity/ordering/genesis-path assertions for returned header sequences
- invalid start-height behavior checks