### PR TITLE
Fix docs/publishWebsite: pin docusaurusVersion to V1

### DIFF
--- a/bitcoin-s-docs/docs.sbt
+++ b/bitcoin-s-docs/docs.sbt
@@ -1,5 +1,11 @@
 lazy val publishWebsite = taskKey[Unit]("Publish website")
 
+// website/ is still classic Docusaurus v1 (see website/package.json),
+// but sbt-mdoc 2.9.1 changed DocusaurusPlugin's default to V3, which
+// runs `yarn deploy` instead of `yarn publish-gh-pages` and breaks
+// docusaurusPublishGhpages. Pin back to V1 until the site is migrated.
+docusaurusVersion := DocusaurusVersion.V1
+
 publishWebsite := Def
   .sequential(
     Compile / unidoc,


### PR DESCRIPTION
## Summary

Every `Release` workflow run since PR #6409 merged (2026-07-21) has been failing on the `sbt ci-release docs/publishWebsite` step with:

```
error Command "deploy" not found.
[error] java.lang.AssertionError: assertion failed: command returned 1: [.../install_ssh.sh]
```

Example: https://github.com/bitcoin-s/bitcoin-s/actions/runs/29970353624/job/89090860160#step:6:1535

### Root cause

`docusaurusPublishGhpages` (from `mdoc`'s `DocusaurusPlugin`) shells out to `yarn <cmd>` in `website/`, where `<cmd>` depends on the `docusaurusVersion` setting:
- `V1` → `yarn publish-gh-pages`
- `V3` → `yarn deploy`

`website/package.json` is still classic Docusaurus 1.x (`"docusaurus": "^1.14.4"`) and only defines a `publish-gh-pages` script — there is no `deploy` script.

#6409 bumped `sbt-mdoc` from `2.9.0` → `2.9.1`. That release added Docusaurus v3 support to `DocusaurusPlugin` and **changed its default `docusaurusVersion` to `V3`** (previously the plugin only supported v1 and hardcoded `yarn publish-gh-pages`, no setting existed). Since nothing in this build overrode `docusaurusVersion`, every publish since that bump has silently picked up the new `V3` default and tried to run a script that doesn't exist.

I confirmed via `sbt --client "docs/docusaurusVersion"` that it resolved to `V3` before this change and `V1` after.

### Fix

Pin `docusaurusVersion := DocusaurusVersion.V1` in `bitcoin-s-docs/docs.sbt` until the website is actually migrated to Docusaurus v3 (at which point this setting should be removed/flipped along with adding a real `deploy` script and Docusaurus v3 config).

## Test plan
- [x] `sbt docs/Compile/compile` succeeds
- [x] `sbt --client "docs/docusaurusVersion"` resolves to `V1` after a reload
- [ ] `Release` workflow's `publish` job succeeds on this branch/after merge