### PR TITLE
Bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -13,11 +13,11 @@ jobs:
       DISABLE_SECP256K1: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           # for some reason there seems to be a bug in the temurin runtime with jlink/jdeps
           # this can likely be reverted back to temurin in the future
@@ -27,7 +27,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -14,11 +14,11 @@ jobs:
       PG_STARTUP_WAIT: "60"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -26,7 +26,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -12,11 +12,11 @@ jobs:
     if: "! contains(github.event.pull_request.labels.*.name, 'documentation')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -16,11 +16,11 @@ jobs:
       TESTCONTAINERS_HOST_OVERRIDE: "localhost"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -28,7 +28,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -17,11 +17,11 @@ jobs:
         run: "git config --global core.autocrlf false"
         shell: bash
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -29,7 +29,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: |
             ~/.ivy2/cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,11 +10,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Check Out Repo
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           # for some reason there seems to be a bug in the temurin runtime with jlink/jdeps
           # this can likely be reverted back to temurin in the future
@@ -24,7 +24,7 @@ jobs:
       - name: Install sbt
         uses: sbt/setup-sbt@v1
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -28,10 +28,10 @@ jobs:
             local_path: app/cli/target/native-image/bitcoin-s-cli
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
+      - uses: olafurpg/setup-scala@v14
         with:
           # from https://github.com/graalvm/graalvm-ce-builds/releases
           java-version: graalvm@21.0.2=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_${{runner.os}}-x64_bin.tar.gz
@@ -41,7 +41,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
       - run: echo $(pwd)
         shell: bash
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v7
         with:
           path: ${{ matrix.local_path }}
           name: ${{ matrix.uploaded_filename }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           # for some reason there seems to be a bug in the temurin runtime with jlink/jdeps
           # this can likely be reverted back to temurin in the future
@@ -54,11 +54,11 @@ jobs:
             # TODO : Do we want to use 'win' or 'windows'?
             TARGET: windows
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           # for some reason there seems to be a bug in the temurin runtime with jlink/jdeps
           # this can likely be reverted back to temurin in the future
@@ -86,7 +86,7 @@ jobs:
       #   shell: bash
       #   run: sbt "appServer / Universal / stage; appServer / Universal / packageBin"
       - name: Upload bitcoin-s-server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
@@ -94,7 +94,7 @@ jobs:
           path: app/server/target/universal/stage
       - name: (release) Upload bitcoin-s-server
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: bitcoin-s-server-${{ matrix.TARGET }}-${{steps.previoustag.outputs.tag}}
           files: app/server/target/universal/*.zip
@@ -105,7 +105,7 @@ jobs:
       #   shell: bash
       #   run: sbt "oracleServer / Universal / stage; oracleServer / Universal / packageBin"
       - name: Upload bitcoin-s-oracle-server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
@@ -113,7 +113,7 @@ jobs:
           path: app/oracle-server/target/universal/stage
       - name: (release) Upload bitcoin-s-oracle-server
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: bitcoin-s-oracle-server-${{ matrix.TARGET }}-${{steps.previoustag.outputs.tag}}
           files: app/oracle-server/target/universal/*.zip
@@ -124,7 +124,7 @@ jobs:
       #   shell: bash
       #   run: sbt "cli / Universal / stage; cli / Universal / packageBin"
       - name: Upload bitcoin-s-cli
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
@@ -132,7 +132,7 @@ jobs:
           path: app/cli/target/universal/stage/
       - name: (release) Upload bitcoin-s-cli
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: bitcoin-s-cli-${{ matrix.TARGET }}-${{steps.previoustag.outputs.tag}}
           files: app/cli/target/universal/*.zip
@@ -168,7 +168,7 @@ jobs:
       W_OUT: "bitcoin-s-ts/wallet-electron-ts/out"
       W_MAKE: "bitcoin-s-ts/wallet-electron-ts/out/make"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Get Previous tag
@@ -180,7 +180,7 @@ jobs:
       # macos keychain unlocking for signing identity access
       - name: (macos) Import developer cert to keychain
         if: startsWith(matrix.os,'macos')
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           create-keychain: true
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
@@ -197,11 +197,11 @@ jobs:
           security find-identity -p codesigning -v
       # Install Node, checkout repo, install dependencies and build repo
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 16.x
       - name: Checkout bitcoin-s-ts repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           repository: bitcoin-s/bitcoin-s-ts
           #    ref: electron-forge-config # TODO : Merge to master and remove
@@ -213,7 +213,7 @@ jobs:
           npm run build
       # Build Krystal Bull
       - name: Download bitcoin-s-oracle-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bitcoin-s-oracle-server-${{ matrix.TARGET }}
           path: bitcoin-s-ts/oracle-electron-ts/bitcoin-s-oracle-server
@@ -319,14 +319,14 @@ jobs:
       # Capture signed Mac app
       # - name: (macos) Upload krystalbull-mac-zip
       #   if: startsWith(matrix.os,'macos')
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   env:
       #     pkg-version: ${{steps.previoustag.outputs.tag}}
       #   with:
       #     name: krystalbull-${{ matrix.TARGET }}-zip
       #     path: ${{env.KB_MAKE}}/zip/darwin/x64/*.zip
       - name: Upload krystalbull-${{ matrix.TARGET }}-${{ matrix.FORMAT }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
@@ -334,7 +334,7 @@ jobs:
           path: ${{env.KB_MAKE}}/*.${{ matrix.FORMAT }}
       - name: (release) Upload krystallbull-${{ matrix.TARGET }}-${{ matrix.FORMAT }}
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: krystalbull-${{ matrix.TARGET }}-${{ matrix.FORMAT }}-${{steps.previoustag.outputs.tag}}
           files: ${{env.KB_MAKE}}/*.${{ matrix.FORMAT }}
@@ -343,7 +343,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Build Suredbits Wallet
       - name: Download bitcoin-s-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: bitcoin-s-server-${{ matrix.TARGET }}
           path: bitcoin-s-ts/wallet-electron-ts/bitcoin-s-server
@@ -414,14 +414,14 @@ jobs:
       # Capture signed Mac app
       # - name: (macos) Upload suredbits-wallet-mac-zip
       #   if: startsWith(matrix.os,'macos')
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v7
       #   env:
       #     pkg-version: ${{steps.previoustag.outputs.tag}}
       #   with:
       #     name: suredbits-wallet-${{ matrix.TARGET }}-zip
       #     path: ${{env.W_MAKE}}/zip/darwin/x64/*.zip
       - name: Upload suredbits-wallet-${{ matrix.TARGET }}-${{ matrix.FORMAT }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           pkg-version: ${{steps.previoustag.outputs.tag}}
         with:
@@ -429,7 +429,7 @@ jobs:
           path: ${{env.W_MAKE}}/*.${{ matrix.FORMAT }}
       - name: (release) Upload suredbits-wallet-${{ matrix.TARGET }}-${{ matrix.FORMAT }}
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: suredbits-wallet-${{ matrix.TARGET }}-${{ matrix.FORMAT }}-${{steps.previoustag.outputs.tag}}
           files: ${{env.W_MAKE}}/*.${{ matrix.FORMAT }}


### PR DESCRIPTION
## Summary

Bumps pinned GitHub Actions versions across all workflows to their latest major releases, and fixes an unpinned `@master` reference to a mutable branch (supply-chain risk).

| Action | Before | After | Latest release |
|---|---|---|---|
| `actions/checkout` | v2 / v2.3.4 / v3 | v7 | [v7.0.1](https://github.com/actions/checkout/releases/tag/v7.0.1) |
| `actions/setup-java` | v3 | v5 | [v5.6.0](https://github.com/actions/setup-java/releases/tag/v5.6.0) |
| `actions/cache` | v3 | v6 | [v6.1.0](https://github.com/actions/cache/releases/tag/v6.1.0) |
| `actions/setup-node` | v3 | v7 | [v7.0.0](https://github.com/actions/setup-node/releases/tag/v7.0.0) |
| `actions/upload-artifact` | v4 / `@master` (unpinned) | v7 | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) |
| `actions/download-artifact` | v4 | v8 | [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1) |
| `docker/login-action` | v1 | v4 | [v4.5.0](https://github.com/docker/login-action/releases/tag/v4.5.0) |
| `apple-actions/import-codesign-certs` | v3 | v7 | [v7.0.0](https://github.com/apple-actions/import-codesign-certs/releases/tag/v7.0.0) |
| `softprops/action-gh-release` | v1 | v3 | [v3.0.2](https://github.com/softprops/action-gh-release/releases/tag/v3.0.2) |
| `olafurpg/setup-scala` | v13 | v14 | [v14](https://github.com/olafurpg/setup-scala/releases/tag/v14) |

Left unchanged — already at the newest version published for that action:
- [`sbt/setup-sbt@v1`](https://github.com/sbt/setup-sbt/releases) (rolling `v1` tag, latest patch v1.5.2)
- [`olafurpg/setup-gpg@v3`](https://github.com/olafurpg/setup-gpg/releases/tag/v3) (repo archived, v3 is final)
- [`actions/upload-release-asset@v1.0.2`](https://github.com/actions/upload-release-asset/releases/tag/v1.0.2) (repo archived, v1.0.2 is final)

Notably, `native.yml` was pinning `actions/upload-artifact` to the mutable `@master` branch instead of a release tag — now pinned to `v7` like the rest of the workflows.

Checked each bumped action's `with:` config against its current usage for breaking changes (e.g. `upload-artifact`/`download-artifact` already handled the v3→v4 unique-artifact-name requirement in a prior bump, so v4→v7/v8 here doesn't hit that). All workflow YAML validated with a parser after editing.

## Test plan
- [ ] CI runs green on this PR across all workflows (Linux/Mac/Windows test suites, Compile, native image build, docker-publish)