### PR TITLE
feat(chain): add Blockchain.getMedianTimePast(header) and return `Option`

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/validation/TipValidationTest.scala
@@ -43,15 +43,15 @@ class TipValidationTest extends ChainUnitTest {
         medianTimePast = blockchain.getMedianTimePast
         newHeaderBadMTP = BlockHeaderHelper
           .buildNextHeader(blockchain.tip,
-                           timeOpt = Some(UInt32(medianTimePast - 1)))
+                           timeOpt = medianTimePast.map(m => UInt32(m - 1)))
           .blockHeader
         newHeaderStaleMTP = BlockHeaderHelper
           .buildNextHeader(blockchain.tip,
-                           timeOpt = Some(UInt32(medianTimePast)))
+                           timeOpt = medianTimePast.map(UInt32.apply))
           .blockHeader
         newHeaderGoodMTP = BlockHeaderHelper
           .buildNextHeader(blockchain.tip,
-                           timeOpt = Some(UInt32(medianTimePast + 1)))
+                           timeOpt = medianTimePast.map(m => UInt32(m + 1)))
           .blockHeader
         tipValidationResultBadMTP = TipValidation.checkNewTip(
           newHeaderBadMTP,
@@ -86,9 +86,7 @@ class TipValidationTest extends ChainUnitTest {
   }
 
   it must "reject block headers that are too new" in { blockHeaderDAO =>
-    val firstHeaderF: Future[BlockHeaderDb] =
-      blockHeaderDAO.getBestChainTips.map(_.head)
-    val blockchainF = firstHeaderF.map(b => Blockchain.fromHeaders(Vector(b)))
+    val blockchainF = blockHeaderDAO.getBlockchains().map(_.head)
     for {
       blockchain <- blockchainF
 
@@ -145,6 +143,132 @@ class TipValidationTest extends ChainUnitTest {
     assert(result.isInstanceOf[ConnectTipResult.BadTip])
   }
 
+  it must "return Some(mtp) for a header that is in the chain with >= 11 ancestors" in {
+    _ =>
+      // Build genesis + 11 successors (12 total) so the tip has exactly 11
+      // ancestors available — the minimum required by nMedianTimeSpan
+      val genesis = ChainTestUtil.regTestGenesisHeaderDb
+      val headers =
+        (0 until Blockchain.nMedianTimeSpan).foldLeft(Vector(genesis)) {
+          (acc, _) =>
+            acc :+ BlockHeaderHelper.buildNextHeader(acc.last)
+        }
+      // Blockchain.fromHeaders expects headers in descending height order
+      val blockchain = Blockchain.fromHeaders(headers.reverse)
+      val tip = blockchain.tip
+
+      val result = blockchain.getMedianTimePast(tip)
+      assert(result.isDefined, "Expected Some(mtp) for a fully-populated chain")
+
+      // The MTP is the median of the 11 timestamps starting at the tip; verify
+      // it sits within the time range of those 11 headers
+      val window = headers.reverse
+        .take(Blockchain.nMedianTimeSpan)
+        .map(_.time.toLong)
+        .sorted
+      val expectedMtp = window(window.length / 2)
+      assert(result.contains(expectedMtp))
+  }
+
+  it must "return None when the requested header is not present in the blockchain" in {
+    _ =>
+      val genesis = ChainTestUtil.regTestGenesisHeaderDb
+      val headers =
+        (0 until Blockchain.nMedianTimeSpan).foldLeft(Vector(genesis)) {
+          (acc, _) =>
+            acc :+ BlockHeaderHelper.buildNextHeader(acc.last)
+        }
+      val blockchain = Blockchain.fromHeaders(headers.reverse)
+
+      // Build a header that is NOT part of the chain
+      val outsideHeader = BlockHeaderHelper.buildNextHeader(genesis)
+
+      val result = blockchain.getMedianTimePast(outsideHeader)
+      assert(
+        result.isEmpty,
+        "Expected None when the header is not found in the blockchain"
+      )
+  }
+
+  it must "return None when the blockchain does not have enough headers below the requested header" in {
+    _ =>
+      // Build genesis + 9 successors (10 total) — fewer than nMedianTimeSpan=11
+      val genesis = ChainTestUtil.regTestGenesisHeaderDb
+      val headers = (0 until 9).foldLeft(Vector(genesis)) { (acc, _) =>
+        acc :+ BlockHeaderHelper.buildNextHeader(acc.last)
+      }
+      val blockchain = Blockchain.fromHeaders(headers.reverse)
+      val tip = blockchain.tip
+
+      assert(
+        blockchain.headers.length < Blockchain.nMedianTimeSpan,
+        "Pre-condition: chain must have fewer headers than nMedianTimeSpan"
+      )
+
+      val result = blockchain.getMedianTimePast(tip)
+      assert(
+        result.isEmpty,
+        "Expected None when there are fewer than 11 headers available for MTP"
+      )
+  }
+
+  it must "return Some(mtp) for a non-tip header in the middle of the blockchain" in {
+    _ =>
+      // Build genesis + 15 successors (16 total)
+      val genesis = ChainTestUtil.regTestGenesisHeaderDb
+      val headers = (0 until 15).foldLeft(Vector(genesis)) { (acc, _) =>
+        acc :+ BlockHeaderHelper.buildNextHeader(acc.last)
+      }
+      // Blockchain stores headers in descending order (tip first)
+      val descHeaders = headers.reverse
+      val blockchain = Blockchain.fromHeaders(descHeaders)
+
+      // Pick a header that sits in the middle (index 5 from the top, height 10)
+      val midHeader = descHeaders(5)
+      assert(
+        descHeaders.length - 5 >= Blockchain.nMedianTimeSpan,
+        "Pre-condition: must have >= 11 headers from midHeader downward"
+      )
+
+      val result = blockchain.getMedianTimePast(midHeader)
+      assert(
+        result.isDefined,
+        s"Expected Some(mtp) for header at height=${midHeader.height}"
+      )
+
+      // Verify it matches computing MTP manually from that slice
+      val slicedBlockchain = Blockchain.fromHeaders(descHeaders.drop(5))
+      val expected = slicedBlockchain.getMedianTimePast
+      assert(result == expected)
+  }
+
+  it must "return None for a mid-chain header when insufficient ancestors exist below it" in {
+    _ =>
+      // Genesis + 12 successors (13 total). The header at index 10 from the top
+      // (height 2) only has 3 headers beneath it — fewer than 11.
+      val genesis = ChainTestUtil.regTestGenesisHeaderDb
+      val headers =
+        (0 until Blockchain.nMedianTimeSpan + 1).foldLeft(Vector(genesis)) {
+          (acc, _) =>
+            acc :+ BlockHeaderHelper.buildNextHeader(acc.last)
+        }
+      val descHeaders = headers.reverse
+      val blockchain = Blockchain.fromHeaders(descHeaders)
+
+      // Header near the bottom of the chain (index 10 from tip == height 2)
+      val nearBottomHeader = descHeaders(10)
+      val remainingBelow = descHeaders.length - 10
+      assert(
+        remainingBelow < Blockchain.nMedianTimeSpan,
+        s"Pre-condition: only $remainingBelow headers below the chosen header, need < ${Blockchain.nMedianTimeSpan}"
+      )
+
+      val result = blockchain.getMedianTimePast(nearBottomHeader)
+      assert(
+        result.isEmpty,
+        "Expected None when not enough ancestors exist below the requested header"
+      )
+  }
   it must "connect a new header to the current tip of a blockchain" in { _ =>
     val blockchain = Blockchain.fromHeaders(
       headers = Vector(ChainTestUtil.regTestGenesisHeaderDb)

--- a/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/blockchain/ChainHandler.scala
@@ -1305,7 +1305,7 @@ class ChainHandler(
         return pbegin[(pend - pbegin)/2];
     }
      */
-    val nMedianTimeSpan = 11
+    val nMedianTimeSpan = Blockchain.nMedianTimeSpan
 
     @tailrec
     def getNTopHeaders(
@@ -1332,7 +1332,17 @@ class ChainHandler(
       .sequence(top11)
       .map(_.flatten) // is this safe / right?
       .map(Blockchain.apply)
-      .map(_.getMedianTimePast)
+      .flatMap { blockchain =>
+        blockchain.getMedianTimePast match {
+          case Some(mtp) => Future.successful(mtp)
+          case None =>
+            val exn = new RuntimeException(
+              s"Could not calculate median time past, not enough blocks in the chain, got only ${blockchain.headers.length} headers"
+            )
+            Future.failed(exn)
+        }
+
+      }
   }
 
   override def isSyncing(): Future[Boolean] = {

--- a/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
+++ b/chain/src/main/scala/org/bitcoins/chain/validation/TipValidation.scala
@@ -94,11 +94,13 @@ sealed abstract class TipValidation
 
         case Some(prevHeaderIdx) =>
           // found a header to connect to!
-          val prevBlockHeader = blockchain.headers(prevHeaderIdx)
+          val prevBlockHeaders = blockchain.headers.slice(
+            prevHeaderIdx,
+            prevHeaderIdx + chainParams.difficultyChangeInterval)
+          val chain = Blockchain.fromHeaders(prevBlockHeaders)
           logger.debug(
             s"Attempting to add new tip=${header.hashBE.hex} with prevhash=${header.previousBlockHashBE.hex} to chain of ${blockchain.length} headers with tip ${blockchain.tip.hashBE.hex}"
           )
-          val chain = blockchain.fromValidHeader(prevBlockHeader)
           val tipResult =
             TipValidation.checkNewTip(newPotentialTip = header,
                                       chain,
@@ -211,11 +213,13 @@ sealed abstract class TipValidation
       newPotentialTip: BlockHeader,
       blockchain: Blockchain
   ): Boolean = {
-    if (blockchain.length <= 4) {
-      false
-    } else {
-      val medianTimePast = blockchain.getMedianTimePast
-      newPotentialTip.time.toLong <= medianTimePast
+    blockchain.getMedianTimePast match {
+      case None =>
+        // if median time past cannot be computed, do not silently
+        // skip MTP validation.
+        false
+      case Some(medianTimePast) =>
+        newPotentialTip.time.toLong <= medianTimePast
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/api/chain/Blockchain.scala
+++ b/core/src/main/scala/org/bitcoins/core/api/chain/Blockchain.scala
@@ -4,21 +4,39 @@ import org.bitcoins.core.api.chain.db.BlockHeaderDb
 
 /** @inheritdoc */
 case class Blockchain(headers: Vector[BlockHeaderDb]) extends BaseBlockChain {
-  def getMedianTimePast: Long = {
-    require(headers.length > 4,
-            s"Need at least 5 headers to calculate MTP, got=${headers.length}")
-    val nMedianTimeSpan: Int = 11
-    val sorted = headers
-      .take(nMedianTimeSpan)
-      .map(_.time.toLong)
-      .sorted
-    sorted.apply(sorted.length / 2)
+  def getMedianTimePast: Option[Long] = {
+    if (headers.length < Blockchain.nMedianTimeSpan) {
+      None
+    } else {
+      val sorted = headers
+        .take(Blockchain.nMedianTimeSpan)
+        .map(_.time.toLong)
+        .sorted
+      Some(sorted.apply(sorted.length / 2))
+    }
 
+  }
+
+  def getMedianTimePast(header: BlockHeaderDb): Option[Long] = {
+    val headerIndexOpt = headers.indexWhere(_.hashBE == header.hashBE) match {
+      case -1  => None
+      case idx => Some(idx)
+    }
+    headerIndexOpt match {
+      case Some(headerIndex) =>
+        val sorted = headers
+          .slice(from = headerIndex,
+                 until = headerIndex + Blockchain.nMedianTimeSpan)
+        Blockchain.fromHeaders(sorted).getMedianTimePast
+      case None =>
+        None
+    }
   }
 }
 
 object Blockchain extends BaseBlockChainCompObject {
-
+  val minHeadersMTP = 5
+  val nMedianTimeSpan: Int = 11
   override def fromHeaders(
       headers: scala.collection.immutable.Seq[BlockHeaderDb]
   ): Blockchain =


### PR DESCRIPTION
Realized during #6363 that it would be nice to return a `Option` from `Blockchain.getMedianTimePast` to be able to handle failure cases gracefully. Also add `Blockchain.getMedianTimePast(header)` to retrieve the median time past for a specific header.