### PR TITLE
crypto: fix 8 lax/unsafe parsing findings in the crypto module

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinSUtilTest.scala
@@ -12,8 +12,8 @@ class BitcoinSUtilTest extends BitcoinSUnitTest {
 
     BytesUtil.isHex("") must be(false)
 
-    // don't allow upper case hex chars
-    BytesUtil.isHex("ABCDEF0123456789") must be(false)
+    // isHex must agree with decodeHex, which accepts uppercase hex too
+    BytesUtil.isHex("ABCDEF0123456789") must be(true)
 
     BytesUtil.isHex("g") must be(false)
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/CryptoUtilTest.scala
@@ -266,4 +266,17 @@ class CryptoUtilTest extends BitcoinSCryptoTest {
     hash.hex must be(expected)
     hash.flip.flip.hex must be(expected)
   }
+
+  it must "treat uppercase hex consistently between isHex and decodeHex" in {
+    // isHex previously used a lowercase-only regex (^[0-9a-f]+$) while
+    // decodeHex (backed by scodec's fromValidHex) happily accepts
+    // uppercase hex, so the two disagreed on what counts as valid hex.
+    val upper = "DEADBEEF"
+    val lower = "deadbeef"
+
+    // decodeHex accepts uppercase; isHex must agree
+    CryptoBytesUtil.decodeHex(upper) must be(ByteVector.fromValidHex(lower))
+    CryptoBytesUtil.isHex(lower) must be(true)
+    CryptoBytesUtil.isHex(upper) must be(true)
+  }
 }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/DERSignatureUtilTest.scala
@@ -187,4 +187,29 @@ class DERSignatureUtilTest extends BitcoinSCryptoTest {
       }
     }
   }
+
+  it must "parse long-form length bytes the same way Bitcoin Core's lax DER parser does" in {
+    // parseDERLax previously mis-parsed long-form length bytes via signed
+    // Byte arithmetic: `lengthByte - 0x80` on a signed Byte yields a
+    // negative count (0x81 -> -255) instead of Core's `lenbyte & 0x7f`
+    // (0x81 -> 1).
+    val rHex =
+      "4c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec016"
+    val sHex =
+      "356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c"
+    val expectedR: BigInt = BigInt(rHex, 16)
+    val expectedS: BigInt = BigInt(sHex, 16)
+
+    // long-form total length byte 0x81, length stored in the next byte (0x44)
+    val longTotalLengthSig =
+      ByteVector.fromValidHex("308144" + "0220" + rHex + "0220" + sHex)
+    DERSignatureUtil.parseDERLax(longTotalLengthSig) must be(
+      Some((expectedR, expectedS)))
+
+    // long-form r integer length byte 0x81, length stored in the next byte (0x20)
+    val longRLengthSig = ByteVector.fromValidHex(
+      "3045" + "02" + "81" + "20" + rHex + "0220" + sHex)
+    DERSignatureUtil.parseDERLax(longRLengthSig) must be(
+      Some((expectedR, expectedS)))
+  }
 }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
@@ -128,6 +128,23 @@ class ECDigitalSignatureTest extends BitcoinSCryptoTest {
     }
   }
 
+  it must "fail cleanly with an IllegalArgumentException when the sighash byte is absent" in {
+    // fromFrontOfBytesWithSigHash previously threw NoSuchElementException
+    // (from `.head` on an empty ByteVector) when the input had no sighash
+    // byte after the DER signature. Correct behavior: a clean, documented
+    // failure such as IllegalArgumentException.
+    val rHex =
+      "4c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec016"
+    val sHex =
+      "356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c"
+    val strictDerNoSigHash: ByteVector =
+      ByteVector.fromValidHex("3044" + "0220" + rHex + "0220" + sHex)
+
+    intercept[IllegalArgumentException] {
+      ECDigitalSignature.fromFrontOfBytesWithSigHash(strictDerNoSigHash)
+    }
+  }
+
   it must "not view an incorrectly encoded sig_hash byte as strictly encoded" in {
     forAll(CryptoGenerators.digitalSignature, CryptoGenerators.hashType) {
       case (sig, hashType) =>

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/ECDigitalSignatureTest.scala
@@ -49,6 +49,36 @@ class ECDigitalSignatureTest extends BitcoinSCryptoTest {
     hex must be(emptySignature)
   }
 
+  it must "not treat garbage bytes that silently decode to r=s=0 as a valid low-S or hash-typed signature" in {
+    // ECDigitalSignature.fromBytes/apply itself must stay lenient and NOT
+    // throw: it is called directly on untrusted, attacker-controlled
+    // scriptSig bytes in consensus-critical script execution (e.g.
+    // CryptoInterpreter.opCheckSig/opCheckMultiSig) with no Try wrapper, so
+    // a malformed signature must fail verification cleanly rather than
+    // crash script validation with an uncaught exception. Instead, the
+    // derived accessors that previously silently treated an undecodable
+    // signature as if it validly decoded to r=s=0 (isLowS, hashTypeOpt)
+    // must correctly report that the bytes are not a valid DER signature.
+    val garbageShort = ByteVector.fromValidHex("deadbeef")
+    val garbageLong = ByteVector.fromValidHex(
+      "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+
+    // must not throw -- garbage bytes are still representable so callers
+    // like the script interpreter can cleanly fail signature checks
+    val sigShort = ECDigitalSignature.fromBytes(garbageShort)
+    val sigLong = ECDigitalSignature.fromBytes(garbageLong)
+
+    // r=s=0 is trivially "low S", but undecodable garbage must not be
+    // reported as having a low (i.e. validly encoded) S value
+    DERSignatureUtil.isLowS(sigShort) must be(false)
+    DERSignatureUtil.isLowS(sigLong) must be(false)
+
+    // there's no reliable way to locate a trailing hash type byte without a
+    // validly decoded signature
+    sigShort.hashTypeOpt must be(None)
+    sigLong.hashTypeOpt must be(None)
+  }
+
   it must "must be der encoded" in {
     forAll(CryptoGenerators.digitalSignature) { signature =>
       assert(signature.isDEREncoded)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/HashDigestTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/HashDigestTest.scala
@@ -43,4 +43,33 @@ class HashDigestTest extends BitcoinSCryptoTest {
     }
   }
 
+  behavior of "Sha1Digest"
+
+  it must "reject wrong-length inputs for Sha1Digest and Sha1DigestBE" in {
+    // Sha1Digest.fromBytes and Sha1DigestBE.fromBytes previously had no
+    // length checks, unlike every other hash digest type in the same file
+    // (Sha256Digest, RipeMd160Digest, Sha256Hash160Digest, Sha3_256Digest
+    // all validate their expected length).
+    val nineteenBytes = ByteVector(Array.fill(19)(1.toByte))
+    val twentyBytes = ByteVector(Array.fill(20)(1.toByte))
+    val twentyOneBytes = ByteVector(Array.fill(21)(1.toByte))
+
+    // positive control: exactly 20 bytes must keep working
+    Sha1Digest.fromBytes(twentyBytes).bytes must be(twentyBytes)
+    Sha1DigestBE.fromBytes(twentyBytes).bytes must be(twentyBytes)
+
+    intercept[IllegalArgumentException] {
+      Sha1Digest.fromBytes(nineteenBytes)
+    }
+    intercept[IllegalArgumentException] {
+      Sha1Digest.fromBytes(twentyOneBytes)
+    }
+    intercept[IllegalArgumentException] {
+      Sha1DigestBE.fromBytes(nineteenBytes)
+    }
+    intercept[IllegalArgumentException] {
+      Sha1DigestBE.fromBytes(twentyOneBytes)
+    }
+  }
+
 }

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/HashTypeTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/HashTypeTest.scala
@@ -89,6 +89,30 @@ class HashTypeTest extends BitcoinSCryptoTest {
     HashType(105512910).isInstanceOf[SIGHASH_ANYONECANPAY] must be(true)
   }
 
+  it must "not count 0x00 as a defined ECDSA hashtype" in {
+    // isDefinedHashtypeSignature previously counted 0x00 as a defined ECDSA
+    // hashtype because hashTypeBytes included sigHashDefaultByte. Bitcoin
+    // Core's CheckSignatureEncoding rejects 0x00 for ECDSA signatures --
+    // SIGHASH_DEFAULT is only a defined hashtype for taproot/schnorr
+    // signatures.
+    val rHex =
+      "4c2dd8a9b6f8d425fcd8ee9a20ac73b619906a6367eac6cb93e70375225ec016"
+    val sHex =
+      "356878eff111ff3663d7e6bf08947f94443845e0dcc54961664d922f7660b80c"
+    val strictDerNoSigHash: ByteVector =
+      ByteVector.fromValidHex("3044" + "0220" + rHex + "0220" + sHex)
+
+    // same strict DER signature, once with 0x01 (SIGHASH_ALL) and once with
+    // 0x00 appended as the sighash byte
+    val sigWithAllHashType =
+      ECDigitalSignature.fromBytes(strictDerNoSigHash.:+(0x01.toByte))
+    val sigWithZeroHashType =
+      ECDigitalSignature.fromBytes(strictDerNoSigHash.:+(0x00.toByte))
+
+    HashType.isDefinedHashtypeSignature(sigWithAllHashType) must be(true)
+    HashType.isDefinedHashtypeSignature(sigWithZeroHashType) must be(false)
+  }
+
   it must "have serialization symmetry" in {
     forAll(NumberGenerator.ints.map(ByteVector.fromInt(_))) { i32 =>
       val hashType = HashType.fromBytes(i32)

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrDigitalSignatureTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrDigitalSignatureTest.scala
@@ -13,6 +13,22 @@ class SchnorrDigitalSignatureTest extends BitcoinSCryptoTest {
     }
   }
 
+  it must "reject a 65 byte signature with a trailing 0x00 sighash byte" in {
+    // fromBytes previously accepted a 65-byte signature whose sighash byte
+    // is 0x00, violating BIP340/341 which require sig[64] != 0x00 for
+    // 65-byte signatures (0x00/SIGHASH_DEFAULT must be represented by a
+    // plain 64-byte signature instead).
+
+    // positive control: a plain 64 byte signature must keep working
+    val sig64 = SchnorrDigitalSignature.dummy.bytes
+    SchnorrDigitalSignature.fromBytes(sig64).bytes must be(sig64)
+
+    val sig65WithZeroHashType = sig64.:+(0x00.toByte)
+    intercept[IllegalArgumentException] {
+      SchnorrDigitalSignature.fromBytes(sig65WithZeroHashType)
+    }
+  }
+
   it must "must create and verify a digital signature" in {
     forAll(NumberGenerator.bytevector(32), CryptoGenerators.privateKey) {
       case (bytes, privKey) =>

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrNonceTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrNonceTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.crypto
 
+import scodec.bits.ByteVector
+
 class SchnorrNonceTest extends BitcoinSCryptoTest {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
@@ -18,6 +20,21 @@ class SchnorrNonceTest extends BitcoinSCryptoTest {
       SchnorrNonce(
         "676f8c22de526e0c0904719847e63bda47b4eceb6986bdbaf8695db362811a010203"
       )
+    )
+
+    // fromBytes previously silently left-padded inputs shorter than 32 bytes
+    // instead of rejecting them -- a 1-byte input like "01" left-padded with
+    // zeros becomes the valid but extremely low-entropy x coordinate x=1
+    assertThrows[IllegalArgumentException](
+      SchnorrNonce.fromBytes(ByteVector.fromValidHex("01"))
+    )
+
+    // fromBytes previously silently dropped the first byte of 33-byte
+    // inputs instead of rejecting them
+    val validXOnlyHex =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    assertThrows[IllegalArgumentException](
+      SchnorrNonce.fromBytes(ByteVector.fromValidHex("02" + validXOnlyHex))
     )
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrPublicKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/SchnorrPublicKeyTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.crypto
 
+import scodec.bits.ByteVector
+
 class SchnorrPublicKeyTest extends BitcoinSCryptoTest {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
@@ -18,6 +20,21 @@ class SchnorrPublicKeyTest extends BitcoinSCryptoTest {
       SchnorrPublicKey(
         "676f8c22de526e0c0904719847e63bda47b4eceb6986bdbaf8695db362811a010203"
       )
+    )
+
+    // fromBytes previously silently left-padded inputs shorter than 32 bytes
+    // instead of rejecting them -- a 1-byte input like "01" left-padded with
+    // zeros becomes the valid but extremely low-entropy x coordinate x=1
+    assertThrows[IllegalArgumentException](
+      SchnorrPublicKey.fromBytes(ByteVector.fromValidHex("01"))
+    )
+
+    // fromBytes previously silently dropped the first byte of 33-byte
+    // inputs instead of rejecting them
+    val validXOnlyHex =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    assertThrows[IllegalArgumentException](
+      SchnorrPublicKey.fromBytes(ByteVector.fromValidHex("02" + validXOnlyHex))
     )
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/XOnlyPubKeyTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/XOnlyPubKeyTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.crypto
 
+import scodec.bits.ByteVector
+
 class XOnlyPubKeyTest extends BitcoinSCryptoTest {
   behavior of "XOnlyPubKey"
 
@@ -17,6 +19,21 @@ class XOnlyPubKeyTest extends BitcoinSCryptoTest {
       XOnlyPubKey(
         "676f8c22de526e0c0904719847e63bda47b4eceb6986bdbaf8695db362811a010203"
       )
+    )
+
+    // fromBytes previously silently left-padded inputs shorter than 32 bytes
+    // instead of rejecting them -- a 1-byte input like "01" left-padded with
+    // zeros becomes the valid but extremely low-entropy x coordinate x=1
+    assertThrows[IllegalArgumentException](
+      XOnlyPubKey.fromBytes(ByteVector.fromValidHex("01"))
+    )
+
+    // fromBytes previously silently dropped the first byte of 33-byte
+    // inputs instead of rejecting them
+    val validXOnlyHex =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    assertThrows[IllegalArgumentException](
+      XOnlyPubKey.fromBytes(ByteVector.fromValidHex("02" + validXOnlyHex))
     )
   }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/CryptoBytesUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/CryptoBytesUtil.scala
@@ -49,7 +49,8 @@ trait CryptoBytesUtil {
   /** Tests if a given string is a hexadecimal string. */
   def isHex(str: String): Boolean = {
     // check valid characters & hex strings have to have an even number of chars
-    str.matches("^[0-9a-f]+$") && (str.length % 2 == 0)
+    // matches decodeHex, which accepts both lowercase and uppercase hex
+    str.matches("^[0-9a-fA-F]+$") && (str.length % 2 == 0)
   }
 
   /** Converts a two character hex string to its byte representation. */

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -200,9 +200,15 @@ sealed abstract class DERSignatureUtil {
     *   if the S value is the low version
     */
   def isLowS(signature: ByteVector): Boolean = {
+    // use parseDERLax directly rather than decodeSignature, which silently
+    // falls back to r=s=0 (trivially "low") for bytes that aren't a valid
+    // DER signature at all
     val result = Try {
-      val (_, s) = decodeSignature(signature)
-      s.bigInteger.compareTo(CryptoParams.halfCurveOrder) <= 0
+      DERSignatureUtil.parseDERLax(signature) match {
+        case Some((_, s)) =>
+          s.bigInteger.compareTo(CryptoParams.halfCurveOrder) <= 0
+        case None => false
+      }
     }
     result match {
       case Success(bool) => bool

--- a/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/DERSignatureUtil.scala
@@ -275,7 +275,10 @@ sealed abstract class DERSignatureUtil {
         lengthByteUnProcessed <- nextOption()
         length <- {
           if ((lengthByteUnProcessed & 0x80) != 0) {
-            var lenByte = lengthByteUnProcessed - 0x80
+            // treat the byte as unsigned before subtracting, mirroring
+            // Bitcoin Core's `lenbyte & 0x7f` (pubkey.cpp) -- as a signed
+            // Scala Byte, 0x81 - 0x80 wrongly yields -255 instead of 1
+            var lenByte = (lengthByteUnProcessed & 0xff) - 0x80
 
             while (
               lenByte > 0 && iterator.hasNext && iterator.head == 0.toByte
@@ -315,7 +318,8 @@ sealed abstract class DERSignatureUtil {
       totalLengthByteUnProcessed <- nextOption()
       _ <- {
         if ((totalLengthByteUnProcessed & 0x80) != 0) {
-          val processedTotalLengthByte = totalLengthByteUnProcessed - 0x80
+          val processedTotalLengthByte =
+            (totalLengthByteUnProcessed & 0xff) - 0x80
           moveIterForward(processedTotalLengthByte)
         } else {
           Some(())

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -38,6 +38,12 @@ case class ECDigitalSignature(bytes: ByteVector) extends DigitalSignature {
   lazy val decodeSignature: (BigInt, BigInt) =
     CryptoUtil.decodeSignature(this)
 
+  /** Same as [[decodeSignature]], but returns None rather than a fallback r=s=0
+    * pair when [[bytes]] is not a lax-DER decodable signature.
+    */
+  lazy val decodeSignatureOpt: Option[(BigInt, BigInt)] =
+    DERSignatureUtil.parseDERLax(bytes)
+
   /** Represents the r value found in a elliptic curve digital signature */
   def r: BigInt = {
     decodeSignature._1
@@ -75,12 +81,21 @@ case class ECDigitalSignature(bytes: ByteVector) extends DigitalSignature {
   }
 
   def hashTypeOpt: Option[HashType] = {
-    val trailingBytes = bytes.drop(ECDigitalSignature.fromRS(r, s).bytes.length)
+    decodeSignatureOpt match {
+      case Some((decodedR, decodedS)) =>
+        val trailingBytes =
+          bytes.drop(ECDigitalSignature.fromRS(decodedR, decodedS).bytes.length)
 
-    if (trailingBytes.nonEmpty && trailingBytes.length <= 4) {
-      Some(HashType.fromBytes(trailingBytes))
-    } else {
-      None
+        if (trailingBytes.nonEmpty && trailingBytes.length <= 4) {
+          Some(HashType.fromBytes(trailingBytes))
+        } else {
+          None
+        }
+      case None =>
+        // bytes isn't a lax-DER decodable signature, so there's no reliable
+        // way to know where the signature ends and a trailing hash type
+        // byte would begin
+        None
     }
   }
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECDigitalSignature.scala
@@ -181,8 +181,12 @@ object ECDigitalSignature extends Factory[ECDigitalSignature] {
     */
   def fromFrontOfBytesWithSigHash(bytes: ByteVector): ECDigitalSignature = {
     val sigWithoutSigHash = fromFrontOfBytes(bytes)
-    ECDigitalSignature(
-      sigWithoutSigHash.bytes :+ bytes.drop(sigWithoutSigHash.byteSize).head)
+    val remainingBytes = bytes.drop(sigWithoutSigHash.byteSize)
+    require(
+      remainingBytes.nonEmpty,
+      s"No sighash byte found after the DER signature in $bytes"
+    )
+    ECDigitalSignature(sigWithoutSigHash.bytes :+ remainingBytes.head)
   }
 
   def apply(r: BigInt, s: BigInt): ECDigitalSignature = fromRS(r, s)

--- a/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/ECKey.scala
@@ -124,7 +124,7 @@ case class ECPublicKeyBytes(bytes: ByteVector)
   /** Parse these bytes into the bitcoin-s internal public key type. */
   def toPublicKey: ECPublicKey = ECPublicKey(bytes)
 
-  def toSchnorrPubKey: SchnorrPublicKey = SchnorrPublicKey.fromBytes(bytes)
+  def toSchnorrPubKey: SchnorrPublicKey = toPublicKey.schnorrPublicKey
 
   override private[crypto] def fromBytes(bytes: ByteVector): this.type =
     ECPublicKeyBytes(bytes).asInstanceOf[this.type]
@@ -243,7 +243,7 @@ case class ECPrivateKey(bytes: ByteVector)
   def toXOnly: XOnlyPubKey = schnorrPublicKey.toXOnly
 
   def schnorrNonce: SchnorrNonce = {
-    SchnorrNonce(publicKey.bytes)
+    publicKey.schnorrNonce
   }
 
   def fieldElement: FieldElement = FieldElement(bytes)
@@ -334,9 +334,10 @@ case class ECPublicKey(bytes: ByteVector)
     schnorrPublicKey.computeSigPoint(data, nonce)
   }
 
-  def schnorrPublicKey: SchnorrPublicKey = SchnorrPublicKey(bytes)
+  def schnorrPublicKey: SchnorrPublicKey = SchnorrPublicKey(
+    compressedBytes.tail)
 
-  def schnorrNonce: SchnorrNonce = SchnorrNonce(bytes)
+  def schnorrNonce: SchnorrNonce = SchnorrNonce(compressedBytes.tail)
 
   def adaptorVerify(
       msg: ByteVector,
@@ -422,7 +423,7 @@ case class ECPublicKey(bytes: ByteVector)
     CryptoUtil.tweakMultiply(this, tweak)
   }
 
-  def toXOnly: XOnlyPubKey = XOnlyPubKey(bytes.drop(1))
+  def toXOnly: XOnlyPubKey = XOnlyPubKey(compressedBytes.tail)
 
   def parity: KeyParity = KeyParity.fromByte(bytes.head)
 

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashDigest.scala
@@ -30,7 +30,12 @@ object Sha1Digest extends Factory[Sha1Digest] {
     override def toString = s"Sha1DigestImpl($hex)"
     // $COVERAGE-ON$
   }
-  override def fromBytes(bytes: ByteVector): Sha1Digest = Sha1DigestImpl(bytes)
+  override def fromBytes(bytes: ByteVector): Sha1Digest = {
+    require(bytes.length == 20,
+            // $COVERAGE-OFF$
+            "Sha1Digest must always be 20 bytes, got: " + bytes.length)
+    Sha1DigestImpl(bytes)
+  }
 }
 
 sealed trait Sha1DigestBE extends Any with HashDigest {
@@ -48,6 +53,9 @@ object Sha1DigestBE extends Factory[Sha1DigestBE] {
   }
 
   override def fromBytes(bytes: ByteVector): Sha1DigestBE = {
+    require(bytes.length == 20,
+            // $COVERAGE-OFF$
+            "Sha1DigestBE must always be 20 bytes, got: " + bytes.length)
     Sha1DigestBEImpl(bytes)
   }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
@@ -198,7 +198,11 @@ object HashType extends Factory[HashType] {
     * https://github.com/bitcoin/bitcoin/blob/b83264d9c7a8ddb79f64bd9540caddc8632ef31f/src/script/interpreter.cpp#L186
     */
   def isDefinedHashtypeSignature(sig: ECDigitalSignature): Boolean = {
-    sig.bytes.nonEmpty && hashTypeBytes.contains(sig.bytes.last)
+    // SIGHASH_DEFAULT (0x00) is only a defined hashtype for taproot
+    // signatures; Bitcoin Core's CheckSignatureEncoding rejects 0x00 as an
+    // ECDSA hashtype byte
+    sig.bytes.nonEmpty && sig.bytes.last != sigHashDefaultByte &&
+    hashTypeBytes.contains(sig.bytes.last)
   }
 
   //    (hash_type <= 0x03 || (hash_type >= 0x81 && hash_type <= 0x83))

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrDigitalSignature.scala
@@ -34,6 +34,10 @@ object SchnorrDigitalSignature extends Factory[SchnorrDigitalSignature] {
   override def fromBytes(bytes: ByteVector): SchnorrDigitalSignature = {
     require(bytes.length == 64 || bytes.length == 65,
             s"SchnorrDigitalSignature must be exactly 64 bytes, got $bytes")
+    require(
+      bytes.length != 65 || bytes(64) != 0x00.toByte,
+      s"A 65 byte SchnorrDigitalSignature must not have an explicit 0x00 (SIGHASH_DEFAULT) trailing byte, got $bytes"
+    )
     val r = bytes.take(32)
     val s = bytes.drop(32).take(32)
     val hashTypeOpt = if (bytes.length == 65) Some(bytes(64)) else None

--- a/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/SchnorrPublicKey.scala
@@ -2,7 +2,6 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
 import scala.util.Try
 
 case class SchnorrPublicKey(bytes: ByteVector) extends PublicKey {
@@ -75,23 +74,12 @@ case class SchnorrPublicKey(bytes: ByteVector) extends PublicKey {
 
 object SchnorrPublicKey extends Factory[SchnorrPublicKey] {
 
-  @tailrec
   def fromBytes(bytes: ByteVector): SchnorrPublicKey = {
-    require(bytes.length <= 33,
-            s"XOnlyPublicKey must be less than 33 bytes, got $bytes")
-    if (bytes.length == 32)
-      new SchnorrPublicKey(bytes)
-    else if (bytes.length < 32) {
-      // means we need to pad the private key with 0 bytes so we have 32 bytes
-      SchnorrPublicKey.fromBytes(bytes.padLeft(32))
-    } else if (bytes.length == 33) {
-      // this is for the case when java serialies a BigInteger to 33 bytes to hold the signed num representation
-      SchnorrPublicKey.fromBytes(bytes.tail)
-    } else {
-      throw new IllegalArgumentException(
-        "XOnlyPublicKey cannot be greater than 33 bytes in size, got: " +
-          CryptoBytesUtil.encodeHex(bytes) + " which is of size: " + bytes.size)
-    }
+    require(
+      bytes.length == 32,
+      "SchnorrPublicKey must be exactly 32 bytes, got: " +
+        CryptoBytesUtil.encodeHex(bytes) + " which is of size: " + bytes.size)
+    new SchnorrPublicKey(bytes)
   }
 
   def apply(xCoor: CurveCoordinate): SchnorrPublicKey = {

--- a/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/XOnlyPubKey.scala
@@ -2,7 +2,6 @@ package org.bitcoins.crypto
 
 import scodec.bits.ByteVector
 
-import scala.annotation.tailrec
 import scala.util.Try
 
 /** Represents the x-coordinate of an ECPublicKey, with undetermined
@@ -102,24 +101,12 @@ case class XOnlyPubKey(bytes: ByteVector) extends PublicKey {
 
 object XOnlyPubKey extends Factory[XOnlyPubKey] {
 
-  @tailrec
   def fromBytes(bytes: ByteVector): XOnlyPubKey = {
-    require(bytes.length <= 33,
-            s"XOnlyPublicKey must be less than 33 bytes, got $bytes")
-
-    if (bytes.length == 32)
-      new XOnlyPubKey(bytes)
-    else if (bytes.length < 32) {
-      // means we need to pad the private key with 0 bytes so we have 32 bytes
-      XOnlyPubKey.fromBytes(bytes.padLeft(32))
-    } else if (bytes.length == 33) {
-      // this is for the case when java serialies a BigInteger to 33 bytes to hold the signed num representation
-      XOnlyPubKey.fromBytes(bytes.tail)
-    } else {
-      throw new IllegalArgumentException(
-        "XOnlyPublicKey cannot be greater than 33 bytes in size, got: " +
-          CryptoBytesUtil.encodeHex(bytes) + " which is of size: " + bytes.size)
-    }
+    require(
+      bytes.length == 32,
+      "XOnlyPubKey must be exactly 32 bytes, got: " +
+        CryptoBytesUtil.encodeHex(bytes) + " which is of size: " + bytes.size)
+    new XOnlyPubKey(bytes)
   }
 
   def apply(coord: CurveCoordinate): XOnlyPubKey = {

--- a/docs/core/adding-spks.md
+++ b/docs/core/adding-spks.md
@@ -712,7 +712,7 @@ We must also create a generator for our `ScriptSignature` type, even if we did n
     for {
       privKey <- CryptoGenerators.privateKey
       hash <- CryptoGenerators.doubleSha256Digest
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       signature = ECDigitalSignature.fromBytes(
         privKey.sign(hash).bytes ++ ByteVector.fromByte(hashType.byte))
       beforeTimeout <- NumberGenerator.bool
@@ -730,7 +730,7 @@ Lastly, we need to construct a generator that returns both a `ScriptPubKey` and 
     (ConditionalScriptSignature, P2PKWithTimeoutScriptPubKey, ECPrivateKey)] =
     for {
       (spk, privKeys) <- p2pkWithTimeoutScriptPubKey
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
     } yield {
       val emptyScriptSig = P2PKWithTimeoutScriptSignature(beforeTimeout = true,
                                                           ECDigitalSignature.empty)

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CreditingTxGen.scala
@@ -226,7 +226,7 @@ sealed abstract class CreditingTxGen {
 
   def p2shOutput: Gen[ScriptSignatureParams[InputInfo]] =
     nonP2SHOutput.flatMap { o =>
-      CryptoGenerators.hashType.map { hashType =>
+      CryptoGenerators.preTaprootHashType.map { hashType =>
         val oldOutput = o.output
         val redeemScript = o.output.scriptPubKey
         val p2sh = P2SHScriptPubKey(redeemScript)
@@ -268,7 +268,7 @@ sealed abstract class CreditingTxGen {
   def cltvOutput: Gen[ScriptSignatureParams[InputInfo]] =
     TransactionGenerators.spendableCLTVValues.flatMap { case (scriptNum, _) =>
       basicOutput.flatMap { o =>
-        CryptoGenerators.hashType.map { hashType =>
+        CryptoGenerators.preTaprootHashType.map { hashType =>
           val oldOutput = o.output
           val csvSPK = CLTVScriptPubKey(scriptNum, oldOutput.scriptPubKey)
           val updatedOutput = TransactionOutput(oldOutput.value, csvSPK)
@@ -307,7 +307,7 @@ sealed abstract class CreditingTxGen {
   def csvOutput: Gen[ScriptSignatureParams[InputInfo]] =
     TransactionGenerators.spendableCSVValues.flatMap { case (scriptNum, _) =>
       basicOutput.flatMap { o =>
-        CryptoGenerators.hashType.map { hashType =>
+        CryptoGenerators.preTaprootHashType.map { hashType =>
           val oldOutput = o.output
           val csvSPK = CSVScriptPubKey(scriptNum, oldOutput.scriptPubKey)
           val updatedOutput = TransactionOutput(oldOutput.value, csvSPK)
@@ -386,7 +386,7 @@ sealed abstract class CreditingTxGen {
       Gen.choose(0, outputs.size - 1).flatMap { (outputIndex: Int) =>
         ScriptGenerators.scriptPubKey.flatMap { case (spk, keys) =>
           WitnessGenerators.scriptWitness.flatMap { (wit: ScriptWitness) =>
-            CryptoGenerators.hashType.map { (hashType: HashType) =>
+            CryptoGenerators.preTaprootHashType.map { (hashType: HashType) =>
               val tc = TransactionConstants
               val signers: Vector[Sign] = keys.toVector
               val creditingTx =
@@ -478,7 +478,7 @@ sealed abstract class CreditingTxGen {
       scriptWitness: Option[ScriptWitness]
   ): Gen[ScriptSignatureParams[InputInfo]] =
     nonEmptyOutputs.flatMap { outputs =>
-      CryptoGenerators.hashType.flatMap { hashType =>
+      CryptoGenerators.preTaprootHashType.flatMap { hashType =>
         Gen.choose(0, outputs.size - 1).map { idx =>
           val old = outputs(idx)
           val updated = outputs.updated(idx, TransactionOutput(old.value, spk))

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -228,7 +228,7 @@ sealed abstract class CryptoGenerators {
   def digitalSignatureWithSigHash: Gen[ECDigitalSignature] = {
     for {
       sig <- digitalSignature
-      sigHash <- hashType
+      sigHash <- preTaprootHashType
     } yield {
       ECDigitalSignature(sig.bytes :+ sigHash.byte)
     }
@@ -253,7 +253,14 @@ sealed abstract class CryptoGenerators {
       sigNoHashType = privKey.schnorrSign(hash.bytes)
       hashType <- taprootHashType
     } yield {
-      sigNoHashType.appendHashType(hashType)
+      // BIP341 states that if we use default sighash we don't append the
+      // hash type byte (see Sign.schnorrSignWithHashType); a 65 byte
+      // signature with an explicit 0x00 trailing byte is invalid
+      if (hashType == HashType.sigHashDefault) {
+        sigNoHashType
+      } else {
+        sigNoHashType.appendHashType(hashType)
+      }
     }
   }
   def schnorrDigitalSignature: Gen[SchnorrDigitalSignature] = {
@@ -309,8 +316,15 @@ sealed abstract class CryptoGenerators {
       hash = CryptoUtil.sha256Hash160(pubKey.bytes)
     } yield hash
 
-  /** Generates a random [[HashType HashType]] */
-  def hashType: Gen[HashType] = Gen.oneOf(HashType.hashTypes)
+  /** Generates a random [[HashType HashType]] to append to a legacy/segwit v0
+    * ECDSA signature. Excludes SIGHASH_DEFAULT: that hashtype byte is only
+    * meaningful for taproot/schnorr signatures (see [[taprootHashType]]) and
+    * ECDigitalSignature.appendHashType always appends the byte verbatim, so
+    * including it here would generate ECDSA signatures with an explicit 0x00
+    * trailing byte that Bitcoin Core rejects as an undefined hashtype.
+    */
+  def preTaprootHashType: Gen[HashType] =
+    Gen.oneOf(HashType.hashTypes.filterNot(_ == HashType.sigHashDefault))
 
   def extVersion: Gen[ExtKeyVersion] = {
     Gen.oneOf(ExtKeyVersion.all)

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/ScriptGenerators.scala
@@ -48,7 +48,7 @@ sealed abstract class ScriptGenerators {
   def p2pkScriptSignature: Gen[P2PKScriptSignature] =
     for {
       sig <- CryptoGenerators.digitalSignature
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       digitalSignature = sig.appendHashType(hashType)
     } yield P2PKScriptSignature(digitalSignature)
 
@@ -56,7 +56,7 @@ sealed abstract class ScriptGenerators {
     for {
       privKey <- CryptoGenerators.privateKey
       hash <- CryptoGenerators.doubleSha256Digest
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       signature = privKey.sign(hash).appendHashType(hashType)
 
     } yield P2PKHScriptSignature(signature, privKey.publicKey)
@@ -65,7 +65,7 @@ sealed abstract class ScriptGenerators {
     for {
       privKey <- CryptoGenerators.privateKey
       hash <- CryptoGenerators.doubleSha256Digest
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       signature = privKey.sign(hash).appendHashType(hashType)
       beforeTimeout <- NumberGenerator.bool
     } yield P2PKWithTimeoutScriptSignature(beforeTimeout, signature)
@@ -74,7 +74,7 @@ sealed abstract class ScriptGenerators {
     val signatures: Gen[Seq[ECDigitalSignature]] = for {
       numKeys <- Gen.choose(1, Consensus.maxPublicKeysPerMultiSig)
       hash <- CryptoGenerators.doubleSha256Digest
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       privKeys <- CryptoGenerators.privateKeySeq(numKeys)
     } yield for {
       privKey <- privKeys
@@ -609,7 +609,7 @@ sealed abstract class ScriptGenerators {
       : Gen[(P2PKScriptSignature, P2PKScriptPubKey, ECPrivateKey)] =
     for {
       privateKey <- CryptoGenerators.privateKey
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       publicKey = privateKey.publicKey
       scriptPubKey = P2PKScriptPubKey(publicKey)
       (creditingTx, outputIndex) =
@@ -651,7 +651,7 @@ sealed abstract class ScriptGenerators {
       : Gen[(P2PKHScriptSignature, P2PKHScriptPubKey, ECPrivateKey)] = {
     for {
       privateKey <- CryptoGenerators.privateKey
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       publicKey = privateKey.publicKey
       scriptPubKey = P2PKHScriptPubKey(publicKey)
       (creditingTx, outputIndex) =
@@ -687,7 +687,7 @@ sealed abstract class ScriptGenerators {
   ] =
     for {
       (spk, privKeys) <- p2pkWithTimeoutScriptPubKey
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
     } yield {
       val privKey = privKeys.head
       val emptyScriptSig = EmptyScriptSignature
@@ -734,7 +734,7 @@ sealed abstract class ScriptGenerators {
       (privateKeysWithExtra, requiredSigs) <-
         CryptoGenerators.privateKeySeqWithRequiredSigs
       privateKeys = privateKeysWithExtra.take(requiredSigs)
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       publicKeys = privateKeys.map(_.publicKey)
       multiSigScriptPubKey =
         MultiSignatureScriptPubKey(requiredSigs, publicKeys)
@@ -872,7 +872,7 @@ sealed abstract class ScriptGenerators {
   ): Gen[(CLTVScriptSignature, CLTVScriptPubKey, Seq[ECPrivateKey])] =
     for {
       (scriptPubKey, privKeys) <- nonLocktimeRawScriptPubKey(defaultMaxDepth)
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       cltv = CLTVScriptPubKey(cltvLockTime, scriptPubKey)
     } yield scriptPubKey match {
       case m: MultiSignatureScriptPubKey =>
@@ -938,7 +938,7 @@ sealed abstract class ScriptGenerators {
   ): Gen[(CSVScriptSignature, CSVScriptPubKey, Seq[ECPrivateKey])] =
     for {
       (scriptPubKey, privKeys) <- nonLocktimeRawScriptPubKey(defaultMaxDepth)
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       csv = CSVScriptPubKey(csvScriptNum, scriptPubKey)
     } yield scriptPubKey match {
       case m: MultiSignatureScriptPubKey =>

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/WitnessGenerators.scala
@@ -95,7 +95,7 @@ sealed abstract class WitnessGenerators {
     for {
       privKey <- CryptoGenerators.privateKey
       amount <- CurrencyUnitGenerator.satoshis
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       witScriptPubKey = P2WPKHWitnessSPKV0(privKey.publicKey)
       unsignedScriptWitness = P2WPKHWitnessV0(privKey.publicKey)
       unsignedWTxSigComponent = createUnsignedRawWTxSigComponent(
@@ -122,7 +122,7 @@ sealed abstract class WitnessGenerators {
     for {
       (scriptPubKey, privKeys) <- ScriptGenerators.p2pkScriptPubKey
       amount <- CurrencyUnitGenerator.satoshis
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       witScriptPubKey = P2WSHWitnessSPKV0(scriptPubKey)
       unsignedScriptWitness = P2WSHWitnessV0(scriptPubKey)
       u = createUnsignedRawWTxSigComponent(
@@ -155,7 +155,7 @@ sealed abstract class WitnessGenerators {
     for {
       (scriptPubKey, privKey) <- ScriptGenerators.p2pkhScriptPubKey
       amount <- CurrencyUnitGenerator.satoshis
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       witScriptPubKey = P2WSHWitnessSPKV0(scriptPubKey)
       unsignedScriptWitness = P2WSHWitnessV0(scriptPubKey)
       u = createUnsignedRawWTxSigComponent(
@@ -190,7 +190,7 @@ sealed abstract class WitnessGenerators {
     for {
       (scriptPubKey, privKeys) <- ScriptGenerators.multiSigScriptPubKey
       amount <- CurrencyUnitGenerator.satoshis
-      hashType <- CryptoGenerators.hashType
+      hashType <- CryptoGenerators.preTaprootHashType
       witScriptPubKey = P2WSHWitnessSPKV0(scriptPubKey)
       unsignedScriptWitness = P2WSHWitnessV0(scriptPubKey)
       u = createUnsignedRawWTxSigComponent(


### PR DESCRIPTION
## Summary

Fixes all 8 findings reported in `CryptoParsingSecurityTest` (see the security reproduction report this branch was built against). Each commit pairs one production fix with the reproduction test that proves it — the reproduction tests were written to assert the *correct* (safe) behavior, so each failed until its corresponding fix landed.

- `DERSignatureUtil.parseDERLax` mis-parsed long-form DER length bytes due to signed-`Byte` arithmetic (`0x81 - 0x80` computed as `-255` instead of Bitcoin Core's `lenbyte & 0x7f` result of `1`).
- `SchnorrPublicKey`/`XOnlyPubKey`/`SchnorrNonce.fromBytes` silently left-padded short inputs and silently dropped the first byte of 33-byte inputs instead of requiring exactly 32 bytes. This uncovered a latent bug in `ECKey.scala` where several `schnorrPublicKey`/`schnorrNonce`/`toXOnly` accessors relied on that leniency to extract the x-coordinate from a compressed public key; fixed those to explicitly use `compressedBytes.tail`.
- A 65-byte `SchnorrDigitalSignature` with an explicit `0x00` (SIGHASH_DEFAULT) trailing byte was accepted, violating BIP340/341.
- Garbage bytes fed into `ECDigitalSignature` silently "decoded" to r=s=0 via `DERSignatureUtil.decodeSignature`'s fallback, which made `isLowS`/`hashTypeOpt` misreport undecodable bytes as valid. Fixed those two accessors to correctly report "not a valid signature" — `ECDigitalSignature.fromBytes` itself intentionally stays lenient (doesn't throw), since it's called directly on untrusted scriptSig bytes in `CryptoInterpreter.opCheckSig`/`opCheckMultiSig` with no `Try` wrapper, and throwing there would turn a clean script failure into a crash.
- `HashType.isDefinedHashtypeSignature` wrongly counted `0x00` as a defined ECDSA hashtype (it's taproot/schnorr-only per Core). This uncovered two related `testkit-core` generator bugs producing invalid signatures with an explicit `0x00` byte, previously masked by the same crypto bug.
- `ECDigitalSignature.fromFrontOfBytesWithSigHash` threw a raw `NoSuchElementException` instead of a clean `IllegalArgumentException` when no sighash byte was present.
- `Sha1Digest`/`Sha1DigestBE.fromBytes` had no length validation, unlike every sibling hash digest type.
- `CryptoBytesUtil.isHex` rejected uppercase hex while `decodeHex` accepted it — now consistent.

## Test plan

- [x] `sbt cryptoTestJVM/test` — 213/213 passing
- [x] `sbt cryptoTestJS/test` — 154/154 passing
- [x] `sbt coreTestJVM/test` script/crypto/protocol/serializer suites — all passing, including the full BIP script interpreter test-vector suite
- [x] `sbt dlcOracleTest/test` — 58/58 passing (exercises schnorr nonce/key derivation end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yT4qDB1VycMnpcNMooCR5