### PR TITLE
Fix stale CI dependency cache keys

### DIFF
--- a/.github/workflows/Compile.yml
+++ b/.github/workflows/Compile.yml
@@ -33,6 +33,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-compile-cache
+          key: ${{ runner.os }}-compile-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-compile-cache-
       - name: Compile and Check Formatting
         run: sbt +test:compile scalafmtCheckAll cryptoTestJVM/test coreTestJVM/test appServer/universal:packageBin oracleServer/universal:packageBin cli/universal:packageBin docs/mdoc

--- a/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
+++ b/.github/workflows/Linux_2.13_App_Chain_Core_Tests.yml
@@ -32,6 +32,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-app-chain-core-tests-cache
+          key: ${{ runner.os }}-app-chain-core-tests-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-app-chain-core-tests-cache-
       - name: run tests
         run: sbt coverage dbCommonsTest/test chainTest/test chain/coverageReport chain/coverageAggregate chain/coveralls cryptoTestJVM/test cryptoJVM/test cryptoJVM/coverageReport cryptoJVM/coverageAggregate cryptoJVM/coveralls coreTestJVM/test coreJVM/coverageReport coreJVM/coverageAggregate coreJVM/coveralls secp256k1jni/test zmq/test zmq/coverageReport zmq/coverageAggregate zmq/coveralls appCommonsTest/test appServerTest/test oracleServerTest/test serverGrpcTest/test cliGrpcTest/test

--- a/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
+++ b/.github/workflows/Linux_2.13_KeyManager_Wallet_DLC_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-keymanager-wallet-dlc-test-cache
+          key: ${{ runner.os }}-keymanager-wallet-dlc-test-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-keymanager-wallet-dlc-test-cache-
       - name: run tests
         run: sbt coverage keyManagerTest/test keyManager/coverageReport keyManager/coverageAggregate keyManager/coveralls feeProviderTest/test walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls dlcOracleTest/test asyncUtilsTestJVM/test dlcOracle/coverageReport dlcOracle/coverageAggregate dlcOracle/coveralls

--- a/.github/workflows/Linux_2.13_Node_Tests.yml
+++ b/.github/workflows/Linux_2.13_Node_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-node-test-cache
+          key: ${{ runner.os }}-node-test-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-node-test-cache-
       - name: run tests
         run: sbt cryptoTestJS/test coreJS/test 'set scalaJSStage in Global := FullOptStage' cryptoTestJS/test coreJS/test asyncUtilsTestJS/test coverage nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcNodeTest/test

--- a/.github/workflows/Linux_2.13_RPC_Tests.yml
+++ b/.github/workflows/Linux_2.13_RPC_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-rpc-tests-cache
+          key: ${{ runner.os }}-rpc-tests-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-rpc-tests-cache-
       - name: run tests
         run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls lndRpcTest/test clightningRpcTest/test esploraTest/test

--- a/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
+++ b/.github/workflows/Mac_2.13_Crypto_Core_AppServer_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-wallet-node-dlc-test-cache
+          key: ${{ runner.os }}-wallet-node-dlc-test-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-wallet-node-dlc-test-cache-
       - name: run tests
         run: sbt coverage cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test chainTest/test dlcNodeTest/test appServerTest/test serverGrpcTest/test cliGrpcTest/test

--- a/.github/workflows/Mac_2.13_RPC_Tests.yml
+++ b/.github/workflows/Mac_2.13_RPC_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-rpc-tests-cache
+          key: ${{ runner.os }}-rpc-tests-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-rpc-tests-cache-
       - name: run tests
         run: sbt coverage bitcoindRpcTest/test bitcoindRpc/coverageReport bitcoindRpc/coverageAggregate bitcoindRpc/coveralls lndRpcTest/test eclairRpcTest/test eclairRpc/coverageReport eclairRpc/coverageAggregate eclairRpc/coveralls esploraTest/test

--- a/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
+++ b/.github/workflows/Mac_2.13_Wallet_Node_DLC_Tests.yml
@@ -30,6 +30,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-wallet-node-dlc-test-cache
+          key: ${{ runner.os }}-wallet-node-dlc-test-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-wallet-node-dlc-test-cache-
       - name: run tests
         run: sbt coverage walletTest/test dlcWalletTest/test wallet/coverageReport wallet/coverageAggregate wallet/coveralls nodeTest/test node/coverageReport node/coverageAggregate node/coveralls dlcOracleTest/test dlcOracle/coverageReport dlcOracle/coveralls

--- a/.github/workflows/PostgresTests.yml
+++ b/.github/workflows/PostgresTests.yml
@@ -34,6 +34,8 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-postgres-cache
+          key: ${{ runner.os }}-postgres-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-postgres-cache-
       - name: run tests
         run: sbt dbCommonsTest/test walletTest/test dlcWalletTest/test chainTest/test dlcOracleTest/test nodeTest/test

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -35,7 +35,9 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.bitcoin-s/binaries
-          key: ${{ runner.os }}-cache
+          key: ${{ runner.os }}-cache-${{ hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-cache-
       - name: Windows Crypto, Core, and Database tests
         run: sbt cryptoTestJVM/test coreTestJVM/test secp256k1jni/test zmq/test appCommonsTest/test asyncUtilsTestJVM/test asyncUtilsTestJS/test appServerTest/test serverGrpcTest/test cliGrpcTest/test
         shell: bash


### PR DESCRIPTION
## Summary
- Every `actions/cache` step across the sbt CI workflows used a static key (e.g. `${{ runner.os }}-compile-cache`) that never changes, so once populated the cache is frozen forever and never re-saved as dependencies change/get added.
- Key off `hashFiles('**/*.sbt', 'project/**.scala', 'project/build.properties')` — including `project/*.scala` since that's where `Deps.scala` (actual dependency versions) lives — with a `restore-keys` fallback so a miss still gets a partial hit instead of a cold cache.

## Test plan
- [ ] Workflow YAML parses correctly (validated locally with `yaml.safe_load`)
- [ ] CI runs green on this PR
- [ ] Confirm a subsequent cache save actually occurs (new cache entry appears under Actions → Caches) once the hash changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)