### PR TITLE
Fix core module security reproduction findings (41 bugs, 1 commit per bug)

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
@@ -19,7 +19,14 @@ class NetworkMessageTest extends BitcoinSUnitTest {
       // since we only support protocol version > 7, i added it manually
       // this means the payload size is bumped by 1 byte in the NetworkHeader from 100 -> 101
       // and a relay byte "00" is appended to the end of the payload
-      "F9BEB4D976657273696F6E000000000065000000358d4932" +
+      //
+      // Since checksums are now verified at parse time, the checksum field
+      // below is the correct doubleSHA256 of the actual (101 byte, with the
+      // appended relay byte) payload -- the wiki page's original checksum
+      // was only ever valid for the unmodified 100 byte payload, which
+      // can't round-trip through VersionMessage: write() always re-emits
+      // the (optional-on-read, always-written) relay byte.
+      "F9BEB4D976657273696F6E000000000065000000030ecc57" +
         "62EA0000010000000000000011B2D05000000000010000000000000000000000000000000000FFFF000000000000010000000000000000000000000000000000FFFF0000000000003B2EB35D8CE617650F2F5361746F7368693A302E372E322FC03E0300" +
         "00"
     }.toLowerCase

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
@@ -79,9 +79,14 @@ class CompactSizeUIntTest extends BitcoinSUnitTest {
       CompactSizeUInt(UInt64(500000))
     )
 
-    val str3 = "ffffffffff"
+    // 0xff prefix + the full 8 bytes it requires, encoding a value that
+    // actually needs the 9-byte form (previously this was tested with
+    // UInt32.max, which canonically belongs to the 5-byte 0xfe form, using
+    // only 4 of the 8 required bytes and relying on parseCompactSizeUInt
+    // silently truncating instead of requiring the full 9 bytes)
+    val str3 = "ff0000000001000000"
     CompactSizeUInt.parseCompactSizeUInt(str3) must be(
-      CompactSizeUInt(UInt64(4294967295L), 9)
+      CompactSizeUInt(UInt64(4294967296L), 9)
     )
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -48,7 +48,7 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
     assert(witSPKV1.pubKey == pubKey)
   }
 
-  it must "fail to construct a valid witness spk v1 when the coordinate is not on the curve" in {
+  it must "construct a witness spk v1 when the coordinate is not on the curve, but fail to access its pubKey" in {
     // all zeroes
     val pubKey = ByteVector.fill(32)(0.toByte)
     // reconstruct asm
@@ -56,8 +56,13 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
       ScriptConstant(pubKey)
     ))
 
+    // classification is structural (witness v1, 32-byte program), so
+    // construction itself must not throw -- otherwise parsing untrusted/
+    // on-chain data containing such an output would crash instead of
+    // classifying it as taproot (see SignatureCheckingSecurityTest)
+    val spk = TaprootScriptPubKey.fromAsm(asm)
     assertThrows[IllegalArgumentException] {
-      TaprootScriptPubKey.fromAsm(asm)
+      spk.pubKey
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -22,6 +22,8 @@ import org.bitcoins.testkitcore.util.{
 }
 import scodec.bits.*
 
+import scala.util.Try
+
 class TransactionTest extends BitcoinSUnitTest {
   behavior of "Transaction"
 
@@ -442,7 +444,14 @@ class TransactionTest extends BitcoinSUnitTest {
       "0100000001a76e1bb0e40d989cf3613c5b73bff552adaa09bdf79264cc0c44b968502db3be01000000fdfd000047304402200b0e9309480146ed5923a14cb3cd607facf9cf7b4f51ac9d448e0c8c3030aa5602201850641a5dd1c002e6ed9b723404a069a002608f45f77af1e3eb96e911d17afd01483045022100c7063f26164395e0ac8127b827cf6ad6a472fa8516197ef9ff565d7465b08dff022073329ded25b9559ce0dfef313ed084f9e294da47ddc814d2eab8839a8a4a9f16014c69522102b09c72ee2fa77abc24613b227d1cb6944c70af7f96711d5f1c4675daaa7554d221029787faf77569cdc59db5a34e0e9f552b9950b61d593e797ae12ac1d69eb5f98821022e9df5da07c71f7e8f5f639a28900d967714f2ae72b096c69c93fd76837b01a753aeffffffff02204e000000000000225120658204033e46a1fa8cceb84013cfe2d376ca72d5f595319497b95b08aa64a97014be00000000000017a914d06f57927ef98f7dfd25e9abdf5de65e1e7215698700000000"
     val btx = BaseTransaction.fromHex(hex)
     val spk = btx.outputs(0).scriptPubKey
-    assert(spk.isInstanceOf[UnassignedWitnessScriptPubKey])
+    // a v1 32-byte witness program is unambiguously taproot regardless of
+    // whether its 32 bytes are a valid x-only coordinate -- classifying it
+    // as UnassignedWitnessScriptPubKey would make it anyone-can-spend
+    assert(spk.isInstanceOf[TaprootScriptPubKey])
+    assert(
+      Try(spk.asInstanceOf[TaprootScriptPubKey].pubKey).isFailure,
+      "the x coordinate in this output is invalid"
+    )
   }
 
   it must "parse a05213473724e2e7f489ae0cbe1d17eef4f6c1b9806e33e5115d85e71d81e994" in {

--- a/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
@@ -18,13 +18,16 @@ class ScriptFlagUtilTest extends BitcoinSUnitTest {
   it must "return false if strict der encoding check is not required" in {
     ScriptFlagUtil.requiresStrictDerEncoding(Seq()) must be(false)
 
+    // ScriptVerifyLowS is deliberately excluded here: Core's
+    // CheckSignatureEncoding applies the DER check whenever DERSIG, LOW_S,
+    // or STRICTENC is set, so LOW_S alone must make this return true (see
+    // the dedicated LOW_S test below).
     ScriptFlagUtil.requiresStrictDerEncoding(
       Seq(
         ScriptVerifyCheckLocktimeVerify,
         ScriptVerifyCheckSequenceVerify,
         ScriptVerifyCleanStack,
         ScriptVerifyDiscourageUpgradableNOPs,
-        ScriptVerifyLowS,
         ScriptVerifyMinimalData,
         ScriptVerifyNone,
         ScriptVerifyNullDummy,
@@ -32,5 +35,11 @@ class ScriptFlagUtilTest extends BitcoinSUnitTest {
         ScriptVerifySigPushOnly
       )
     ) must be(false)
+  }
+
+  it must "check that strict der encoding is required when only LOW_S is set" in {
+    ScriptFlagUtil.requiresStrictDerEncoding(Seq(ScriptVerifyLowS)) must be(
+      true
+    )
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
@@ -15,6 +15,8 @@ class ReservedOperationsFactoryTest extends BitcoinSUnitTest {
     ReservedOperation("b0") must be(Some(OP_NOP1))
   }
   it must "find an undefined operation from its hex value" in {
-    ReservedOperation("bb").isDefined must be(true)
+    // 0xbb (187) is no longer undefined -- per BIP342 it is OP_SUCCESS187,
+    // see OpSuccessOperation. 0xff (255) remains genuinely unassigned.
+    ReservedOperation("ff").isDefined must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -23,6 +23,7 @@ import org.bitcoins.core.protocol.transaction.{
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.serializers.blockchain.RawMerkleBlockSerializer
+import org.bitcoins.core.util.NumberUtil
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.{BitVector, ByteVector}
@@ -156,5 +157,23 @@ class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
     )
 
     BlockHeader.getBlockProof(zeroTargetHeader) must be(BigInt(0))
+  }
+
+  it must "interpret the nBits exponent byte as unsigned in targetExpansion" in {
+    // Finding 6 (Low): targetExpansion reads the nBits exponent byte as a
+    // signed Scala Byte
+    // (core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala:147,160-172).
+    // Bitcoin Core's SetCompact treats the exponent byte (nCompact >> 24) as
+    // an unsigned value 0-255. A byte >= 0x80 wraps negative in Scala's
+    // signed Byte, taking the "negative exponent, shift right" branch
+    // instead of the correct "large exponent, multiply by 256^n" branch --
+    // dividing a tiny mantissa by an astronomically large power of two
+    // instead of multiplying it, silently producing a target of zero for a
+    // huge, nonzero exponent.
+    val nBits = UInt32.fromBytes(ByteVector.fromValidHex("c8010203"))
+
+    val target = NumberUtil.targetExpansion(nBits)
+
+    target.target must not be BigInt(0)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -1,10 +1,26 @@
 package org.bitcoins.core.security
 
+import org.bitcoins.core.consensus.Consensus
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.{
   MainNetChainParams,
   PartialMerkleTree
 }
+import org.bitcoins.core.protocol.script.{
+  EmptyScriptPubKey,
+  EmptyScriptSignature,
+  ScriptWitness
+}
+import org.bitcoins.core.protocol.transaction.{
+  TransactionConstants,
+  TransactionInput,
+  TransactionOutPoint,
+  TransactionOutput,
+  TransactionWitness,
+  WitnessTransaction
+}
+import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.serializers.blockchain.RawMerkleBlockSerializer
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
@@ -83,5 +99,39 @@ class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
     // 64-bit Long arithmetic from the start.
     PartialMerkleTree.calcMaxHeight(1 << 29) must be(29)
     PartialMerkleTree.calcMaxHeight(1L << 31) must be(31)
+  }
+
+  it must "use Core's witness-stripped base size check in checkTransaction" in {
+    // Finding 4 (Low): checkTransaction rejects any transaction whose full,
+    // witness-inclusive serialized size exceeds the legacy 1MB MAX_BLOCK_SIZE
+    // (core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala:1391).
+    // Bitcoin Core's CheckTransaction has no such check -- it only rejects a
+    // transaction whose witness-STRIPPED base size, scaled by
+    // WITNESS_SCALE_FACTOR (4), exceeds MAX_BLOCK_WEIGHT:
+    // GetSerializeSize(TX_NO_WITNESS(tx)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT
+    // (consensus/tx_check.cpp). A transaction with a tiny base size but a
+    // large witness (well within the weight limit) is legitimate and must
+    // not be rejected just because its total wire size exceeds 1MB.
+    val outPoint = TransactionOutPoint(
+      DoubleSha256Digest(
+        "01272b2b1c8c33a1b4e9ab111db41c9ac275e686fbd9c5d482e586d03e9e0552"
+      ).flip,
+      UInt32.zero
+    )
+    val input =
+      TransactionInput(outPoint, EmptyScriptSignature, UInt32.zero)
+    val output = TransactionOutput(Satoshis.zero, EmptyScriptPubKey)
+    val hugeWitness = ScriptWitness(Vector(ByteVector.fill(2000000)(0x00)))
+    val tx = WitnessTransaction(
+      TransactionConstants.version,
+      Vector(input),
+      Vector(output),
+      TransactionConstants.lockTime,
+      TransactionWitness(Vector(hugeWitness))
+    )
+
+    assert(tx.baseSize * Consensus.weightScalar <= Consensus.maxBlockWeight)
+    assert(tx.bytes.size > Consensus.maxBlockSize)
+    ScriptInterpreter.checkTransaction(tx) must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -68,4 +68,20 @@ class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
       RawMerkleBlockSerializer.read(merkleBlockBytes)
     }
   }
+
+  it must "compute calcMaxHeight with integer-exact results for large transaction counts" in {
+    // Finding 3 (Low): float-based calcMaxHeight disagrees with Bitcoin
+    // Core's integer loop at n = 2^29 and n = 2^31
+    // (core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala:391-392).
+    // Correct behavior: exact powers of two return their exponent (Core's
+    // CalcTreeWidth loop gives 29 and 31); the log2 double computation
+    // rounds to 30 and 32.
+    //
+    // Note: 1 << 31 overflows as a 32-bit Int (wraps to Int.MinValue), so
+    // calcMaxHeight must accept a Long to even be able to represent 2^31 as
+    // an argument; 1L << 31 avoids that overflow by doing the shift in
+    // 64-bit Long arithmetic from the start.
+    PartialMerkleTree.calcMaxHeight(1 << 29) must be(29)
+    PartialMerkleTree.calcMaxHeight(1L << 31) must be(31)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -4,6 +4,7 @@ import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.blockchain.{
+  BlockHeader,
   MainNetChainParams,
   PartialMerkleTree
 }
@@ -133,5 +134,27 @@ class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
     assert(tx.baseSize * Consensus.weightScalar <= Consensus.maxBlockWeight)
     assert(tx.bytes.size > Consensus.maxBlockSize)
     ScriptInterpreter.checkTransaction(tx) must be(true)
+  }
+
+  it must "return zero block proof for a zero target" in {
+    // Finding 5 (Low): getBlockProof only special-cases a negative or
+    // overflowed target, but not a zero target
+    // (core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala:205-213).
+    // Bitcoin Core's GetBlockProof explicitly checks
+    // `fNegative || fOverflow || bnTarget == 0` before dividing
+    // (pow.cpp) -- with nBits encoding a target of exactly zero, dividing
+    // by (target + 1) = 1 wrongly produces the enormous value 2^256
+    // instead of the correct proof-of-work contribution of zero.
+    val genesisHeader = MainNetChainParams.genesisBlock.blockHeader
+    val zeroTargetHeader = BlockHeader(
+      genesisHeader.version,
+      genesisHeader.previousBlockHash,
+      genesisHeader.merkleRootHash,
+      genesisHeader.time,
+      UInt32.zero,
+      genesisHeader.nonce
+    )
+
+    BlockHeader.getBlockProof(zeroTargetHeader) must be(BigInt(0))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -176,4 +176,24 @@ class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
 
     target.target must not be BigInt(0)
   }
+
+  it must "include the 80-byte header and txCount varint in Block.blockWeight" in {
+    // Finding 7 (Low): blockWeight only sums the weight of the transactions,
+    // omitting the fixed 80-byte block header and the txCount CompactSizeUInt
+    // (core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala:45).
+    // Bitcoin Core's GetBlockWeight scales the WHOLE serialized block (header
+    // and txCount included, not just the transaction list) by
+    // WITNESS_SCALE_FACTOR in its base-size term
+    // (::GetSerializeSize(block, ... NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) +
+    // ::GetSerializeSize(block, ...), block.cpp). The header and txCount carry
+    // no witness data, so they must count at the full scale factor (4), the
+    // same way legacy (non-segwit) transaction bytes do.
+    val block = MainNetChainParams.genesisBlock
+
+    val expectedWeight =
+      (block.blockHeader.bytes.size + block.txCount.bytes.size) *
+        Consensus.weightScalar + block.transactions.map(_.weight).sum
+
+    block.blockWeight must be(expectedWeight)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/MerkleConsensusSecurityTest.scala
@@ -1,0 +1,71 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.blockchain.{
+  MainNetChainParams,
+  PartialMerkleTree
+}
+import org.bitcoins.core.serializers.blockchain.RawMerkleBlockSerializer
+import org.bitcoins.crypto.DoubleSha256Digest
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.{BitVector, ByteVector}
+
+/** Security reproduction tests for merkle/block/consensus helper findings.
+  * Every test asserts the CORRECT/SAFE behavior, so each one FAILS until the
+  * corresponding bug is fixed. Production code is intentionally untouched.
+  */
+class MerkleConsensusSecurityTest extends BitcoinSUnitTest {
+
+  "MerkleConsensusSecurity" must "reject crafted merkleblock inputs with a clean error instead of crashing or accepting them" in {
+    // Finding 1 (Medium): PartialMerkleTree reconstruct crashes with raw
+    // `.head` exceptions and lacks Bitcoin Core's sanity caps
+    // (core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala:72,124,325,330,364;
+    // core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializer.scala:19-46).
+    // Correct behavior: zero/absurd transaction counts and truncated
+    // bits/hashes are rejected cleanly (IllegalArgumentException), like
+    // Bitcoin Core's merkleblock deserialization/ExtractMatches checks.
+    val h = DoubleSha256Digest(
+      "01272b2b1c8c33a1b4e9ab111db41c9ac275e686fbd9c5d482e586d03e9e0552"
+    )
+
+    // zero transactions: calcMaxHeight(0) degenerates and the traversal
+    // crashes on `.head` of the empty bits/hashes instead of rejecting
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32.zero, Vector.empty, BitVector.empty)
+    }
+
+    // absurd transaction count: Bitcoin Core rejects
+    // nTransactions > MAX_BLOCK_WEIGHT / MIN_TRANSACTION_WEIGHT (= 66,666)
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32(100000L), Vector.empty, BitVector.low(8))
+    }
+
+    // fewer hashes than the traversal consumes: crashes with `.head` on the
+    // empty hash vector (root bit set forces traversal into both children)
+    val rootSetBits =
+      BitVector.bits(Seq(true, false, false, false, false, false, false, false))
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32.two, Vector(h), rootSetBits)
+    }
+
+    // fewer bits than the traversal consumes: all-true flags force recursion
+    // past the end of the 8 provided bits, crashing on `.head`
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32(5), Vector.fill(8)(h), BitVector.high(8))
+    }
+
+    // the same zero-transaction case parsed off the wire as a merkleblock
+    // message must be rejected cleanly as well
+    val merkleBlockBytes = {
+      val headerBytes = MainNetChainParams.genesisBlock.blockHeader.bytes
+      val txCountLE = ByteVector.low(4) // nTransactions = 0
+      val hashCount = ByteVector(0.toByte)
+      val flagCount = ByteVector(1.toByte)
+      val flags = ByteVector(0.toByte)
+      headerBytes ++ txCountLE ++ hashCount ++ flagCount ++ flags
+    }
+    intercept[IllegalArgumentException] {
+      RawMerkleBlockSerializer.read(merkleBlockBytes)
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -1,6 +1,6 @@
 package org.bitcoins.core.security
 
-import org.bitcoins.core.p2p.VersionMessage
+import org.bitcoins.core.p2p.{NetworkMessage, VersionMessage}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
@@ -31,6 +31,29 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
         assert(!ex.isInstanceOf[IndexOutOfBoundsException],
                s"Version message without relay byte must not throw " +
                  s"IndexOutOfBoundsException, got: $ex")
+    }
+  }
+
+  it must "reject a network message with a corrupted checksum" in {
+    // Finding: p2p message checksums are never verified, see
+    // core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala:1674 and
+    // core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala:11-20
+    // Correct behavior: a message whose checksum does not match
+    // doubleSHA256(payload) must be rejected.
+    // This is the version message from the bitcoin wiki used in
+    // NetworkMessageTest, with the last checksum nibble flipped (32 -> 33).
+    val corruptedChecksumHex = {
+      "f9beb4d976657273696f6e000000000065000000358d4933" +
+        "62EA0000010000000000000011B2D05000000000010000000000000000000000000000000000FFFF000000000000010000000000000000000000000000000000FFFF0000000000003B2EB35D8CE617650F2F5361746F7368693A302E372E322FC03E0300" +
+        "00"
+    }.toLowerCase
+
+    Try(NetworkMessage.fromHex(corruptedChecksumHex)) match {
+      case Success(msg) =>
+        fail(
+          s"Network message with a corrupted checksum must be rejected, but parsed to: $msg")
+      case Failure(_) =>
+        succeed
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.core.security
 
+import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.config.RegTest
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.p2p.{
   NetworkHeader,
   NetworkMessage,
@@ -9,6 +10,7 @@ import org.bitcoins.core.p2p.{
   VerAckMessage,
   VersionMessage
 }
+import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
@@ -145,6 +147,48 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
         // the valid trailing message must eventually be surfaced
         (firstMessages ++ secondMessages).map(_.payload) must contain(
           VerAckMessage)
+    }
+  }
+
+  it must "reject bloom filters that violate the BIP37 maxSize/maxHashFuncs limits" in {
+    // Finding: the bloom filter parser lacks the BIP37 maxSize (36000 bytes)
+    // and maxHashFuncs (50) caps, so a crafted filter makes contains/insert
+    // burn CPU, see
+    // core/src/main/scala/org/bitcoins/core/serializers/bloom/RawBloomFilterSerializer.scala:15-27
+    // and core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala:56,116
+    // Correct behavior: parsed filters violating the BIP37 limits must be
+    // rejected at parse time.
+    // NB: we intentionally only assert the missing parse-time validation;
+    // actually calling contains/insert on such a filter would burn CPU.
+    val tooManyHashFuncsBytes =
+      CompactSizeUInt(UInt64(1)).bytes ++
+        ByteVector(0.toByte) ++
+        UInt32(BloomFilter.maxHashFuncs.toLong + 1).bytes.reverse ++
+        UInt32.zero.bytes.reverse ++
+        ByteVector(1.toByte) // BLOOM_UPDATE_ALL
+
+    Try(BloomFilter.fromBytes(tooManyHashFuncsBytes)) match {
+      case Success(filter) =>
+        fail(
+          s"Bloom filter with hashFuncs > 50 must be rejected, but parsed to: $filter")
+      case Failure(_) =>
+        succeed
+    }
+
+    val tooBigSize = BloomFilter.maxSize.toInt + 1
+    val tooBigFilterBytes =
+      CompactSizeUInt(UInt64(tooBigSize)).bytes ++
+        ByteVector.fill(tooBigSize)(0.toByte) ++
+        UInt32.one.bytes.reverse ++
+        UInt32.zero.bytes.reverse ++
+        ByteVector(1.toByte) // BLOOM_UPDATE_ALL
+
+    Try(BloomFilter.fromBytes(tooBigFilterBytes)) match {
+      case Success(filter) =>
+        fail(
+          s"Bloom filter with filterSize > 36000 must be rejected, but parsed to: $filter")
+      case Failure(_) =>
+        succeed
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -1,6 +1,14 @@
 package org.bitcoins.core.security
 
-import org.bitcoins.core.p2p.{NetworkMessage, VersionMessage}
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.p2p.{
+  NetworkHeader,
+  NetworkMessage,
+  NetworkPayload,
+  VersionMessage
+}
+import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
@@ -54,6 +62,26 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
           s"Network message with a corrupted checksum must be rejected, but parsed to: $msg")
       case Failure(_) =>
         succeed
+    }
+  }
+
+  it must "produce a clean parse error for an unknown command name" in {
+    // Finding: an unknown command string throws NoSuchElementException at
+    // core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala:1674
+    // Correct behavior: an unknown command must produce a clean, descriptive
+    // parse error (or a handled unknown-payload type), not a raw
+    // NoSuchElementException from a Map lookup.
+    val header =
+      NetworkHeader(RegTest,
+                    "madeup",
+                    UInt32.zero,
+                    CryptoUtil.doubleSHA256(ByteVector.empty).bytes.take(4))
+
+    Try(NetworkPayload(header, ByteVector.empty)) match {
+      case Failure(_: NoSuchElementException) =>
+        fail("Unknown command name must not throw a raw NoSuchElementException")
+      case _ =>
+        succeed // a descriptive failure or a handled unknown payload is fine
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -6,8 +6,10 @@ import org.bitcoins.core.p2p.{
   NetworkHeader,
   NetworkMessage,
   NetworkPayload,
+  VerAckMessage,
   VersionMessage
 }
+import org.bitcoins.core.util.NetworkUtil
 import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
@@ -106,5 +108,43 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
 
     val msg = NetworkMessage.fromBytes(streamBytes)
     msg.payload.bytes.size must be(header.payloadSize.toInt)
+  }
+
+  it must "not wedge forever on unparseable bytes at the start of the stream" in {
+    // Finding: parseIndividualMessages never drops bytes that deterministically
+    // fail to parse, so the same failing parse is retried on every subsequent
+    // chunk and no later valid message is ever surfaced, see
+    // core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala:202-207
+    // Correct behavior: the parser must either skip the bad bytes or fail
+    // cleanly -- it must not silently return empty forever while a valid
+    // message sits later in the stream.
+    // A "filterload" message whose declared payload (1 byte) is too short to
+    // contain a bloom filter: the header parses fine, but the payload parse
+    // fails deterministically (RawBloomFilterSerializer reads the flags byte
+    // at index 9).
+    val badPayload = ByteVector(0.toByte)
+    val badHeader =
+      NetworkHeader(RegTest,
+                    "filterload",
+                    UInt32(badPayload.size),
+                    CryptoUtil.doubleSHA256(badPayload).bytes.take(4))
+    val badBytes = badHeader.bytes ++ badPayload
+
+    val validMessage = NetworkMessage(RegTest, VerAckMessage)
+
+    // feed the stream chunk by chunk, as a TCP stream would arrive
+    val (firstMessages, leftover) =
+      NetworkUtil.parseIndividualMessages(badBytes)
+    val secondAttempt =
+      Try(NetworkUtil.parseIndividualMessages(leftover ++ validMessage.bytes))
+
+    secondAttempt match {
+      case Failure(_) =>
+        succeed // failing cleanly on the garbage is acceptable
+      case Success((secondMessages, _)) =>
+        // the valid trailing message must eventually be surfaced
+        (firstMessages ++ secondMessages).map(_.payload) must contain(
+          VerAckMessage)
+    }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -84,4 +84,27 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
         succeed // a descriptive failure or a handled unknown payload is fine
     }
   }
+
+  it must "not interpret trailing bytes beyond payloadSize as part of the payload" in {
+    // Finding: the payload is not sliced to the declared `payloadSize`, see
+    // core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala:11-20
+    // Correct behavior: only `payloadSize` bytes after the header may be
+    // interpreted as the payload; trailing bytes belong to the next message
+    // in the stream and must be left alone.
+    // RejectMessage is used because its `extra` field consumes all remaining
+    // bytes, so trailing bytes leak into the parsed payload.
+    // payload: message="tx", code=0x10, reason="", no extra data
+    val payloadBytes = ByteVector.fromValidHex("0274781000")
+    val header =
+      NetworkHeader(RegTest,
+                    "reject",
+                    UInt32(payloadBytes.size),
+                    CryptoUtil.doubleSHA256(payloadBytes).bytes.take(4))
+    // simulate framing where the next message's bytes follow immediately
+    val trailingBytes = ByteVector.fromValidHex("f9beb4d976657261")
+    val streamBytes = header.bytes ++ payloadBytes ++ trailingBytes
+
+    val msg = NetworkMessage.fromBytes(streamBytes)
+    msg.payload.bytes.size must be(header.payloadSize.toInt)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -2,8 +2,10 @@ package org.bitcoins.core.security
 
 import org.bitcoins.core.bloom.BloomFilter
 import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.{UInt32, UInt64}
 import org.bitcoins.core.p2p.{
+  FeeFilterMessage,
   NetworkHeader,
   NetworkMessage,
   NetworkPayload,
@@ -189,6 +191,29 @@ class P2pParsingSecurityTest extends BitcoinSUnitTest {
           s"Bloom filter with filterSize > 36000 must be rejected, but parsed to: $filter")
       case Failure(_) =>
         succeed
+    }
+  }
+
+  it must "parse a feefilter message with a feerate not divisible by 1000 without throwing" in {
+    // Finding: FeeFilterMessage.satPerByte throws on peer-supplied feerates
+    // not divisible by 1000, see
+    // core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala:812 and
+    // core/src/main/scala/org/bitcoins/core/currency/FeeUnit.scala:130-148
+    // (actual path: core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala)
+    // Correct behavior: a feefilter message with any peer-supplied feerate
+    // must be usable without throwing; satPerByte must round instead of
+    // demanding exact divisibility.
+    // 999 sat/kb in little endian, as it appears on the wire
+    val feeFilterBytes = ByteVector.fromValidHex("e703000000000000")
+    val feeFilterMessage = FeeFilterMessage.fromBytes(feeFilterBytes)
+
+    feeFilterMessage.feeRate.currencyUnit.satoshis must be(Satoshis(999))
+
+    Try(feeFilterMessage.satPerByte) match {
+      case Success(_) =>
+        succeed
+      case Failure(ex) =>
+        fail(s"satPerByte must not throw for feerate 999 sat/kb, got: $ex")
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/P2pParsingSecurityTest.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.p2p.VersionMessage
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
+
+import scala.util.{Failure, Success, Try}
+
+/** Security reproduction tests for p2p message parsing. Each test asserts the
+  * CORRECT/SAFE behavior, so every test here FAILS until the corresponding bug
+  * is fixed. Do not change these assertions to match the buggy behavior.
+  */
+class P2pParsingSecurityTest extends BitcoinSUnitTest {
+
+  "P2pParsing" must "handle a version message missing the optional relay byte gracefully" in {
+    // Finding: a Version message without the optional `relay` byte throws
+    // IndexOutOfBoundsException at
+    // core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializer.scala:56
+    // Correct behavior: accept the message with a default relay value, or fail
+    // with a clean parse error -- never a raw index exception.
+    // This is the version message from VersionMessageTest with the trailing
+    // relay byte ("01") removed, as sent by pre-70001 peers.
+    val payloadWithoutRelay = ByteVector.fromValidHex(
+      "7f1101000d040000000000004ea1035d0000000000000000000000000000000000000000000000000000000000000d04000000000000000000000000000000000000000000000000fa562b93b3113e02122f5361746f7368693a302e31372e302e312f68000000")
+
+    Try(VersionMessage.fromBytes(payloadWithoutRelay)) match {
+      case Success(_) =>
+        succeed // accepted with a default relay value
+      case Failure(ex) =>
+        // a clean parse failure is acceptable, a raw index exception is not
+        assert(!ex.isInstanceOf[IndexOutOfBoundsException],
+               s"Version message without relay byte must not throw " +
+                 s"IndexOutOfBoundsException, got: $ex")
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -18,8 +18,7 @@ import org.bitcoins.core.script.locktime.{
   OP_CHECKSEQUENCEVERIFY
 }
 import org.bitcoins.core.script.result.ScriptErrorNegativeLockTime
-import org.bitcoins.core.script.stack.OP_IFDUP
-import org.bitcoins.core.script.stack.StackInterpreter
+import org.bitcoins.core.script.stack.{OP_IFDUP, OP_ROLL, StackInterpreter}
 import org.bitcoins.core.script.{
   ExecutedScriptProgram,
   PreExecutionScriptProgram
@@ -159,6 +158,25 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
       )
     val newProgram = StackInterpreter.opIfDup(program)
     newProgram.stack must be(stack)
+  }
+
+  it must "move the nth stack element to the top with OP_ROLL even when duplicate values are on the stack" in {
+    // Finding 7 (Low): core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala:170-173
+    // removes the rolled element with stack.tail.diff(List(newStackTop)), which removes the FIRST
+    // equal element instead of the element at depth n.
+    // Correct behavior (Core): the element at depth n is moved to the top.
+    val a = ScriptConstant("aa")
+    val b = ScriptConstant("bb")
+    val stack = List(ScriptNumber(2), a, b, a)
+    val script = List(OP_ROLL)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = StackInterpreter.opRoll(program)
+    // the second 'a' (depth 2) moves to the top; the first 'a' stays at depth 1
+    newProgram.stack must be(List(a, a, b))
   }
 
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -1,0 +1,36 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.script.constant.ScriptNumber
+import org.bitcoins.core.script.locktime.{
+  LockTimeInterpreter,
+  OP_CHECKSEQUENCEVERIFY
+}
+import org.bitcoins.core.script.result.ScriptErrorNegativeLockTime
+import org.bitcoins.core.script.ExecutedScriptProgram
+import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
+
+/** Security reproduction tests for script number / opcode semantics. Every test
+  * in this file asserts the CORRECT (Bitcoin Core compatible) behavior, so each
+  * test FAILS until the underlying bug is fixed.
+  */
+class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
+
+  "ScriptArithmeticSecurity" must "fail OP_CHECKSEQUENCEVERIFY for ANY negative operand with ScriptErrorNegativeLockTime" in {
+    // Finding 1 (High): core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala:92-113
+    // only rejects ScriptNumber.negativeOne; other negatives (e.g. -2) have the BIP68 disable
+    // bit set in two's complement and are treated as a NOP (BIP112 bypass).
+    // Correct behavior per BIP112: any operand < 0 fails with SCRIPT_ERR_NEGATIVE_LOCKTIME.
+    val stack = List(ScriptNumber(-2))
+    val script = List(OP_CHECKSEQUENCEVERIFY)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = LockTimeInterpreter.opCheckSequenceVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be(
+      Some(ScriptErrorNegativeLockTime)
+    )
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -1,12 +1,20 @@
 package org.bitcoins.core.security
 
-import org.bitcoins.core.script.constant.ScriptNumber
+import org.bitcoins.core.crypto.{BaseTxSigComponent, TxSigComponent}
+import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.script.arithmetic.{ArithmeticInterpreter, OP_1ADD}
+import org.bitcoins.core.script.constant.{ScriptConstant, ScriptNumber}
+import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNone}
 import org.bitcoins.core.script.locktime.{
   LockTimeInterpreter,
   OP_CHECKSEQUENCEVERIFY
 }
 import org.bitcoins.core.script.result.ScriptErrorNegativeLockTime
-import org.bitcoins.core.script.ExecutedScriptProgram
+import org.bitcoins.core.script.{
+  ExecutedScriptProgram,
+  PreExecutionScriptProgram
+}
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
 
 /** Security reproduction tests for script number / opcode semantics. Every test
@@ -31,6 +39,37 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
     newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
     newProgram.asInstanceOf[ExecutedScriptProgram].error must be(
       Some(ScriptErrorNegativeLockTime)
+    )
+  }
+
+  it must "fail a 5-byte numeric operand to OP_1ADD like Bitcoin Core's 4-byte CScriptNum limit" in {
+    // Finding 2 (Medium): core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala:306
+    // re-encodes ScriptConstant operands via ScriptNumberUtil.toLong, shrinking a non-minimal
+    // 5-byte encoding of a small number to <= 4 bytes, so the consensus CScriptNum size check
+    // (isLargerThan4Bytes) is bypassed when SCRIPT_VERIFY_MINIMALDATA is not set.
+    // Correct behavior: Core fails any numeric operand larger than 4 bytes.
+    val stack =
+      List(ScriptConstant("ff00000000")) // 5-byte non-minimal encoding of 255
+    val script = List(OP_1ADD)
+    val t = buildTxSigComponent(Seq(ScriptVerifyNone))
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    val newProgram = ArithmeticInterpreter.op1Add(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
+      true
+    )
+  }
+
+  private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {
+    BaseTxSigComponent(
+      transaction = TestUtil.transaction,
+      inputIndex = TestUtil.testProgram.txSignatureComponent.inputIndex,
+      output = TransactionOutput(
+        CurrencyUnits.zero,
+        TestUtil.testProgram.txSignatureComponent.scriptPubKey
+      ),
+      flags = flags
     )
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -2,12 +2,19 @@ package org.bitcoins.core.security
 
 import org.bitcoins.core.crypto.{BaseTxSigComponent, TxSigComponent}
 import org.bitcoins.core.currency.CurrencyUnits
-import org.bitcoins.core.protocol.transaction.TransactionOutput
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.protocol.transaction.{
+  BaseTransaction,
+  EmptyTransaction,
+  TransactionInput,
+  TransactionOutput
+}
 import org.bitcoins.core.script.arithmetic.{ArithmeticInterpreter, OP_1ADD}
 import org.bitcoins.core.script.constant.{ScriptConstant, ScriptNumber}
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNone}
 import org.bitcoins.core.script.locktime.{
   LockTimeInterpreter,
+  OP_CHECKLOCKTIMEVERIFY,
   OP_CHECKSEQUENCEVERIFY
 }
 import org.bitcoins.core.script.result.ScriptErrorNegativeLockTime
@@ -95,6 +102,45 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
       parsed.size must be(1)
       parsed.head.toString.startsWith("OP_SUCCESS") must be(true)
     }
+  }
+
+  it must "fail OP_CHECKLOCKTIMEVERIFY with a non-minimally encoded locktime when the minimal data flag is set" in {
+    // Finding 5 (Low): core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala:33-71
+    // opCheckLockTimeVerify never checks ScriptFlagUtil.requireMinimalData / isShortestEncoding
+    // (unlike opCheckSequenceVerify at LockTimeInterpreter.scala:95-97).
+    // Correct behavior: a non-minimal locktime operand fails when SCRIPT_VERIFY_MINIMALDATA is set
+    // (Core's CScriptNum enforces fRequireMinimal for CLTV too).
+    val stack = Seq(ScriptNumber("0100")) // non-minimal encoding of 1
+    val script = Seq(OP_CHECKLOCKTIMEVERIFY)
+    val oldInput = TestUtil.transaction.inputs.head
+    val input = TransactionInput(
+      oldInput.previousOutput,
+      oldInput.scriptSignature,
+      UInt32.zero
+    )
+    val tx = BaseTransaction(
+      EmptyTransaction.version,
+      Vector(input),
+      EmptyTransaction.outputs,
+      UInt32(1)
+    )
+    val t = BaseTxSigComponent(
+      transaction = tx,
+      inputIndex = TestUtil.testProgram.txSignatureComponent.inputIndex,
+      output = TransactionOutput(
+        CurrencyUnits.zero,
+        TestUtil.testProgram.txSignatureComponent.scriptPubKey
+      ),
+      // standard flags include ScriptVerifyMinimalData
+      flags = TestUtil.testProgram.flags
+    )
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    val newProgram = LockTimeInterpreter.opCheckLockTimeVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
+      true
+    )
   }
 
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -15,7 +15,9 @@ import org.bitcoins.core.script.{
   ExecutedScriptProgram,
   PreExecutionScriptProgram
 }
+import org.bitcoins.core.serializers.script.ScriptParser
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
+import scodec.bits.ByteVector
 
 /** Security reproduction tests for script number / opcode semantics. Every test
   * in this file asserts the CORRECT (Bitcoin Core compatible) behavior, so each
@@ -78,6 +80,21 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
     newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
       true
     )
+  }
+
+  it must "parse opcode bytes 0xbb-0xff as OP_SUCCESS187-254 operations" in {
+    // Finding 4 (High): core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala:64-66
+    // and core/src/main/scala/org/bitcoins/core/serializers/script/ScriptParser.scala:175 —
+    // fromByte does a Map lookup with no fallback for unassigned opcode bytes; per BIP342
+    // bytes 187-254 are OP_SUCCESS187-254 and must be parseable/usable.
+    // NOTE: in this snapshot these bytes do NOT throw NoSuchElementException; they parse to
+    // ReservedOperation.UndefinedOP_NOP (ReservedOperations.scala:97-100), which is still
+    // wrong per BIP342 — they are OP_SUCCESSx operations, not reserved NOPs.
+    (187 to 254).foreach { opCode =>
+      val parsed = ScriptParser.fromBytes(ByteVector(opCode.toByte))
+      parsed.size must be(1)
+      parsed.head.toString.startsWith("OP_SUCCESS") must be(true)
+    }
   }
 
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -10,7 +10,12 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput
 }
 import org.bitcoins.core.script.arithmetic.{ArithmeticInterpreter, OP_1ADD}
-import org.bitcoins.core.script.constant.{ScriptConstant, ScriptNumber}
+import org.bitcoins.core.script.constant.{
+  BytesToPushOntoStack,
+  OP_16,
+  ScriptConstant,
+  ScriptNumber
+}
 import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNone}
 import org.bitcoins.core.script.locktime.{
   LockTimeInterpreter,
@@ -24,6 +29,7 @@ import org.bitcoins.core.script.{
   PreExecutionScriptProgram
 }
 import org.bitcoins.core.serializers.script.ScriptParser
+import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
 
@@ -177,6 +183,15 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
     val newProgram = StackInterpreter.opRoll(program)
     // the second 'a' (depth 2) moves to the top; the first 'a' stays at depth 1
     newProgram.stack must be(List(a, a, b))
+  }
+
+  it must "count a scriptSig ending in OP_16 as push-only" in {
+    // Finding 8 (Low): core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala:202-220
+    // isPushOnly uses scriptOp.opCode < OP_16.opCode, rejecting OP_16 itself; Core's IsPushOnly
+    // (script.cpp) allows all opcodes up to and including OP_16.
+    // Correct behavior: OP_16 counts as a push.
+    val asm = Seq(BytesToPushOntoStack(1), ScriptConstant("ff"), OP_16)
+    BitcoinScriptUtil.isPushOnly(asm) must be(true)
   }
 
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -61,6 +61,25 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
     )
   }
 
+  it must "fail gracefully with a ScriptError on numeric operands larger than 8 bytes instead of throwing NumberFormatException" in {
+    // Finding 3 (High): core/src/main/scala/org/bitcoins/core/script/constant/ScriptNumberUtil.scala:108
+    // parses operand hex with java.lang.Long.parseLong; a >8-byte operand overflows and throws
+    // NumberFormatException, which escapes the interpreter (ArithmeticInterpreter.scala:306;
+    // same pattern at ArithmeticInterpreter.scala:357-368 and LockTimeInterpreter.scala:67,116).
+    // Correct behavior: a script evaluation error, not a crash.
+    val stack = List(ScriptConstant("ffffffffffffffff7f")) // 9-byte operand
+    val script = List(OP_1ADD)
+    val t = buildTxSigComponent(Seq(ScriptVerifyNone))
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    // currently throws NumberFormatException out of the interpreter
+    val newProgram = ArithmeticInterpreter.op1Add(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
+      true
+    )
+  }
+
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {
     BaseTxSigComponent(
       transaction = TestUtil.transaction,

--- a/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/ScriptArithmeticSecurityTest.scala
@@ -18,6 +18,8 @@ import org.bitcoins.core.script.locktime.{
   OP_CHECKSEQUENCEVERIFY
 }
 import org.bitcoins.core.script.result.ScriptErrorNegativeLockTime
+import org.bitcoins.core.script.stack.OP_IFDUP
+import org.bitcoins.core.script.stack.StackInterpreter
 import org.bitcoins.core.script.{
   ExecutedScriptProgram,
   PreExecutionScriptProgram
@@ -141,6 +143,22 @@ class ScriptArithmeticSecurityTest extends BitcoinSUnitTest {
     newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
       true
     )
+  }
+
+  it must "not duplicate a non-canonical zero encoding with OP_IFDUP (Bitcoin Core treats it as false)" in {
+    // Finding 6 (Medium): core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala:38
+    // only compares the stack top against ScriptNumber.zero (the empty vector); Core's CastToBool
+    // treats every all-zero byte encoding (and negative zero) as false.
+    // Correct behavior: "00" is false, so OP_IFDUP leaves the stack unchanged.
+    val stack = List(ScriptConstant("00"))
+    val script = List(OP_IFDUP)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = StackInterpreter.opIfDup(program)
+    newProgram.stack must be(stack)
   }
 
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -14,9 +14,12 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.PreExecutionScriptProgram
-import org.bitcoins.core.script.flag.ScriptVerifyDiscourageUpgradableWitnessProgram
+import org.bitcoins.core.script.flag.{
+  ScriptFlag,
+  ScriptVerifyDiscourageUpgradableWitnessProgram
+}
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
-import org.bitcoins.core.script.result.ScriptOk
+import org.bitcoins.core.script.result.{ScriptErrorSchnorrSigHashType, ScriptOk}
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto.*
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
@@ -33,9 +36,49 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
 
   behavior of "Signature checking security"
 
-  // fixed, deterministic key -- no randomness in this spec
+  // fixed, deterministic keys — no randomness in this spec
   private val privKey1: ECPrivateKey =
     ECPrivateKey.fromFieldElement(FieldElement.one)
+  private val privKey2: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(2.toByte))
+  private val noncePrivKey: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(3.toByte))
+
+  /** Builds a single input taproot script path spend of a single tapleaf.
+    * Returns the sig component and the tapleaf hash so callers can compute the
+    * BIP341 sighash themselves.
+    */
+  private def buildTapscriptSpend(
+      leafScriptBytes: ByteVector,
+      witnessStack: Vector[ByteVector],
+      flags: Seq[ScriptFlag]): (TaprootTxSigComponent, Sha256Digest) = {
+    val leafSPK =
+      ScriptPubKey.fromAsmBytes(leafScriptBytes).asInstanceOf[RawScriptPubKey]
+    val internalKey = privKey2.toXOnly
+    val leaf = TapLeaf(LeafVersion.Tapscript, leafSPK)
+    val (keyParity, taprootSPK) =
+      TaprootScriptPubKey.fromInternalKeyTapscriptTree(internalKey, leaf)
+    val controlBlock =
+      TapscriptControlBlock.fromSingleLeaf(LeafVersion.Tapscript,
+                                           internalKey,
+                                           keyParity)
+    val witness = TaprootScriptPath(controlBlock, None, leafSPK, witnessStack)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount))
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+    val outpoint = wtx.inputs(inputIndex.toInt).previousOutput
+    val outputMap = PreviousOutputMap(
+      Map(outpoint -> creditingTx.outputs(outputIndex.toInt)))
+    val component = TaprootTxSigComponent(wtx, inputIndex, outputMap, flags)
+    val tapLeafHash = TaprootScriptPath.computeTapleafHash(leaf)
+    (component, tapLeafHash)
+  }
 
   it must "not treat a v1 witness program with an invalid x coordinate as anyone-can-spend" in {
     // Finding (High): a taproot (v1) 32-byte witness program whose x-only key
@@ -140,5 +183,31 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
       signature = sig,
       flags = flags)
     result must be(SignatureValidationSuccess)
+  }
+
+  it must "reject a 65-byte tapscript signature with an explicit SIGHASH_DEFAULT byte" in {
+    // Finding (Medium): tapscript accepts a 65-byte signature whose last byte
+    // is 0x00 (explicit SIGHASH_DEFAULT), violating BIP341
+    // (core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala:157-172,228-240,
+    // crypto/src/main/scala/org/bitcoins/crypto/HashType.scala:205-216).
+    // Correct behavior: validation fails with ScriptErrorSchnorrSigHashType.
+    val flags = Policy.standardFlags
+    // <x-only pubkey> OP_CHECKSIG
+    val leafScriptBytes = ByteVector.fromValidHex("20") ++
+      privKey1.toXOnly.bytes ++ ByteVector.fromValidHex("ac")
+    // build a placeholder spend to compute the BIP341 sighash, then sign it
+    val (placeholderComponent, tapLeafHash) =
+      buildTapscriptSpend(leafScriptBytes, Vector.empty, flags)
+    val sighash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashDefault,
+      TaprootSerializationOptions(Some(tapLeafHash), None, None))
+    val sig64 = privKey1.schnorrSignWithNonce(sighash.bytes, noncePrivKey)
+    // explicitly append SIGHASH_DEFAULT (0x00) — not allowed by BIP341
+    val sig65 = sig64.bytes ++ ByteVector.fromByte(0x00.toByte)
+    val (component, _) =
+      buildTapscriptSpend(leafScriptBytes, Vector(sig65), flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptErrorSchnorrSigHashType)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -17,6 +17,7 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.PreExecutionScriptProgram
+import org.bitcoins.core.script.constant.{OP_0, ScriptConstant}
 import org.bitcoins.core.script.flag.{
   ScriptFlag,
   ScriptVerifyDiscourageUpgradableWitnessProgram,
@@ -24,8 +25,13 @@ import org.bitcoins.core.script.flag.{
   ScriptVerifyNullFail
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
-import org.bitcoins.core.script.result.{ScriptErrorSchnorrSigHashType, ScriptOk}
+import org.bitcoins.core.script.result.{
+  ScriptErrorSchnorrSigHashType,
+  ScriptErrorSigNullFail,
+  ScriptOk
+}
 import org.bitcoins.core.script.util.PreviousOutputMap
+import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.crypto.*
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
@@ -316,5 +322,48 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
       signature = ECDigitalSignature.empty,
       flags = Seq(ScriptVerifyLowS))
     result must be(SignatureValidationErrorIncorrectSignatures)
+  }
+
+  it must "apply NULLFAIL to all signatures in OP_CHECKMULTISIG, including consumed ones" in {
+    // Finding (Medium): NULLFAIL in OP_CHECKMULTISIG only checks the
+    // unconsumed signatures, not all provided ones
+    // (core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala:267-298).
+    // Correct behavior: Core checks every signature slot on failure, so a
+    // failing CHECKMULTISIG with any non-empty signature must fail the script.
+    // LOW_S is removed to decouple this test from the empty-signature LOW_S bug
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyLowS)
+    val pubKey1 = privKey1.publicKey
+    val pubKey2 = privKey2.publicKey
+    val multiSigSPK = MultiSignatureScriptPubKey(2, Vector(pubKey1, pubKey2))
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(multiSigSPK, Some(amount))
+    val (placeholderTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex)
+    val output = TransactionOutput(amount, multiSigSPK)
+    val placeholderComponent =
+      BaseTxSigComponent(placeholderTx, inputIndex, output, flags)
+    val hash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    // pubKey2 is pushed last in the multisig script, so it is checked first
+    val validSig =
+      privKey2.sign(hash.bytes).appendHashType(HashType.sigHashAll)
+    val sigPush = BitcoinScriptUtil.calculatePushOp(validSig.bytes) ++ Vector(
+      ScriptConstant(validSig.bytes))
+    // dummy, empty signature, valid signature — the valid signature is on top
+    // of the stack and is checked (and consumed) first
+    val scriptSig =
+      NonStandardScriptSignature.fromAsm(Vector(OP_0, OP_0) ++ sigPush)
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   scriptSig,
+                                                   outputIndex)
+    val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptErrorSigNullFail)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -504,4 +504,16 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
       s"The uint256-one error hash only applies to the legacy sighash algorithm, a segwit v0 sighash must not return it"
     )
   }
+
+  it must "not count 0x00 as a defined hashtype byte for STRICTENC" in {
+    // Finding (Info): isDefinedHashtypeSignature counts the 0x00 byte as a
+    // defined ECDSA hashtype, unlike Core's STRICTENC
+    // (crypto/src/main/scala/org/bitcoins/crypto/HashType.scala:119-128,200-202).
+    // Correct behavior: Core's IsDefinedHashtypeSignature rejects a 0x00
+    // hashtype byte.
+    val sigEndingInZero = ECDigitalSignature(
+      ByteVector.fromValidHex("3006020101020101") ++ ByteVector.fromByte(
+        0x00.toByte))
+    HashType.isDefinedHashtypeSignature(sigEndingInZero) must be(false)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -33,6 +33,7 @@ import org.bitcoins.core.script.result.{
   ScriptErrorSigNullFail,
   ScriptOk
 }
+import org.bitcoins.core.script.stack.OP_DROP
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.crypto.*
@@ -439,5 +440,21 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
     val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
     val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
     result must be(ScriptOk)
+  }
+
+  it must "remove all occurrences of a signature with legacy FindAndDelete" in {
+    // Finding (Low): legacy FindAndDelete removes only the first whole-token
+    // occurrence of the signature instead of all occurrences
+    // (core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala:546-578).
+    // Correct behavior: Core's FindAndDelete removes all occurrences.
+    val sig = ECDigitalSignature(
+      "304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901")
+    val sigPush = BitcoinScriptUtil.calculatePushOp(sig.bytes) ++ Vector(
+      ScriptConstant(sig.bytes))
+    // the same signature pushed twice in one script
+    val script = sigPush ++ Vector(OP_DROP) ++ sigPush ++ Vector(OP_DROP)
+    val result = BitcoinScriptUtil.removeSignatureFromScript(sig, script)
+    assert(!result.contains(ScriptConstant(sig.hex)),
+           s"All occurrences of the signature must be removed, got=$result")
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -1,6 +1,8 @@
 package org.bitcoins.core.security
 
 import org.bitcoins.core.crypto.{
+  BaseTxSigComponent,
+  SignatureValidationErrorIncorrectSignatures,
   SignatureValidationSuccess,
   TaprootSerializationOptions,
   TaprootTxSigComponent,
@@ -9,7 +11,7 @@ import org.bitcoins.core.crypto.{
   WitnessTxSigComponentRaw,
   WitnessTxSigComponentRebuilt
 }
-import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.*
@@ -18,6 +20,7 @@ import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.{
   ScriptFlag,
   ScriptVerifyDiscourageUpgradableWitnessProgram,
+  ScriptVerifyLowS,
   ScriptVerifyNullFail
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
@@ -285,5 +288,33 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
     assert(
       result != ScriptOk,
       s"An invalid non-empty tapscript signature must fail the script immediately, got=$result")
+  }
+
+  it must "not fail an empty signature with the LOW_S check" in {
+    // Finding (Medium): an empty signature combined with the LOW_S flag fails
+    // the whole script with ScriptErrorSigHighS instead of just pushing false
+    // (core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala:133-136).
+    // Correct behavior: Core's CheckSignatureEncoding exempts the empty
+    // signature from all encoding checks, so verification just returns false.
+    val pubKey = privKey1.publicKey
+    val spk = P2PKHScriptPubKey(pubKey)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk)
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex)
+    val component =
+      BaseTxSigComponent(spendingTx,
+                         inputIndex,
+                         TransactionOutput(CurrencyUnits.zero, spk),
+                         Seq(ScriptVerifyLowS))
+    val result = TransactionSignatureChecker.checkSignature(
+      txSignatureComponent = component,
+      script = spk.asm,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = ECDigitalSignature.empty,
+      flags = Seq(ScriptVerifyLowS))
+    result must be(SignatureValidationErrorIncorrectSignatures)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.security
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
   SignatureValidationErrorIncorrectSignatures,
+  SignatureValidationErrorNotStrictDerEncoding,
   SignatureValidationSuccess,
   TaprootSerializationOptions,
   TaprootTxSigComponent,
@@ -20,6 +21,7 @@ import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.constant.{OP_0, ScriptConstant}
 import org.bitcoins.core.script.flag.{
   ScriptFlag,
+  ScriptFlagUtil,
   ScriptVerifyDiscourageUpgradableWitnessProgram,
   ScriptVerifyLowS,
   ScriptVerifyNullFail
@@ -365,5 +367,37 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
     val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
     val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
     result must be(ScriptErrorSigNullFail)
+  }
+
+  it must "require strict DER encoding when only the LOW_S flag is set" in {
+    // Finding (Low): the DER-encoding check is skipped when only the LOW_S
+    // flag is set
+    // (core/src/main/scala/org/bitcoins/core/script/flag/ScriptFlagUtil.scala:12-14).
+    // Correct behavior: Core's CheckSignatureEncoding applies the DER check
+    // whenever DERSIG, LOW_S or STRICTENC is set.
+    ScriptFlagUtil.requiresStrictDerEncoding(Seq(ScriptVerifyLowS)) must be(
+      true)
+
+    val pubKey = privKey1.publicKey
+    val spk = P2PKHScriptPubKey(pubKey)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk)
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex)
+    val component =
+      BaseTxSigComponent(spendingTx,
+                         inputIndex,
+                         TransactionOutput(CurrencyUnits.zero, spk),
+                         Seq(ScriptVerifyLowS))
+    val nonDerSig = ECDigitalSignature(ByteVector.fill(71)(0xff.toByte))
+    val result = TransactionSignatureChecker.checkSignature(
+      txSignatureComponent = component,
+      script = spk.asm,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = nonDerSig,
+      flags = Seq(ScriptVerifyLowS))
+    result must be(SignatureValidationErrorNotStrictDerEncoding)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -1,6 +1,14 @@
 package org.bitcoins.core.security
 
-import org.bitcoins.core.crypto.TaprootTxSigComponent
+import org.bitcoins.core.crypto.{
+  SignatureValidationSuccess,
+  TaprootSerializationOptions,
+  TaprootTxSigComponent,
+  TransactionSignatureChecker,
+  TransactionSignatureSerializer,
+  WitnessTxSigComponentRaw,
+  WitnessTxSigComponentRebuilt
+}
 import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.*
@@ -24,6 +32,10 @@ import scala.util.{Failure, Success, Try}
 class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
 
   behavior of "Signature checking security"
+
+  // fixed, deterministic key -- no randomness in this spec
+  private val privKey1: ECPrivateKey =
+    ECPrivateKey.fromFieldElement(FieldElement.one)
 
   it must "not treat a v1 witness program with an invalid x coordinate as anyone-can-spend" in {
     // Finding (High): a taproot (v1) 32-byte witness program whose x-only key
@@ -67,5 +79,66 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
           result != ScriptOk,
           s"Spending a v1 witness program with an invalid x-only key must fail validation, got=$result")
     }
+  }
+
+  it must "commit the segwit v0 sighash to the scriptCode after the last executed OP_CODESEPARATOR" in {
+    // Finding (High): the segwit v0 (BIP143) sighash ignores the executed
+    // OP_CODESEPARATOR in the scriptCode — checkSignature on a
+    // WitnessTxSigComponent ignores the script argument and re-serializes the
+    // full witness script
+    // (core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala:160-165,
+    // core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala:192-243,
+    // core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala:476-487).
+    // Correct behavior: the sighash commits to the script after the last
+    // executed OP_CODESEPARATOR, so a signature over that sighash must verify.
+    val pubKey = privKey1.publicKey
+    // <pubkey> OP_CODESEPARATOR OP_CHECKSIG
+    val fullScriptBytes = ByteVector.fromValidHex("21") ++ pubKey.bytes ++
+      ByteVector.fromValidHex("abac")
+    val witnessScript = ScriptPubKey
+      .fromAsmBytes(fullScriptBytes)
+      .asInstanceOf[RawScriptPubKey]
+    // the scriptCode Core would use: everything after the last OP_CODESEPARATOR
+    val strippedScript =
+      ScriptPubKey.fromAsmBytes(ByteVector.fromValidHex("ac"))
+    val p2wsh = P2WSHWitnessSPKV0(witnessScript)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(p2wsh, Some(amount))
+    val witness = P2WSHWitnessV0(witnessScript, Vector.empty)
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+    val flags = Policy.standardFlags
+    val rawComponent =
+      WitnessTxSigComponentRaw(wtx,
+                               inputIndex,
+                               TransactionOutput(amount, p2wsh),
+                               flags)
+    // manually compute the expected BIP143 sighash with the post-codeseparator
+    // scriptCode, and sign that hash
+    val expectedHashComponent =
+      WitnessTxSigComponentRebuilt(wtx = wtx,
+                                   inputIndex = inputIndex,
+                                   output =
+                                     TransactionOutput(amount, strippedScript),
+                                   witScriptPubKey = p2wsh,
+                                   flags = flags)
+    val expectedHash = TransactionSignatureSerializer.hashForSignature(
+      expectedHashComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    val sig =
+      privKey1.sign(expectedHash.bytes).appendHashType(HashType.sigHashAll)
+    val result = TransactionSignatureChecker.checkSignature(
+      txSignatureComponent = rawComponent,
+      script = strippedScript.asm,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = sig,
+      flags = flags)
+    result must be(SignatureValidationSuccess)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -17,7 +17,8 @@ import org.bitcoins.core.protocol.transaction.*
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.{
   ScriptFlag,
-  ScriptVerifyDiscourageUpgradableWitnessProgram
+  ScriptVerifyDiscourageUpgradableWitnessProgram,
+  ScriptVerifyNullFail
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.{ScriptErrorSchnorrSigHashType, ScriptOk}
@@ -259,5 +260,30 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
     assert(
       hashT.isFailure,
       s"BIP341 requires taproot SIGHASH_SINGLE with no corresponding output to fail validation, got=$hashT")
+  }
+
+  it must "fail a tapscript OP_CHECKSIG immediately on an invalid non-empty signature" in {
+    // Finding (Medium): tapscript OP_CHECKSIG with an invalid non-empty
+    // signature pushes 0 and continues when NULLFAIL is not set
+    // (core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala:129-135,
+    // core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala:200-220,317-326).
+    // Correct behavior per BIP342 (and Core, which fails with
+    // SCRIPT_ERR_SCHNORR_SIG): script execution fails immediately.
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyNullFail)
+    // <x-only pubkey> OP_CHECKSIG OP_DROP OP_TRUE
+    // if an invalid signature only pushed 0, this script would succeed
+    val leafScriptBytes = ByteVector.fromValidHex("20") ++
+      privKey1.toXOnly.bytes ++ ByteVector.fromValidHex("ac7551")
+    // a well-formed 64-byte schnorr signature over a different message, so it
+    // is invalid for this input's sighash
+    val invalidSig =
+      privKey1.schnorrSignWithNonce(ByteVector.fill(32)(0x55.toByte),
+                                    noncePrivKey)
+    val (component, _) =
+      buildTapscriptSpend(leafScriptBytes, Vector(invalidSig.bytes), flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    assert(
+      result != ScriptOk,
+      s"An invalid non-empty tapscript signature must fail the script immediately, got=$result")
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -457,4 +457,51 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
     assert(!result.contains(ScriptConstant(sig.hex)),
            s"All occurrences of the signature must be removed, got=$result")
   }
+
+  it must "compute the BIP143 sighash with zero hashOutputs for a segwit v0 SIGHASH_SINGLE with an out of range input index" in {
+    // Finding (Low): a segwit v0 sighash with an out-of-range input index
+    // throws IndexOutOfBoundsException
+    // (core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala:236,398-401).
+    // Correct behavior per Core v30.3 (src/script/interpreter.cpp:1599-1638):
+    // the uint256-one error hash applies ONLY to the legacy (SigVersion::BASE)
+    // sighash. For segwit v0, Core computes a normal BIP143 sighash; when the
+    // input index has no corresponding output under SIGHASH_SINGLE, BIP143
+    // sets hashOutputs to 32 zero bytes instead of erroring. A fully
+    // independent preimage computation is impractical here because an
+    // out-of-range input index has no outpoint to commit to, so this test
+    // asserts the call completes without throwing and does not return the
+    // legacy uint256-one error hash.
+    val uint256OneErrorHash = DoubleSha256Digest.fromHex(
+      "0100000000000000000000000000000000000000000000000000000000000000")
+    val pubKey = privKey1.publicKey
+    val spk = P2WPKHWitnessSPKV0(pubKey)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk)
+    val witness = P2WPKHWitnessV0(pubKey)
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(
+        creditingTx,
+        EmptyScriptSignature,
+        outputIndex,
+        Some((witness, CurrencyUnits.zero)))
+    val component = WitnessTxSigComponentRaw(
+      spendingTx.asInstanceOf[WitnessTransaction],
+      UInt32.one, // out of range: the transaction has a single input
+      TransactionOutput(CurrencyUnits.zero, spk),
+      Policy.standardFlags
+    )
+    val hashT = Try(
+      TransactionSignatureSerializer.hashForSignature(
+        component,
+        HashType.sigHashSingle,
+        TaprootSerializationOptions.empty))
+    assert(
+      hashT.isSuccess,
+      s"A segwit v0 SIGHASH_SINGLE sighash with an out of range input index must be computed with hashOutputs=zero (BIP143), not throw, got=$hashT"
+    )
+    assert(
+      hashT != Success(uint256OneErrorHash),
+      s"The uint256-one error hash only applies to the legacy sighash algorithm, a segwit v0 sighash must not return it"
+    )
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -24,7 +24,8 @@ import org.bitcoins.core.script.flag.{
   ScriptFlagUtil,
   ScriptVerifyDiscourageUpgradableWitnessProgram,
   ScriptVerifyLowS,
-  ScriptVerifyNullFail
+  ScriptVerifyNullFail,
+  ScriptVerifyWitness
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.{
@@ -399,5 +400,44 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
       signature = nonDerSig,
       flags = Seq(ScriptVerifyLowS))
     result must be(SignatureValidationErrorNotStrictDerEncoding)
+  }
+
+  it must "not enforce WITNESS_UNEXPECTED when the ScriptVerifyWitness flag is not set" in {
+    // Finding (Low): WITNESS_UNEXPECTED is enforced even without the
+    // ScriptVerifyWitness flag
+    // (core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala:132,1434-1451).
+    // Correct behavior: Core only performs this check when
+    // SCRIPT_VERIFY_WITNESS is set.
+    val pubKey = privKey1.publicKey
+    val spk = P2PKHScriptPubKey(pubKey)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk, Some(amount))
+    val witness = P2WPKHWitnessV0(pubKey)
+    // placeholder transaction to compute the legacy sighash
+    val (placeholderTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyWitness)
+    val output = TransactionOutput(amount, spk)
+    val placeholderComponent =
+      BaseTxSigComponent(placeholderTx, inputIndex, output, flags)
+    val hash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    val sig = privKey1.sign(hash.bytes).appendHashType(HashType.sigHashAll)
+    val scriptSig = P2PKHScriptSignature(sig, pubKey)
+    // the spending transaction carries an unused witness for this input
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   scriptSig,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptOk)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -10,6 +10,7 @@ import org.bitcoins.core.crypto.{
   WitnessTxSigComponentRebuilt
 }
 import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.*
@@ -209,5 +210,54 @@ class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
       buildTapscriptSpend(leafScriptBytes, Vector(sig65), flags)
     val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
     result must be(ScriptErrorSchnorrSigHashType)
+  }
+
+  it must "fail validation for taproot SIGHASH_SINGLE with no corresponding output" in {
+    // Finding (Medium): taproot SIGHASH_SINGLE with a missing corresponding
+    // output returns the legacy uint256-one hash instead of failing validation
+    // (core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala:398-409).
+    // Correct behavior per BIP341: validation fails.
+    val taprootSPK = TaprootScriptPubKey(privKey1.toXOnly)
+    val amount1 = Satoshis(10000)
+    val amount2 = Satoshis(20000)
+    val (creditingTx1, _) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount1))
+    val (creditingTx2, _) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount2))
+    val outpoint1 = TransactionOutPoint(creditingTx1.txId, UInt32.zero)
+    val outpoint2 = TransactionOutPoint(creditingTx2.txId, UInt32.zero)
+    val inputs = Vector(
+      TransactionInput(outpoint1,
+                       EmptyScriptSignature,
+                       TransactionConstants.sequence),
+      TransactionInput(outpoint2,
+                       EmptyScriptSignature,
+                       TransactionConstants.sequence)
+    )
+    // only one output, so input index 1 has no corresponding output
+    val outputs =
+      Vector(TransactionOutput(Satoshis(5000), EmptyScriptPubKey))
+    val witness =
+      TransactionWitness(Vector(TaprootKeyPath.dummy, TaprootKeyPath.dummy))
+    val wtx = WitnessTransaction(
+      TransactionConstants.version,
+      inputs,
+      outputs,
+      TransactionConstants.lockTime,
+      witness
+    )
+    val outputMap = PreviousOutputMap(
+      Map(outpoint1 -> creditingTx1.outputs.head,
+          outpoint2 -> creditingTx2.outputs.head))
+    val component =
+      TaprootTxSigComponent(wtx, UInt32.one, outputMap, Policy.standardFlags)
+    val hashT = Try(
+      TransactionSignatureSerializer.hashForSignature(
+        component,
+        HashType.sigHashSingle,
+        TaprootSerializationOptions.empty))
+    assert(
+      hashT.isFailure,
+      s"BIP341 requires taproot SIGHASH_SINGLE with no corresponding output to fail validation, got=$hashT")
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/SignatureCheckingSecurityTest.scala
@@ -1,0 +1,71 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.crypto.TaprootTxSigComponent
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.script.*
+import org.bitcoins.core.protocol.transaction.*
+import org.bitcoins.core.script.PreExecutionScriptProgram
+import org.bitcoins.core.script.flag.ScriptVerifyDiscourageUpgradableWitnessProgram
+import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.result.ScriptOk
+import org.bitcoins.core.script.util.PreviousOutputMap
+import org.bitcoins.crypto.*
+import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
+import scodec.bits.ByteVector
+
+import scala.util.{Failure, Success, Try}
+
+/** Security reproduction tests for sighash and signature verification
+  * semantics. Each test asserts the CORRECT/SAFE behavior (Bitcoin Core and BIP
+  * parity), so every test here FAILS until the underlying bug is fixed. The
+  * failing tests are the fix checklist.
+  */
+class SignatureCheckingSecurityTest extends BitcoinSUnitTest {
+
+  behavior of "Signature checking security"
+
+  it must "not treat a v1 witness program with an invalid x coordinate as anyone-can-spend" in {
+    // Finding (High): a taproot (v1) 32-byte witness program whose x-only key
+    // is NOT a valid x coordinate is misclassified as an unassigned witness
+    // program, making it anyone-can-spend
+    // (core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala:1491-1499,
+    // core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala:586-604).
+    // Correct behavior: the program is recognized as taproot and validation fails.
+    // 0xffff...ff >= secp256k1 field size p, so it cannot be a valid x coordinate
+    val invalidProgram = ByteVector.fill(32)(0xff.toByte)
+    val spkBytes = ByteVector.fromValidHex("5120") ++ invalidProgram
+    Try(ScriptPubKey.fromAsmBytes(spkBytes)) match {
+      case Failure(_) =>
+        // rejecting the invalid taproot output key at parse time is acceptable
+        succeed
+      case Success(spk) =>
+        assert(
+          !spk.isInstanceOf[UnassignedWitnessScriptPubKey],
+          s"A v1 32-byte witness program must be classified as taproot, not as an unassigned witness program, got=$spk"
+        )
+        val amount = Satoshis(10000)
+        val (creditingTx, outputIndex) =
+          TransactionTestUtil.buildCreditingTransaction(spk, Some(amount))
+        val witness =
+          ScriptWitness(Vector(SchnorrDigitalSignature.dummy.bytes))
+        val (spendingTx, inputIndex) =
+          TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                       EmptyScriptSignature,
+                                                       outputIndex,
+                                                       Some((witness, amount)))
+        val flags = Policy.standardFlags.filterNot(
+          _ == ScriptVerifyDiscourageUpgradableWitnessProgram)
+        val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+        val outpoint = wtx.inputs(inputIndex.toInt).previousOutput
+        val outputMap =
+          PreviousOutputMap(Map(outpoint -> TransactionOutput(amount, spk)))
+        val component =
+          TaprootTxSigComponent(wtx, inputIndex, outputMap, flags)
+        val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+        assert(
+          result != ScriptOk,
+          s"Spending a v1 witness program with an invalid x-only key must fail validation, got=$result")
+    }
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/TlvParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TlvParsingSecurityTest.scala
@@ -1,0 +1,85 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.protocol.BigSizeUInt
+import org.bitcoins.core.protocol.tlv.{ContractDescriptorV0TLV, ValueIterator}
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
+
+import scala.util.Try
+
+/** Security reproduction tests for the DLC/TLV parser.
+  *
+  * Each test asserts the CORRECT/SAFE behavior. Tests that reproduce a bug FAIL
+  * until the bug is fixed. Do not modify these tests to match buggy behavior.
+  */
+class TlvParsingSecurityTest extends BitcoinSUnitTest {
+
+  "ValueIterator.takeBigSizePrefixedList" must
+    "not build a result vector proportional to an attacker-controlled count" in {
+      // Finding 1 (High): ValueIterator.scala:67-72 materializes
+      // `0.until(len.toInt).toVector` before any element is parsed.
+      // Correct behavior: the declared count is checked against the
+      // remaining bytes first, parsing fails, and no per-element work runs.
+      val declaredCount = 3000000L // millions: wasteful, but no OOM
+      val bytes =
+        BigSizeUInt(declaredCount).bytes ++ ByteVector(0x01, 0x02, 0x03, 0x04)
+      val iter = ValueIterator(bytes)
+
+      var elementParses = 0
+      val result = Try(iter.takeBigSizePrefixedList { () =>
+        elementParses += 1
+        ()
+      })
+
+      assert(
+        result.isFailure,
+        s"Parsing must fail: declared count $declaredCount exceeds the " +
+          s"remaining bytes, but parsing succeeded with " +
+          s"${result.toOption.map(_.length)} elements"
+      )
+      assert(
+        elementParses == 0,
+        s"The element parse function ran $elementParses times even though " +
+          s"the declared count $declaredCount exceeds the remaining bytes")
+    }
+
+  it must
+    "reject an oversized declared count before parsing any element" in {
+      // Finding 1 (High): ValueIterator.scala:67-72 starts parsing elements
+      // after an unvalidated attacker-controlled count.
+      // Correct behavior: parsing fails before the first element parse runs.
+      val declaredCount = 3000000L
+      val iter = ValueIterator(BigSizeUInt(declaredCount).bytes) // 0 elements
+
+      var elementParses = 0
+      val result = Try(iter.takeBigSizePrefixedList { () =>
+        elementParses += 1
+        iter.takeU16() // minimal element read, throws when out of bytes
+      })
+
+      assert(result.isFailure,
+             "Parsing must fail when the declared count exceeds the " +
+               "remaining bytes")
+      assert(
+        elementParses == 0,
+        s"Element parsing started ($elementParses parse attempts) before " +
+          s"the declared count $declaredCount was checked")
+    }
+
+  "ContractDescriptorV0TLV" must
+    "fail when the declared outcome count exceeds the value bytes" in {
+      // Finding 1 (High): caller at TLV.scala:1039 uses
+      // ValueIterator.takeBigSizePrefixedList (ValueIterator.scala:67-72).
+      // Correct behavior: a value that declares millions of outcomes but
+      // contains none must fail to parse instead of trusting the count.
+      val declaredCount = 3000000L
+      val value = BigSizeUInt(declaredCount).bytes // count only, 0 outcomes
+
+      val result = Try(ContractDescriptorV0TLV.fromTLVValue(value))
+
+      assert(
+        result.isFailure,
+        s"Parsing must fail: declared outcome count $declaredCount exceeds " +
+          s"the ${value.length} value bytes")
+    }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -1,0 +1,43 @@
+package org.bitcoins.core.security
+
+import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+/** Security reproduction tests for transaction, witness and CompactSizeUInt
+  * parsing. Each test asserts the CORRECT/SAFE behavior, so every test here
+  * FAILS until the corresponding bug is fixed. The failing tests are the fix
+  * checklist.
+  */
+class TransactionParsingSecurityTest extends BitcoinSUnitTest {
+
+  behavior of "Transaction parsing security"
+
+  it must "reject a malformed witness transaction instead of silently re-parsing it as a base transaction" in {
+    // Finding 1 (Medium): the catch-all fallback in Transaction.fromBytes
+    // (core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala:126-146)
+    // catches the witness parse failure and re-parses the SAME bytes as a base
+    // transaction, silently dropping the witness intent. Correct behavior:
+    // parsing fails.
+    // The bytes below have a valid marker/flag, 1 input and 1 output, but the
+    // witness section declares 2 stack items whose encoding consumes bytes
+    // into the locktime, leaving only 3 locktime bytes. WitnessTransaction
+    // parsing fails; the fallback then parses the bytes as a base tx
+    // (0 inputs, 1 garbage output).
+    val malformedWitnessTx =
+      "01000000" + // version
+        "0001" + // witness marker + flag
+        "01" + // 1 input
+        "0000000000000000000000000000000000000000000000000000000000000000" + // prev txid
+        "00000000" + // vout
+        "00" + // empty scriptSig
+        "ffffffff" + // sequence
+        "01" + // 1 output
+        "0000000000000000" + // 0 satoshis
+        "00" + // empty scriptPubKey
+        "02" + // witness: 2 stack items
+        "01" + "aa" + // item 1: len 1
+        // item 2 is parsed out of the locktime bytes below
+        "00000000" // locktime
+    Transaction.fromHexT(malformedWitnessTx).isFailure must be(true)
+  }
+}

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -1,9 +1,15 @@
 package org.bitcoins.core.security
 
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
+import org.bitcoins.core.protocol.transaction.{
+  Transaction,
+  TxUtil,
+  WitnessTransaction
+}
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
+import org.bitcoins.core.wallet.fee.{SatoshisPerByte, SatoshisPerVirtualByte}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.*
 
@@ -148,5 +154,22 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
         "00" + "02" + // marker 0, INVALID flag 2
         "0140d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f7420100000017160014a4b4ca48de0b3fffc15404a1acdc8dbaae226955ffffffff0100e1f5050000000017a9144a1154d50b03292b3024370901711946cb7cccc387024830450221008604ef8f6d8afa892dee0f31259b6ce02dd70c545cfcfed8148179971876c54a022076d771d6e91bed212783c9b06e0de600fab2d518fad6f15a2b191d7fbd262a3e0121039d25ab79f41f75ceaf882411fd41fa670a4c672c23ffaf0e361a969cde0692e800000000"
     WitnessTransaction.fromHexT(invalidFlagTx).isFailure must be(true)
+  }
+
+  it must "detect Long overflow in fee multiplication instead of silently wrapping" in {
+    // Finding 8 (Info): FeeUnit.* multiplies with plain Long arithmetic
+    // (core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala:15) and
+    // TxUtil.isValidFeeRange computes 40 * feeRate.toLong the same way
+    // (core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala:329),
+    // so extreme fee rates silently wrap to a small/negative fee.
+    // Correct behavior: the overflow is detected (ArithmeticException).
+    val hugeFeeRate = SatoshisPerByte(Satoshis(Long.MaxValue / 2))
+    an[ArithmeticException] must be thrownBy (hugeFeeRate * 4L)
+
+    val hugeFeeRatePerVByte =
+      SatoshisPerVirtualByte(Satoshis(Long.MaxValue / 40 + 1))
+    an[ArithmeticException] must be thrownBy TxUtil
+      .isValidFeeRange(Satoshis(100), Satoshis(50), hugeFeeRatePerVByte)
+      .get
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.security
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.*
 
 import scala.util.Try
 
@@ -93,5 +94,17 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
     Try(
       org.bitcoins.core.serializers.script.RawScriptPubKeyParser
         .read(truncatedScript)).isFailure must be(true)
+  }
+
+  it must "fail with a parse error (not a raw index exception) on very short transaction input" in {
+    // Finding 3 (Low): Transaction.fromBytes does unchecked bytes(4)/bytes(5)
+    // indexing
+    // (core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala:127-128),
+    // so input shorter than 6 bytes throws a raw IndexOutOfBoundsException.
+    // Correct behavior: a proper parse failure (e.g. IllegalArgumentException).
+    val ex = intercept[Exception] {
+      Transaction.fromBytes(hex"0100000000")
+    }
+    ex.isInstanceOf[IndexOutOfBoundsException] must be(false)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.security
 
+import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
@@ -106,5 +107,21 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
       Transaction.fromBytes(hex"0100000000")
     }
     ex.isInstanceOf[IndexOutOfBoundsException] must be(false)
+  }
+
+  it must "reject truncated and non-canonical CompactSizeUInt varints" in {
+    // Finding 4 (Low): CompactSizeUInt.parseCompactSizeUInt
+    // (core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala:122-136)
+    // silently pads truncated multi-byte varints and accepts non-canonical
+    // encodings. Correct behavior: both are rejected.
+
+    // 0xfd prefix requires 2 more bytes, only 1 is present
+    CompactSizeUInt.fromBytesT(hex"fd01").isFailure must be(true)
+
+    // non-canonical: value 1 must use the 1-byte form, not the 0xfd form
+    CompactSizeUInt.fromBytesT(hex"fd0100").isFailure must be(true)
+
+    // non-canonical: value 253 must use the 0xfd form, not the 0xfe form
+    CompactSizeUInt.fromBytesT(hex"fefd000000").isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -1,7 +1,10 @@
 package org.bitcoins.core.security
 
 import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+
+import scala.util.Try
 
 /** Security reproduction tests for transaction, witness and CompactSizeUInt
   * parsing. Each test asserts the CORRECT/SAFE behavior, so every test here
@@ -9,6 +12,25 @@ import org.bitcoins.testkitcore.util.BitcoinSUnitTest
   * checklist.
   */
 class TransactionParsingSecurityTest extends BitcoinSUnitTest {
+
+  // genesis block coinbase tx, same fixture as RawBlockSerializerTest
+  // https://en.bitcoin.it/wiki/Genesis_block
+  private val genesisCoinbaseTx =
+    "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4" +
+      "d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e2062726" +
+      "96e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678" +
+      "afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c3" +
+      "84df7ba0b8d578a4c702b6bf11d5fac00000000"
+
+  private val genesisBlockHeader =
+    "01000000" + // version
+      "0000000000000000000000000000000000000000000000000000000000000000" + // prev block hash
+      "3ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a" + // merkle root
+      "29ab5f49" + // timestamp
+      "ffff001d" + // nbits
+      "1dac2b7c" // nonce
+
+  private val genesisBlock = genesisBlockHeader + "01" + genesisCoinbaseTx
 
   behavior of "Transaction parsing security"
 
@@ -39,5 +61,37 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
         // item 2 is parsed out of the locktime bytes below
         "00000000" // locktime
     Transaction.fromHexT(malformedWitnessTx).isFailure must be(true)
+  }
+
+  it must "reject trailing garbage and truncated fields in transactions, blocks, and scripts" in {
+    // Finding 2 (Medium): parsers accept trailing garbage and silently
+    // zero-pad/clamp truncated fields:
+    // - BaseTransaction.fromBytes takes lockTime as lockTimeBytes.take(4) and
+    //   ignores bytes after it
+    //   (core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala:201-212);
+    //   WitnessTransaction.fromBytes has the same pattern at lines 330-334.
+    // - RawBlockSerializer.read discards the leftover bytes after the last tx
+    //   (core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializer.scala:17).
+    // - BitcoinScriptUtil.parseScript clamps a declared script length to the
+    //   available bytes instead of failing
+    //   (core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala:664-672).
+    // Correct behavior: all of these inputs are rejected.
+
+    // trailing garbage after a valid base transaction
+    Transaction.fromHexT(genesisCoinbaseTx + "deadbeef").isFailure must be(true)
+
+    // truncated locktime (last byte removed) must not be zero-padded
+    Transaction.fromHexT(genesisCoinbaseTx.dropRight(2)).isFailure must be(true)
+
+    // trailing garbage after a valid block
+    Try(RawBlockSerializer.read(genesisBlock + "deadbeef")).isFailure must be(
+      true)
+
+    // scriptPubKey declares 25 bytes but only 24 are present
+    val truncatedScript =
+      "1976a9143b75df7c44a47fed51374aef67bb7e7ae071b0a788"
+    Try(
+      org.bitcoins.core.serializers.script.RawScriptPubKeyParser
+        .read(truncatedScript)).isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -1,7 +1,7 @@
 package org.bitcoins.core.security
 
 import org.bitcoins.core.protocol.CompactSizeUInt
-import org.bitcoins.core.protocol.transaction.Transaction
+import org.bitcoins.core.protocol.transaction.{Transaction, WitnessTransaction}
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
 import org.bitcoins.core.serializers.script.RawScriptWitnessParser
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
@@ -134,5 +134,19 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
     // length larger than the remaining bytes is rejected.
     // 1 stack item, declared element length 2, only 1 byte available.
     Try(RawScriptWitnessParser.read(hex"0102ff")).isFailure must be(true)
+  }
+
+  it must "reject a witness transaction with a flag byte other than 1" in {
+    // Finding 6 (Info): WitnessTransaction.fromBytes only requires flag != 0
+    // (core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala:317-323).
+    // BIP144 defines the flag as 0x01 and Bitcoin Core rejects any other
+    // value. Correct behavior: reject.
+    // This is a valid witness tx (txid c586389e5e4b3acb9d6c8be1c19ae8ab2795397633176f5a6442a261bbdefc3a,
+    // same fixture as TransactionTest) with the flag byte changed 01 -> 02.
+    val invalidFlagTx =
+      "02000000" + // version
+        "00" + "02" + // marker 0, INVALID flag 2
+        "0140d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f7420100000017160014a4b4ca48de0b3fffc15404a1acdc8dbaae226955ffffffff0100e1f5050000000017a9144a1154d50b03292b3024370901711946cb7cccc387024830450221008604ef8f6d8afa892dee0f31259b6ce02dd70c545cfcfed8148179971876c54a022076d771d6e91bed212783c9b06e0de600fab2d518fad6f15a2b191d7fbd262a3e0121039d25ab79f41f75ceaf882411fd41fa670a4c672c23ffaf0e361a969cde0692e800000000"
+    WitnessTransaction.fromHexT(invalidFlagTx).isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/security/TransactionParsingSecurityTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.security
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.serializers.blockchain.RawBlockSerializer
+import org.bitcoins.core.serializers.script.RawScriptWitnessParser
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.*
 
@@ -123,5 +124,15 @@ class TransactionParsingSecurityTest extends BitcoinSUnitTest {
 
     // non-canonical: value 253 must use the 0xfd form, not the 0xfe form
     CompactSizeUInt.fromBytesT(hex"fefd000000").isFailure must be(true)
+  }
+
+  it must "reject witness stack elements whose declared length exceeds the remaining bytes" in {
+    // Finding 5 (Low): RawScriptWitnessParser.read clamps the stack element
+    // length with ByteVector.take instead of failing
+    // (core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala:30),
+    // silently mutating witness data. Correct behavior: a declared element
+    // length larger than the remaining bytes is rejected.
+    // 1 stack item, declared element length 2, only 1 byte available.
+    Try(RawScriptWitnessParser.read(hex"0102ff")).isFailure must be(true)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -402,6 +402,13 @@ object BloomFilter extends Factory[BloomFilter] {
       hashFuncs: UInt32,
       tweak: UInt32,
       flags: BloomFlag): BloomFilter = {
+    require(
+      filterSize.num.toLong <= maxSize.toLong,
+      s"Bloom filter size cannot be larger than $maxSize, got $filterSize")
+    require(
+      hashFuncs.toLong <= maxHashFuncs.toLong,
+      s"Bloom filter hashFuncs cannot be larger than $maxHashFuncs, got $hashFuncs"
+    )
     BloomFilterImpl(filterSize, data, hashFuncs, tweak, flags)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -242,19 +242,13 @@ trait TransactionSignatureChecker {
                                                       taprootOptions)
     ) match {
       case Failure(_) =>
-        nullFailCheckSchnorrSig(sigs = Vector(signature),
-                                result =
-                                  SignatureValidationErrorIncorrectSignatures,
-                                flags = flags)
+        tapscriptNullFailCheck(signature)
       case Success(hash) =>
         val result = pubKey.verify(hash, signature)
         if (result) {
           SignatureValidationSuccess
         } else {
-          nullFailCheckSchnorrSig(sigs = Vector(signature),
-                                  result =
-                                    SignatureValidationErrorIncorrectSignatures,
-                                  flags = flags)
+          tapscriptNullFailCheck(signature)
         }
     }
   }
@@ -354,15 +348,20 @@ trait TransactionSignatureChecker {
     } else result
   }
 
-  private def nullFailCheckSchnorrSig(
-      sigs: Seq[SchnorrDigitalSignature],
-      result: TransactionSignatureCheckerResult,
-      flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    val nullFailEnabled = ScriptFlagUtil.requireScriptVerifyNullFail(flags)
-    if (nullFailEnabled && !result.isValid && sigs.exists(_.bytes.nonEmpty)) {
-      // we need to check that all signatures were empty byte vectors, else this fails because of BIP146 and nullfail
+  /** BIP342 makes NULLFAIL mandatory for tapscript signature checks, regardless
+    * of whether the SCRIPT_VERIFY_NULLFAIL flag is set: an invalid non-empty
+    * signature must always fail the script immediately, not push false and
+    * continue like the legacy/segwit v0 OP_CHECKSIG "soft fail" behavior does.
+    * An empty signature is a valid way to signal "no signature provided" and
+    * continues to soft-fail (push false).
+    */
+  private def tapscriptNullFailCheck(
+      signature: SchnorrDigitalSignature): TransactionSignatureCheckerResult = {
+    if (signature.bytes.nonEmpty) {
       SignatureValidationErrorNullFail
-    } else result
+    } else {
+      SignatureValidationErrorIncorrectSignatures
+    }
   }
 
   /** Removes the hash type from the [[ECDigitalSignature]] */

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -281,18 +281,25 @@ trait TransactionSignatureChecker {
       sigs: List[ECDigitalSignature],
       pubKeys: List[ECPublicKeyBytes],
       flags: Seq[ScriptFlag],
-      requiredSigs: Long): TransactionSignatureCheckerResult = {
+      requiredSigs: Long,
+      originalSigs: List[ECDigitalSignature] = null)
+      : TransactionSignatureCheckerResult = {
     require(requiredSigs >= 0,
             s"requiredSigs cannot be negative, got $requiredSigs")
+    // NULLFAIL (BIP146) applies to every signature originally provided to
+    // OP_CHECKMULTISIG, not just the ones remaining at the point validation
+    // is determined to have failed -- a signature that matched earlier and
+    // was "consumed" (sigs.tail'd away) must still be checked.
+    val allSigs = if (originalSigs == null) sigs else originalSigs
     if (sigs.size > pubKeys.size) {
       // this is how bitcoin core treats this. If there are ever any more
       // signatures than public keys remaining we immediately return
       // false https://github.com/bitcoin/bitcoin/blob/8c1dbc5e9ddbafb77e60e8c4e6eb275a3a76ac12/src/script/interpreter.cpp#L943-L945
-      nullFailCheck(sigs, SignatureValidationErrorIncorrectSignatures, flags)
+      nullFailCheck(allSigs, SignatureValidationErrorIncorrectSignatures, flags)
     } else if (requiredSigs > sigs.size) {
       // for the case when we do not have enough sigs left to check to meet the required signature threshold
       // https://github.com/bitcoin/bitcoin/blob/8c1dbc5e9ddbafb77e60e8c4e6eb275a3a76ac12/src/script/interpreter.cpp#L990-L991
-      nullFailCheck(sigs, SignatureValidationErrorSignatureCount, flags)
+      nullFailCheck(allSigs, SignatureValidationErrorSignatureCount, flags)
     } else if (sigs.nonEmpty && pubKeys.nonEmpty) {
       val sig = sigs.head
       val pubKey = pubKeys.head
@@ -305,7 +312,8 @@ trait TransactionSignatureChecker {
                                   sigs.tail,
                                   pubKeys.tail,
                                   flags,
-                                  requiredSigs - 1)
+                                  requiredSigs - 1,
+                                  allSigs)
         case SignatureValidationErrorIncorrectSignatures |
             SignatureValidationErrorNullFail =>
           // notice we pattern match on 'SignatureValidationErrorNullFail' here, this is because
@@ -316,21 +324,22 @@ trait TransactionSignatureChecker {
                                   sigs,
                                   pubKeys.tail,
                                   flags,
-                                  requiredSigs)
+                                  requiredSigs,
+                                  allSigs)
         case x @ (SignatureValidationErrorNotStrictDerEncoding |
             SignatureValidationErrorSignatureCount |
             SignatureValidationErrorPubKeyEncoding |
             SignatureValidationErrorHighSValue |
             SignatureValidationErrorHashType |
             SignatureValidationErrorWitnessPubKeyType) =>
-          nullFailCheck(sigs, x, flags)
+          nullFailCheck(allSigs, x, flags)
       }
     } else if (sigs.isEmpty) {
       // means that we have checked all of the sigs against the public keys
       // validation succeeds
       SignatureValidationSuccess
     } else
-      nullFailCheck(sigs, SignatureValidationErrorIncorrectSignatures, flags)
+      nullFailCheck(allSigs, SignatureValidationErrorIncorrectSignatures, flags)
 
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -141,7 +141,8 @@ trait TransactionSignatureChecker {
         ) {
           SignatureValidationErrorNotStrictDerEncoding
         } else if (
-          ScriptFlagUtil.requireLowSValue(flags) && !DERSignatureUtil
+          ScriptFlagUtil.requireLowSValue(
+            flags) && signature.bytes.nonEmpty && !DERSignatureUtil
             .isLowS(signature)
         ) {
           SignatureValidationErrorHighSValue

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -11,6 +11,7 @@ import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 2/16/16. Responsible for checking digital signatures on
   * inputs against their respective public keys
@@ -80,12 +81,22 @@ trait TransactionSignatureChecker {
     if (!validHashType) {
       ScriptErrorSchnorrSigHashType
     } else {
-      val hash =
+      // hashForSignature throws for a taproot SIGHASH_SINGLE with no
+      // corresponding output (BIP341 requires that to fail validation,
+      // unlike the legacy sighash algorithm's placeholder error hash) --
+      // that must surface as a clean script failure here, not an uncaught
+      // exception escaping the interpreter
+      Try(
         TransactionSignatureSerializer.hashForSignature(txSigComponent,
                                                         hashType,
                                                         taprootOptions)
-      val result = pubKey.verify(hash, schnorrSignature)
-      if (result) ScriptOk else ScriptErrorSchnorrSig
+      ) match {
+        case Success(hash) =>
+          val result = pubKey.verify(hash, schnorrSignature)
+          if (result) ScriptOk else ScriptErrorSchnorrSig
+        case Failure(_) =>
+          ScriptErrorSchnorrSig
+      }
     }
   }
 
@@ -220,18 +231,31 @@ trait TransactionSignatureChecker {
       hashType: HashType,
       taprootOptions: TaprootSerializationOptions,
       flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    val hash =
+    // hashForSignature throws for a taproot SIGHASH_SINGLE with no
+    // corresponding output (BIP341 requires that to fail validation,
+    // unlike the legacy sighash algorithm's placeholder error hash) --
+    // that must surface as a clean signature check failure here, not an
+    // uncaught exception escaping the interpreter
+    Try(
       TransactionSignatureSerializer.hashForSignature(txSignatureComponent,
                                                       hashType,
                                                       taprootOptions)
-    val result = pubKey.verify(hash, signature)
-    if (result) {
-      SignatureValidationSuccess
-    } else {
-      nullFailCheckSchnorrSig(sigs = Vector(signature),
-                              result =
-                                SignatureValidationErrorIncorrectSignatures,
-                              flags = flags)
+    ) match {
+      case Failure(_) =>
+        nullFailCheckSchnorrSig(sigs = Vector(signature),
+                                result =
+                                  SignatureValidationErrorIncorrectSignatures,
+                                flags = flags)
+      case Success(hash) =>
+        val result = pubKey.verify(hash, signature)
+        if (result) {
+          SignatureValidationSuccess
+        } else {
+          nullFailCheckSchnorrSig(sigs = Vector(signature),
+                                  result =
+                                    SignatureValidationErrorIncorrectSignatures,
+                                  flags = flags)
+        }
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -158,6 +158,22 @@ trait TransactionSignatureChecker {
             ByteVector(0.toByte, 0.toByte, 0.toByte, hashTypeByte))
           val spk = ScriptPubKey.fromAsm(sigsRemovedScript)
           val hashForSignature = txSignatureComponent match {
+            case w: WitnessTxSigComponentRaw =>
+              // BIP143 commits to the scriptCode after the last executed
+              // OP_CODESEPARATOR (sigsRemovedScript/spk above), not the raw
+              // witness script -- rebuild the component with the stripped
+              // script so the sighash actually commits to it, mirroring the
+              // BaseTxSigComponent/WitnessTxSigComponentRebuilt cases below
+              val sigsRemovedTxSigComponent = WitnessTxSigComponentRebuilt(
+                wtx = w.transaction,
+                inputIndex = w.inputIndex,
+                output = TransactionOutput(w.fundingOutput.value, spk),
+                witScriptPubKey = w.scriptPubKey,
+                flags = w.flags)
+              TransactionSignatureSerializer.hashForSignature(
+                sigsRemovedTxSigComponent,
+                hashType,
+                TaprootSerializationOptions.empty)
             case w: WitnessTxSigComponent =>
               TransactionSignatureSerializer.hashForSignature(
                 w,

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -404,6 +404,18 @@ sealed abstract class TransactionSignatureSerializer {
       (hashType.isInstanceOf[SIGHASH_SINGLE] || hashType
         .isInstanceOf[SIGHASH_SINGLE_ANYONECANPAY]) &&
       inputIndex >= UInt32(spendingTransaction.outputs.size) &&
+      txSigComponent.sigVersion.isInstanceOf[SigVersionTaproot]
+    ) {
+      // BIP341 requires taproot SIGHASH_SINGLE with no corresponding output
+      // to fail validation outright, unlike the legacy (SigVersionBase)
+      // sighash algorithm's uint256-one placeholder error hash
+      throw new IllegalArgumentException(
+        "BIP341 requires taproot SIGHASH_SINGLE with no corresponding " +
+          s"output to fail validation, inputIndex=$inputIndex")
+    } else if (
+      (hashType.isInstanceOf[SIGHASH_SINGLE] || hashType
+        .isInstanceOf[SIGHASH_SINGLE_ANYONECANPAY]) &&
+      inputIndex >= UInt32(spendingTransaction.outputs.size) &&
       txSigComponent.sigVersion != SigVersionWitnessV0
     ) {
       errorHash

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -13,6 +13,8 @@ import org.bitcoins.core.wallet.utxo.{InputInfo, InputSigningInfo}
 import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
+import scala.util.Try
+
 /** Created by chris on 2/16/16. Wrapper that serializes like Transaction, but
   * with the modifications required for the signature hash done
   * [[https://github.com/bitcoin/bitcoin/blob/93c85d458ac3e2c496c1a053e1f5925f55e29100/src/script/interpreter.cpp#L1016-L1105]]
@@ -41,9 +43,16 @@ sealed abstract class TransactionSignatureSerializer {
     val spendingTransaction = txSigComponent.transaction
     val inputIndex = txSigComponent.inputIndex
     val output = txSigComponent.fundingOutput
-    val script = BitcoinScriptUtil.calculateScriptForSigning(
-      txSigComponent,
-      output.scriptPubKey.asm)
+    // for a witness sig version, rebuilding the scriptCode reads the witness
+    // stack at inputIndex, which throws for an out-of-range input index (a
+    // scenario the SigVersionWitnessV0 branch below is otherwise built to
+    // tolerate, unlike the legacy sighash algorithm's errorHash short
+    // circuit) -- fall back to the funding output's raw asm rather than
+    // letting that escape as an uncaught exception
+    val script = Try(
+      BitcoinScriptUtil.calculateScriptForSigning(txSigComponent,
+                                                  output.scriptPubKey.asm)
+    ).getOrElse(output.scriptPubKey.asm)
 
     txSigComponent match {
       case _: BaseTxSigComponent | _: WitnessTxSigComponentRaw |
@@ -233,7 +242,17 @@ sealed abstract class TransactionSignatureSerializer {
 
         val scriptBytes = BytesUtil.toByteVector(script)
 
-        val i = spendingTransaction.inputs(inputIndexInt)
+        // an out-of-range input index isn't guarded against for
+        // SigVersionWitnessV0 the way it is for the legacy sighash
+        // algorithm above (which returns errorHash instead) -- BIP143 does
+        // not define a placeholder outpoint/sequence for a nonexistent
+        // input, so fall back to empty/zero values rather than throwing
+        val i = spendingTransaction.inputs
+          .lift(inputIndexInt)
+          .getOrElse(
+            TransactionInput(EmptyTransactionOutPoint,
+                             EmptyScriptSignature,
+                             UInt32.zero))
         val serializationForSig: ByteVector =
           spendingTransaction.version.bytes.reverse ++ outPointHash ++ sequenceHash ++
             i.previousOutput.bytes ++ CompactSizeUInt.calc(scriptBytes).bytes ++

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1671,8 +1671,11 @@ object NetworkPayload {
       networkHeader: NetworkHeader,
       payloadBytes: ByteVector): NetworkPayload = {
     // the commandName in the network header tells us what payload type this is
-    val deserializer: ByteVector => NetworkPayload = readers(
-      networkHeader.commandName)
+    val deserializer: ByteVector => NetworkPayload = readers.getOrElse(
+      networkHeader.commandName,
+      throw new IllegalArgumentException(
+        s"Unknown command name for network payload: ${networkHeader.commandName}")
+    )
     deserializer(payloadBytes)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -810,7 +810,10 @@ sealed trait FeeFilterMessage extends ControlPayload {
   def feeRate: SatoshisPerKiloByte
 
   def satPerByte: SatoshisPerByte = {
-    feeRate.toSatPerByte
+    // a peer-supplied fee rate is not guaranteed to be evenly divisible by
+    // 1000, so round rather than demanding exact divisibility (which would
+    // throw for a perfectly valid, just non-round, feerate)
+    feeRate.toSatPerByteRounded
   }
 
   override def commandName: String = NetworkPayload.feeFilterCommandName

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -267,8 +267,12 @@ sealed abstract class Bech32mAddress extends BitcoinAddress {
 
   override def isStandard: Boolean = {
     scriptPubKey match {
-      case _: WitnessScriptPubKeyV0         => false // shouldn't be possible
-      case _: TaprootScriptPubKey           => true
+      case _: WitnessScriptPubKeyV0     => false // shouldn't be possible
+      case taproot: TaprootScriptPubKey =>
+        // a v1 32-byte witness program whose 32 bytes are not a valid x-only
+        // coordinate is structurally taproot but not standard -- Bitcoin
+        // Core's IsWitnessStandard requires a valid taproot output key
+        Try(taproot.pubKey).isSuccess
       case _: UnassignedWitnessScriptPubKey => false
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
@@ -126,13 +126,38 @@ object CompactSizeUInt extends Factory[CompactSizeUInt] {
     if (firstByte < 253)
       CompactSizeUInt(UInt64(firstByte), 1)
     // 16 bit number
-    else if (firstByte.toInt == 253)
-      CompactSizeUInt(UInt64(bytes.slice(1, 3).reverse), 3)
+    else if (firstByte.toInt == 253) {
+      require(
+        bytes.length >= 3,
+        s"Not enough bytes to parse a 16 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 3).reverse)
+      require(
+        num.toBigInt >= 253,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xfd prefix")
+      CompactSizeUInt(num, 3)
+    }
     // 32 bit number
-    else if (firstByte.toInt == 254)
-      CompactSizeUInt(UInt64(bytes.slice(1, 5).reverse), 5)
+    else if (firstByte.toInt == 254) {
+      require(
+        bytes.length >= 5,
+        s"Not enough bytes to parse a 32 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 5).reverse)
+      require(
+        num.toBigInt > 0xffffL,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xfe prefix")
+      CompactSizeUInt(num, 5)
+    }
     // 64 bit number
-    else CompactSizeUInt(UInt64(bytes.slice(1, 9).reverse), 9)
+    else {
+      require(
+        bytes.length >= 9,
+        s"Not enough bytes to parse a 64 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 9).reverse)
+      require(
+        num.toBigInt > UInt32.max.toBigInt,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xff prefix")
+      CompactSizeUInt(num, 9)
+    }
   }
 
   def parse(bytes: ByteVector): CompactSizeUInt = parseCompactSizeUInt(bytes)

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -42,7 +43,15 @@ sealed abstract class Block extends NetworkElement {
     * Block weight is defined as Base size * 3 + Total size
     * [[https://github.com/bitcoin/bitcoin/blob/7490ae8b699d2955b665cf849d86ff5bb5245c28/src/primitives/block.cpp#L35]]
     */
-  def blockWeight: Long = transactions.map(_.weight).sum
+  def blockWeight: Long = {
+    // the 80-byte header and the txCount varint carry no witness data, so
+    // they contribute at the full WITNESS_SCALE_FACTOR the same way
+    // Bitcoin Core's GetBlockWeight includes the whole serialized block
+    // (not just the transactions) in both its base-size and total-size terms
+    val headerAndTxCountWeight =
+      (blockHeader.bytes.size + txCount.bytes.size) * Consensus.weightScalar
+    headerAndTxCountWeight + transactions.map(_.weight).sum
+  }
 }
 
 /** Companion object for creating Blocks

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -205,7 +205,7 @@ object BlockHeader extends Factory[BlockHeader] {
   def getBlockProof(header: BlockHeader): BigInt = {
     val target = NumberUtil.targetExpansion(header.nBits)
 
-    if (target.isNegative || target.isOverflow) {
+    if (target.isNegative || target.isOverflow || target.target == BigInt(0)) {
       BigInt(0)
     } else {
       (BigInt(1) << 256) / (target.target + BigInt(1))

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util._
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
@@ -274,10 +275,35 @@ object PartialMerkleTree {
     *   the bits used indicate the structure of the partial merkle tree
     * @return
     */
+  /** A minimal valid serialized transaction is at least 60 bytes, matching
+    * Bitcoin Core's MIN_TRANSACTION_WEIGHT (merkleblock.cpp), used below to cap
+    * the declared transaction count to a value that could plausibly fit in a
+    * block.
+    */
+  private val minTransactionWeight: Long = 60
+
   def apply(
       transactionCount: UInt32,
       hashes: Vector[DoubleSha256Digest],
       bits: BitVector): PartialMerkleTree = {
+    // sanity checks mirroring Bitcoin Core's CPartialMerkleTree::ExtractMatches
+    // (merkleblock.cpp) -- reject degenerate/absurd inputs cleanly before
+    // attempting to reconstruct the tree, rather than crashing or silently
+    // accepting them
+    require(transactionCount != UInt32.zero,
+            "PartialMerkleTree must have at least 1 transaction")
+    require(
+      transactionCount.toLong <= Consensus.maxBlockWeight / minTransactionWeight,
+      s"PartialMerkleTree transaction count is too high, got=$transactionCount"
+    )
+    require(
+      hashes.size <= transactionCount.toInt,
+      s"Cannot have more hashes than transactions, got ${hashes.size} hashes for $transactionCount transactions"
+    )
+    require(
+      bits.size >= hashes.size,
+      s"Must have at least one bit per hash, got ${bits.size} bits for ${hashes.size} hashes"
+    )
     val tree = reconstruct(transactionCount.toInt, hashes, bits)
     PartialMerkleTree(tree, transactionCount, bits, hashes)
   }
@@ -320,8 +346,14 @@ object PartialMerkleTree {
         pos: Int): (BinaryTreeDoubleSha256Digest,
                     Vector[DoubleSha256Digest],
                     BitVector) = {
+      require(
+        remainingMatches.nonEmpty,
+        "Traversal ran out of bits while reconstructing the partial merkle tree")
       if (height == maxHeight) {
         // means we have a txid node
+        require(
+          remainingHashes.nonEmpty,
+          "Traversal ran out of hashes while reconstructing the partial merkle tree")
         (LeafDoubleSha256Digest(remainingHashes.head),
          remainingHashes.tail,
          remainingMatches.tail)
@@ -361,6 +393,9 @@ object PartialMerkleTree {
           val node = NodeDoubleSha256Digest(nodeHash, leftNode, rightNode)
           (node, rightRemainingHashes, rightRemainingBits)
         } else {
+          require(
+            remainingHashes.nonEmpty,
+            "Traversal ran out of hashes while reconstructing the partial merkle tree")
           (LeafDoubleSha256Digest(remainingHashes.head),
            remainingHashes.tail,
            remainingMatches.tail)

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -7,7 +7,6 @@ import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
 import scodec.bits.BitVector
 
 import scala.annotation.tailrec
-import scala.math._
 
 /** Created by chris on 8/7/16. Represents a subset of known txids inside of a
   * [[org.bitcoins.core.protocol.blockchain.Block Block]] in a way that allows
@@ -421,10 +420,20 @@ object PartialMerkleTree {
   }
 
   /** Calculates the maximum height for a binary tree with the number of
-    * transactions specified
+    * transactions specified. Mirrors Bitcoin Core's integer-exact loop (`while
+    * (CalcTreeWidth(nHeight) > 1) nHeight++;` in merkleblock.cpp) rather than a
+    * floating point log2, which can disagree with Core at exact powers of two
+    * due to double-precision rounding (e.g. computing 30 instead of 29 for n =
+    * 2^29).
     */
-  def calcMaxHeight(numTransactions: Int): Int =
-    Math.ceil((log(numTransactions) / log(2))).toInt
+  def calcMaxHeight(numTransactions: Long): Int = {
+    @tailrec
+    def loop(height: Int): Int = {
+      val width = (numTransactions + (1L << height) - 1) >> height
+      if (width > 1) loop(height + 1) else height
+    }
+    loop(0)
+  }
 
   /** Determines if the right sub tree can exists inside of the partial merkle
     * tree This function should only be used to determine if a right sub tree

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1449,13 +1449,20 @@ case class TaprootScriptPubKey(override val asm: Vector[ScriptToken])
   override def witnessProgram: Seq[ScriptToken] = asm.tail.tail
   override val scriptType: ScriptType = ScriptType.WITNESS_V1_TAPROOT
 
-  val pubKey: XOnlyPubKey = {
+  // lazy: a v1 32-byte witness program is structurally taproot even when its
+  // 32 bytes are not a valid x-only coordinate (see isValidAsm above); parsing
+  // untrusted/on-chain data as a TaprootScriptPubKey must not throw merely by
+  // constructing it, only spending it should fail
+  lazy val pubKey: XOnlyPubKey = {
     require(asm(2).bytes.length == 32,
             s"pubKeyBytes must be 32 bytes in length, got=${asm(2).byteSize}")
     XOnlyPubKey.fromBytes(asm(2).bytes)
   }
 
-  override def toString = s"${ScriptDescriptorType.TR.toString}(${pubKey.hex})"
+  override def toString = {
+    val pubKeyStr = Try(pubKey.hex).getOrElse(s"invalid:${asm(2).hex}")
+    s"${ScriptDescriptorType.TR.toString}($pubKeyStr)"
+  }
 }
 
 object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
@@ -1490,12 +1497,17 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
 
   override def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
     val asmBytes = BytesUtil.toByteVector(asm)
+    // Classification is purely structural (witness v1, 32-byte program),
+    // matching Bitcoin Core: a v1 32-byte witness program is unambiguously
+    // Taproot regardless of whether its 32 bytes form a valid x-only
+    // coordinate. Requiring cryptographic validity here would misclassify
+    // an invalid-x-coordinate taproot output as an unassigned (future,
+    // anyone-can-spend) witness version instead of a taproot output that
+    // must fail validation.
     asm.length == 3 &&
     asm.headOption.contains(OP_1) &&
     asmBytes.size == 34 &&
-    WitnessScriptPubKey.isValidAsm(asm) &&
-    // have to make sure we have a valid xonly pubkey, not just 32 bytes
-    XOnlyPubKey.fromBytesT(asm(2).bytes).isSuccess
+    WitnessScriptPubKey.isValidAsm(asm)
   }
 
   /** Computes a [[TaprootScriptPubKey]] from a given internal key with no

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/ValueIterator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/ValueIterator.scala
@@ -66,9 +66,21 @@ case class ValueIterator(value: ByteVector) {
 
   def takeBigSizePrefixedList[E](takeFunc: () => E): Vector[E] = {
     val len = takeBigSize()
-    0.until(len.toInt).toVector.map { _ =>
-      takeFunc()
+    val declaredCount = len.toInt
+    // every element consumes at least one byte, so a declared count greater
+    // than the remaining bytes can never be satisfied -- reject it before
+    // allocating anything proportional to the (attacker-controlled) count
+    require(
+      declaredCount <= current.length,
+      s"Declared count $declaredCount exceeds the ${current.length} remaining bytes"
+    )
+    val builder = Vector.newBuilder[E]
+    var i = 0
+    while (i < declaredCount) {
+      builder += takeFunc()
+      i += 1
     }
+    builder.result()
   }
 
   def takeU16(): UInt16 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -132,11 +132,37 @@ object Transaction extends Factory[Transaction] {
         // these transactions will not have a script witness associated with them making them invalid
         // witness transactions (you need to have a witness to be considered a witness tx)
         // see: https://github.com/bitcoin-s/bitcoin-s/blob/01d89df1b7c6bc4b1594406d54d5e6019705c654/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala#L88
-        try {
-          WitnessTransaction.fromBytes(bytes)
-        } catch {
-          case scala.util.control.NonFatal(_) =>
+        //
+        // This mirrors how Bitcoin Core actually disambiguates the
+        // marker/flag bytes: Core reads the input vector first, and only
+        // reinterprets the following byte as a witness flag if that read
+        // comes back empty (see UnserializeTransaction in
+        // primitives/transaction.h). So the fallback to reinterpreting as a
+        // base transaction is only ever considered when the witness-format
+        // input vector itself came back empty; once a non-empty input
+        // vector has parsed successfully, the bytes are unambiguously meant
+        // to be a witness transaction, and any later failure (e.g. a
+        // malformed witness stack or truncated locktime) is a genuine parse
+        // error that must not be silently reinterpreted as an unrelated
+        // base transaction.
+        scala.util.Try(WitnessTransaction.parseInputsAndOutputs(bytes)) match {
+          case scala.util.Failure(_) =>
             BaseTransaction.fromBytes(bytes)
+          case scala.util.Success((version, inputs, outputs, witnessBytes))
+              if inputs.isEmpty =>
+            scala.util
+              .Try {
+                WitnessTransaction.fromParsedInputsAndOutputs(version,
+                                                              inputs,
+                                                              outputs,
+                                                              witnessBytes)
+              }
+              .getOrElse(BaseTransaction.fromBytes(bytes))
+          case scala.util.Success((version, inputs, outputs, witnessBytes)) =>
+            WitnessTransaction.fromParsedInputsAndOutputs(version,
+                                                          inputs,
+                                                          outputs,
+                                                          witnessBytes)
         }
       } else {
         BaseTransaction.fromBytes(bytes)
@@ -311,6 +337,27 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
     * [[https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/primitives/transaction.h#L244-L251]]
     */
   override def fromBytes(bytes: ByteVector): WitnessTransaction = {
+    val (version, inputs, outputs, witnessBytes) =
+      parseInputsAndOutputs(bytes)
+    fromParsedInputsAndOutputs(version, inputs, outputs, witnessBytes)
+  }
+
+  /** Parses the version and BIP141 marker/flag/input-vector/output-vector
+    * portion of a witness-serialized transaction, without parsing the witness
+    * stacks or locktime that follow.
+    *
+    * Exposed separately (rather than folded into [[fromBytes]]) so
+    * [[Transaction.fromBytes]] can distinguish a failure here -- which can mean
+    * the bytes were never really witness-formatted to begin with, see the
+    * marker/flag ambiguity noted there -- from a failure while parsing the
+    * witness/locktime section of bytes that unambiguously did parse as a
+    * witness transaction's input/output vectors.
+    */
+  private[transaction] def parseInputsAndOutputs(
+      bytes: ByteVector): (Int32,
+                           Vector[TransactionInput],
+                           Vector[TransactionOutput],
+                           ByteVector) = {
     val versionBytes = bytes.take(4)
     val version = Int32(versionBytes.reverse)
     val marker = bytes(4)
@@ -326,6 +373,18 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)
     val (outputs, witnessBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(outputBytes, TransactionOutput)
+    (version, inputs, outputs, witnessBytes)
+  }
+
+  /** Parses the witness stacks and locktime following an already-parsed
+    * input/output vector pair (see [[parseInputsAndOutputs]]) and builds the
+    * resulting [[WitnessTransaction]].
+    */
+  private[transaction] def fromParsedInputsAndOutputs(
+      version: Int32,
+      inputs: Vector[TransactionInput],
+      outputs: Vector[TransactionOutput],
+      witnessBytes: ByteVector): WitnessTransaction = {
     val witness = TransactionWitness(witnessBytes, inputs.size)
     val lockTimeBytes = witnessBytes.drop(witness.byteSize)
     require(

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -171,6 +171,27 @@ object Transaction extends Factory[Transaction] {
     tx
   }
 
+  /** Note: unlike [[fromBytes]], this requires `hex` to decode to EXACTLY one
+    * transaction with no trailing bytes left over. [[fromBytes]] itself cannot
+    * enforce that: it also serves as the per-element parser when deserializing
+    * a sequence of transactions sharing one buffer (e.g. a block's transaction
+    * list in RawBlockSerializer), where bytes trailing a single parsed
+    * transaction are the start of the next one, not garbage. A hex string, by
+    * contrast, is always meant to represent exactly one transaction --
+    * mirroring Bitcoin Core's own split between its stream-based tx
+    * deserializer (never checks for leftover bytes) and DecodeHexTx (which
+    * explicitly checks the stream is empty afterward).
+    */
+  override def fromHex(hex: String): Transaction = {
+    val bytes = org.bitcoins.crypto.CryptoBytesUtil.decodeHex(hex)
+    val tx = fromBytes(bytes)
+    require(
+      tx.bytes.length == bytes.length,
+      s"${bytes.length - tx.bytes.length} trailing bytes after a complete transaction"
+    )
+    tx
+  }
+
   /** This allows us to accurately type transaction input's
     * [[org.bitcoins.core.protocol.script.ScriptSignature]] as we have the
     * corresponding [[org.bitcoins.core.protocol.script.ScriptPubKey]] the input
@@ -232,6 +253,9 @@ object BaseTransaction extends Factory[BaseTransaction] {
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)
     val (outputs, lockTimeBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(outputBytes, TransactionOutput)
+    require(
+      lockTimeBytes.length >= 4,
+      s"Must have at least 4 bytes for locktime, got=${lockTimeBytes.length}")
     val lockTime = UInt32(lockTimeBytes.take(4).reverse)
 
     BaseTransaction(version, inputs, outputs, lockTime)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -390,8 +390,8 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
       "Incorrect marker for witness transaction, the marker MUST be 0 for the marker according to BIP141, got: " + marker)
     val flag = bytes(5)
     require(
-      flag.toInt != 0,
-      "Incorrect flag for witness transaction, this must NOT be 0 according to BIP141, got: " + flag)
+      flag == WitnessTransaction.flag,
+      "Incorrect flag for witness transaction, BIP141 defines the flag as exactly 1, got: " + flag)
     val txInputBytes = bytes.slice(6, bytes.size)
     val (inputs, outputBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -124,7 +124,7 @@ object Transaction extends Factory[Transaction] {
     // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-id
     val tx = {
       if (
-        bytes(4) == WitnessTransaction.marker && bytes(
+        bytes.length > 5 && bytes(4) == WitnessTransaction.marker && bytes(
           5) == WitnessTransaction.flag
       ) {
         // this throw/catch is _still_ necessary for the case where we have unsigned base transactions

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -326,7 +326,7 @@ object TxUtil {
       // See this link for more info on variance in size on ECDigitalSignatures
       // https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 
-      val acceptableVariance = 40 * feeRate.toLong
+      val acceptableVariance = Math.multiplyExact(40L, feeRate.toLong)
       val min = Satoshis(-acceptableVariance)
       val max = Satoshis(acceptableVariance)
       val difference = estimatedFee - actualFee

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.control.ControlOperations
 import org.bitcoins.core.script.crypto.CryptoOperation
 import org.bitcoins.core.script.locktime.LocktimeOperation
-import org.bitcoins.core.script.reserved.ReservedOperation
+import org.bitcoins.core.script.reserved.{OpSuccessOperation, ReservedOperation}
 import org.bitcoins.core.script.splice.SpliceOperation
 import org.bitcoins.core.script.stack.StackOperation
 import org.bitcoins.core.util.BytesUtil
@@ -94,7 +94,8 @@ object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
       ArithmeticOperation.operations ++
       BytesToPushOntoStack.operations ++
       SpliceOperation.operations ++
-      ScriptNumberOperation.operations
+      ScriptNumberOperation.operations ++
+      OpSuccessOperation.operations
   }
 
   /** This contains duplicate operations There is an optimization here by moving

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -303,7 +303,12 @@ sealed abstract class ArithmeticInterpreter {
         ) {
           program.failExecution(ScriptErrorUnknownError)
         } else {
-          val interpretedNumber = ScriptNumber(ScriptNumberUtil.toLong(s.hex))
+          // preserve the original byte-level encoding (as the binary
+          // arithmetic operations below already do) rather than
+          // re-deriving a ScriptNumber from its Long value, which would
+          // silently minimize a non-minimal operand's size and bypass the
+          // isLargerThan4Bytes consensus check that runs next
+          val interpretedNumber = ScriptNumber(s.hex)
           val newProgram =
             program.updateStack(interpretedNumber :: program.stack.tail)
           performUnaryArithmeticOperation(newProgram, op)

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.script.{
 import org.bitcoins.core.util.BitcoinScriptUtil
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 1/25/16.
   */
@@ -263,6 +264,17 @@ sealed abstract class ArithmeticInterpreter {
   private def isLargerThan4Bytes(scriptNumber: ScriptNumber): Boolean =
     scriptNumber.bytes.size > 4
 
+  /** Safely interprets a ScriptConstant as a ScriptNumber. ScriptNumber
+    * construction eagerly derives a Long value from the operand's bytes
+    * (ScriptNumberUtil.toLong), which throws NumberFormatException for a
+    * non-minimal operand wider than 8 bytes -- an untrusted, attacker
+    * controlled scriptSig/witness value. Bitcoin Core's CScriptNum constructor
+    * rejects such operands with a caught scriptnum_error instead of letting an
+    * unrepresentable value escape as a crash, so we do the same here.
+    */
+  private def interpretNumber(constant: ScriptConstant): Try[ScriptNumber] =
+    Try(ScriptNumber(constant.hex))
+
   /** Performs the given arithmetic operation on the stack head
     * @param program
     *   the program whose stack top is used as an argument for the arithmetic
@@ -308,10 +320,14 @@ sealed abstract class ArithmeticInterpreter {
           // re-deriving a ScriptNumber from its Long value, which would
           // silently minimize a non-minimal operand's size and bypass the
           // isLargerThan4Bytes consensus check that runs next
-          val interpretedNumber = ScriptNumber(s.hex)
-          val newProgram =
-            program.updateStack(interpretedNumber :: program.stack.tail)
-          performUnaryArithmeticOperation(newProgram, op)
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              val newProgram =
+                program.updateStack(interpretedNumber :: program.stack.tail)
+              performUnaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         }
       case Some(_: ScriptToken) =>
         // pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
@@ -359,22 +375,34 @@ sealed abstract class ArithmeticInterpreter {
           }
         case (x: ScriptConstant, _: ScriptNumber) =>
           // interpret x as a number
-          val interpretedNumber = ScriptNumber(x.hex)
-          val newProgram =
-            program.updateStack(interpretedNumber :: program.stack.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          interpretNumber(x) match {
+            case Success(interpretedNumber) =>
+              val newProgram =
+                program.updateStack(interpretedNumber :: program.stack.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (x: ScriptNumber, y: ScriptConstant) =>
-          val interpretedNumber = ScriptNumber(y.hex)
-          val newProgram =
-            program.updateStack(x :: interpretedNumber :: program.stack.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          interpretNumber(y) match {
+            case Success(interpretedNumber) =>
+              val newProgram = program.updateStack(
+                x :: interpretedNumber :: program.stack.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (x: ScriptConstant, y: ScriptConstant) =>
           // interpret x and y as a number
-          val interpretedNumberX = ScriptNumber(x.hex)
-          val interpretedNumberY = ScriptNumber(y.hex)
-          val newProgram = program.updateStack(
-            interpretedNumberX :: interpretedNumberY :: program.stack.tail.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          (interpretNumber(x), interpretNumber(y)) match {
+            case (Success(interpretedNumberX), Success(interpretedNumberY)) =>
+              val newProgram = program.updateStack(
+                interpretedNumberX ::
+                  interpretedNumberY :: program.stack.tail.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case _ =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (_: ScriptToken, _: ScriptToken) =>
           // pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
           // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -161,9 +161,16 @@ sealed abstract class CryptoInterpreter {
       Right((sig, HashType.sigHashDefault))
     } else if (sigBytes.length == 65) {
       val hashTypeByte = sigBytes.last
-      val hashType = HashType.fromByte(hashTypeByte)
-      val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
-      Right((sig, hashType))
+      if (hashTypeByte == HashType.sigHashDefaultByte) {
+        // BIP341: SIGHASH_DEFAULT must never be explicitly encoded as a
+        // trailing hash type byte -- only the 64-byte (implicit) form is
+        // valid for the default hash type
+        Left(ScriptErrorSchnorrSigHashType)
+      } else {
+        val hashType = HashType.fromByte(hashTypeByte)
+        val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
+        Right((sig, hashType))
+      }
     } else {
       Left(ScriptErrorSchnorrSigSize)
     })

--- a/core/src/main/scala/org/bitcoins/core/script/flag/ScriptFlagUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/flag/ScriptFlagUtil.scala
@@ -10,7 +10,11 @@ trait ScriptFlagUtil {
     * @return
     */
   def requiresStrictDerEncoding(flags: Seq[ScriptFlag]): Boolean = {
-    flags.contains(ScriptVerifyDerSig) || flags.contains(ScriptVerifyStrictEnc)
+    // Core's CheckSignatureEncoding applies the DER check whenever any of
+    // DERSIG, LOW_S, or STRICTENC is set -- LOW_S implies a DER-encoded
+    // signature is required in order to even parse out the S value to check.
+    flags.contains(ScriptVerifyDerSig) || flags.contains(
+      ScriptVerifyLowS) || flags.contains(ScriptVerifyStrictEnc)
   }
 
   /** Checks if we are required to check for strict encoding

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1388,8 +1388,15 @@ sealed abstract class ScriptInterpreter {
   def checkTransaction(transaction: Transaction): Boolean = {
     val inputOutputsNotZero =
       !(transaction.inputs.isEmpty || transaction.outputs.isEmpty)
-    val txNotLargerThanBlock = transaction.bytes.size < Consensus.maxBlockSize
-    val txNotHeavierThanBlock = transaction.weight < Consensus.maxBlockWeight
+    // Bitcoin Core's CheckTransaction only checks the witness-stripped base
+    // size scaled by WITNESS_SCALE_FACTOR against MAX_BLOCK_WEIGHT
+    // (GetSerializeSize(TX_NO_WITNESS(tx)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT).
+    // There is no separate check against the legacy 1MB MAX_BLOCK_SIZE using
+    // the full witness-inclusive size, so a transaction with a small base
+    // size but a large witness (well within the weight limit) must not be
+    // rejected just because its total serialized size exceeds 1MB.
+    val txNotHeavierThanBlock =
+      transaction.baseSize * Consensus.weightScalar <= Consensus.maxBlockWeight
     val outputsSpendValidAmountsOfMoney = !transaction.outputs.exists(o =>
       o.value < CurrencyUnits.zero || o.value > Consensus.maxMoney)
 
@@ -1406,7 +1413,7 @@ sealed abstract class ScriptInterpreter {
     } else {
       !transaction.inputs.exists(_.previousOutput == EmptyTransactionOutPoint)
     }
-    inputOutputsNotZero && txNotLargerThanBlock && txNotHeavierThanBlock && outputsSpendValidAmountsOfMoney &&
+    inputOutputsNotZero && txNotHeavierThanBlock && outputsSpendValidAmountsOfMoney &&
     allOutputsValidMoneyRange && noDuplicateInputs && isValidScriptSigForCoinbaseTx
   }
 

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -644,10 +644,19 @@ sealed abstract class ScriptInterpreter {
       } else {
         taprootWitness match {
           case keypath: TaprootKeyPath =>
-            val program = checkSchnorrSignature(
-              keypath,
-              taprootSPK.pubKey.schnorrPublicKey,
-              program = scriptPubKeyExecutedProgram)
+            // taprootSPK.pubKey throws if the output key's 32 bytes are not
+            // a valid x-only coordinate (see TaprootScriptPubKey.isValidAsm,
+            // which classifies a v1 32-byte program as taproot purely
+            // structurally, independent of key validity) -- that must fail
+            // key-path signature verification, not crash the interpreter
+            val program = Try(taprootSPK.pubKey.schnorrPublicKey) match {
+              case Success(schnorrPubKey) =>
+                checkSchnorrSignature(keypath,
+                                      schnorrPubKey,
+                                      program = scriptPubKeyExecutedProgram)
+              case Failure(_) =>
+                scriptPubKeyExecutedProgram.failExecution(ScriptErrorSchnorrSig)
+            }
             Success(program)
           case _: TaprootUnknownPath =>
             // is this right? I believe to maintain softfork compatibility we

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -129,7 +129,10 @@ sealed abstract class ScriptInterpreter {
     executedProgram.error match {
       case Some(err) => err
       case None =>
-        if (hasUnexpectedWitness(program)) {
+        if (
+          program.flags.contains(ScriptVerifyWitness) && hasUnexpectedWitness(
+            program)
+        ) {
           // note: the 'program' value we pass above is intentional, we need to check the original program
           // as the 'executedProgram' may have had the scriptPubKey value changed to the rebuilt ScriptPubKey of the witness program
           ScriptErrorWitnessUnexpected

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1320,6 +1320,14 @@ sealed abstract class ScriptInterpreter {
         case (reservedOperation: ReservedOperation) :: _ =>
           (program.failExecution(ScriptErrorBadOpCode),
            calcOpCount(opCount, reservedOperation))
+        // BIP342 OP_SUCCESSx opcodes only take on their "succeed immediately"
+        // semantics inside Tapscript, which this generic interpreter loop
+        // does not (yet) evaluate with awareness of; outside that context
+        // they remain invalid opcodes, matching their pre-BIP342 behavior as
+        // unassigned/reserved opcodes.
+        case (opSuccess: OP_SUCCESSx) :: _ =>
+          (program.failExecution(ScriptErrorBadOpCode),
+           calcOpCount(opCount, opSuccess))
         // splice operations
         case OP_SIZE :: _ =>
           val programOrError = SpliceInterpreter.opSize(program)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -47,6 +47,10 @@ sealed abstract class LockTimeInterpreter {
         case s: ScriptNumber if s < ScriptNumber.zero =>
           program.failExecution(ScriptErrorNegativeLockTime)
         case s: ScriptNumber
+            if ScriptFlagUtil.requireMinimalData(
+              program.flags) && !s.isShortestEncoding =>
+          program.failExecution(ScriptErrorUnknownError)
+        case s: ScriptNumber
             if s >= ScriptNumber(500000000) && transaction.lockTime < UInt32(
               500000000) =>
           program.failExecution(ScriptErrorUnsatisfiedLocktime)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -89,7 +89,7 @@ sealed abstract class LockTimeInterpreter {
       program.failExecution(ScriptErrorInvalidStackOperation)
     } else {
       program.stack.head match {
-        case ScriptNumber.negativeOne =>
+        case s: ScriptNumber if s < ScriptNumber.zero =>
           program.failExecution(ScriptErrorNegativeLockTime)
         case s: ScriptNumber
             if ScriptFlagUtil.requireMinimalData(

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.script.{
 }
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 2/8/16.
   */
@@ -63,8 +64,13 @@ sealed abstract class LockTimeInterpreter {
             program.failExecution(ScriptErrorUnsatisfiedLocktime)
           }
         case s: ScriptConstant =>
-          opCheckLockTimeVerify(
-            program.updateStack(ScriptNumber(s.hex) :: program.stack.tail))
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              opCheckLockTimeVerify(
+                program.updateStack(interpretedNumber :: program.stack.tail))
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case _: ScriptToken => program.failExecution(ScriptErrorUnknownError)
       }
     }
@@ -112,8 +118,13 @@ sealed abstract class LockTimeInterpreter {
             program.failExecution(ScriptErrorUnsatisfiedLocktime)
           }
         case s: ScriptConstant =>
-          opCheckSequenceVerify(
-            program.updateStack(ScriptNumber(s.hex) :: program.stack.tail))
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              opCheckSequenceVerify(
+                program.updateStack(interpretedNumber :: program.stack.tail))
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case token: ScriptToken =>
           throw new RuntimeException(
             "Stack top must be either a ScriptConstant or a ScriptNumber, we got: " + token)
@@ -298,6 +309,17 @@ sealed abstract class LockTimeInterpreter {
 
   def isLockTimeBitOff(num: Int64): Boolean =
     isLockTimeBitOff(ScriptNumber(num.hex))
+
+  /** Safely interprets a ScriptConstant as a ScriptNumber. ScriptNumber
+    * construction eagerly derives a Long value from the operand's bytes
+    * (ScriptNumberUtil.toLong), which throws NumberFormatException for a
+    * non-minimal operand wider than 8 bytes -- an untrusted, attacker
+    * controlled scriptSig/witness value. Bitcoin Core's CScriptNum constructor
+    * rejects such operands with a caught scriptnum_error instead of letting an
+    * unrepresentable value escape as a crash, so we do the same here.
+    */
+  private def interpretNumber(constant: ScriptConstant): Try[ScriptNumber] =
+    Try(ScriptNumber(constant.hex))
 }
 
 object LockTimeInterpreter extends LockTimeInterpreter

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/OpSuccessOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/OpSuccessOperations.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.core.script.reserved
+
+import org.bitcoins.core.script.ScriptOperationFactory
+import org.bitcoins.core.script.constant.ScriptOperation
+
+/** The OP_SUCCESSx opcodes introduced by BIP342 (Tapscript). Encountering any
+  * of these opcodes during Tapscript execution causes script validation to
+  * succeed immediately, unlike the other reserved/NOP opcodes.
+  * @see
+  *   [[https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki#new-op_success-opcodes BIP342]]
+  */
+case class OP_SUCCESSx(opCode: Int) extends ScriptOperation {
+  require(opCode >= 187 && opCode <= 254,
+          s"OP_SUCCESSx opcode must be in [187, 254], got $opCode")
+
+  override def toString: String = s"OP_SUCCESS$opCode"
+}
+
+object OpSuccessOperation extends ScriptOperationFactory[OP_SUCCESSx] {
+
+  override val operations: Vector[OP_SUCCESSx] =
+    (187 to 254).map(OP_SUCCESSx(_)).toVector
+}

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -170,10 +170,15 @@ sealed abstract class StackInterpreter {
         else if (
           number.toLong >= 0 && number.toLong < program.stack.tail.size
         ) {
-          val newStackTop = program.stack.tail(number.toInt)
-          // removes the old instance of the stack top, appends the new index to the head
-          val newStack = newStackTop :: program.stack.tail
-            .diff(List(newStackTop))
+          val idx = number.toInt
+          val rest = program.stack.tail
+          val newStackTop = rest(idx)
+          // remove the element at depth idx by position, not by value --
+          // rest.diff(List(newStackTop)) would remove the FIRST element
+          // equal to newStackTop, which is wrong when duplicate values
+          // are on the stack
+          val newStack =
+            newStackTop :: (rest.take(idx) ++ rest.drop(idx + 1))
           program.updateStackAndScript(newStack, program.script.tail)
         } else {
           program.failExecution(ScriptErrorInvalidStackOperation)

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.script.{
   ExecutionInProgressScriptProgram,
   StartedScriptProgram
 }
+import org.bitcoins.core.util.BitcoinScriptUtil
 
 import scala.util.{Failure, Success, Try}
 
@@ -35,7 +36,9 @@ sealed abstract class StackInterpreter {
     require(program.script.headOption.contains(OP_IFDUP),
             "Top of the script stack must be OP_DUP")
     if (program.stack.nonEmpty) {
-      if (program.stack.head == ScriptNumber.zero)
+      // Core's CastToBool treats every all-zero byte encoding (and negative
+      // zero) as false, not just the canonical empty-vector zero
+      if (!BitcoinScriptUtil.castToBool(program.stack.head))
         return program.updateScript(program.script.tail)
       program.updateStackAndScript(program.stack.head :: program.stack,
                                    program.script.tail)

--- a/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializer.scala
@@ -14,8 +14,11 @@ sealed abstract class RawBlockSerializer extends RawBitcoinSerializer[Block] {
   def read(bytes: ByteVector): Block = {
     val blockHeader: BlockHeader = BlockHeader(bytes.take(80))
     val txBytes: ByteVector = bytes.splitAt(80)._2
-    val (transactions, _) = RawSerializerHelper
+    val (transactions, remaining) = RawSerializerHelper
       .parseCmpctSizeUIntSeq[Transaction](txBytes, Transaction(_: ByteVector))
+    require(
+      remaining.isEmpty,
+      s"${remaining.length} trailing bytes after the last transaction in a block")
     Block(blockHeader, transactions)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.serializers.p2p
 
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.crypto.CryptoUtil
 import scodec.bits.ByteVector
 
 trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
@@ -14,6 +15,13 @@ trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
       throw new RuntimeException(
         s"We do not have enough bytes for payload! Expected=${header.payloadSize.toInt} got=${payloadBytes.length}")
     } else {
+      val declaredPayloadBytes = payloadBytes.take(header.payloadSize.toInt)
+      val actualChecksum =
+        CryptoUtil.doubleSHA256(declaredPayloadBytes).bytes.take(4)
+      require(
+        actualChecksum == header.checksum,
+        s"Checksum does not match, expected=${header.checksum}, got=$actualChecksum"
+      )
       val payload = NetworkPayload(header, payloadBytes)
       val n = NetworkMessage(header, payload)
       n

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
@@ -22,7 +22,7 @@ trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
         actualChecksum == header.checksum,
         s"Checksum does not match, expected=${header.checksum}, got=$actualChecksum"
       )
-      val payload = NetworkPayload(header, payloadBytes)
+      val payload = NetworkPayload(header, declaredPayloadBytes)
       val n = NetworkMessage(header, payload)
       n
     }

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
@@ -10,14 +10,22 @@ sealed abstract class RawFeeFilterMessageSerializer
     extends RawBitcoinSerializer[FeeFilterMessage] {
 
   override def read(bytes: ByteVector): FeeFilterMessage = {
-    val satBytes = bytes.take(8).reverse
+    // Satoshis(bytes: ByteVector) already reverses (it's read via
+    // RawSatoshisSerializer.read, which expects big-endian and reverses a
+    // little-endian input); reversing here too was a double-reversal bug
+    // that read this little-endian wire field as if big-endian
+    val satBytes = bytes.take(8)
     val sat = Satoshis(satBytes)
     val satPerKb = SatoshisPerKiloByte(sat)
     FeeFilterMessage(satPerKb)
   }
 
   override def write(feeFilterMessage: FeeFilterMessage): ByteVector = {
-    feeFilterMessage.feeRate.currencyUnit.satoshis.bytes.reverse
+    // Satoshis.bytes already produces little-endian wire bytes (via
+    // RawSatoshisSerializer.write, which reverses its big-endian internal
+    // representation); reversing here too was the write-side half of the
+    // same double-reversal bug
+    feeFilterMessage.feeRate.currencyUnit.satoshis.bytes
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializer.scala
@@ -53,7 +53,13 @@ trait RawVersionMessageSerializer extends RawBitcoinSerializer[VersionMessage] {
     val startHeight = Int32(
       bytes.slice(startHeightStartIndex, startHeightStartIndex + 4).reverse)
 
-    val relay = bytes(startHeightStartIndex + 4) != 0
+    // the relay byte is optional (added in protocol version 70001, BIP37);
+    // older peers omit it entirely, so default to relay=true rather than
+    // indexing unconditionally and throwing when it's absent
+    val relay =
+      if (bytes.size > startHeightStartIndex + 4)
+        bytes(startHeightStartIndex + 4) != 0
+      else true
 
     VersionMessage(
       version = version,

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
@@ -12,7 +12,9 @@ trait RawScriptPubKeyParser extends RawBitcoinSerializer[ScriptPubKey] {
   override def read(bytes: ByteVector): ScriptPubKey = {
     if (bytes.isEmpty) EmptyScriptPubKey
     else {
-      BitcoinScriptUtil.parseScript(bytes = bytes, f = ScriptPubKey.fromAsm)
+      BitcoinScriptUtil.parseScript(bytes = bytes,
+                                    f = ScriptPubKey.fromAsm,
+                                    strict = true)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -13,7 +13,9 @@ sealed abstract class RawScriptSignatureParser
   def read(bytes: ByteVector): ScriptSignature = {
     if (bytes.isEmpty) EmptyScriptSignature
     else {
-      BitcoinScriptUtil.parseScript(bytes = bytes, f = ScriptSignature.fromAsm)
+      BitcoinScriptUtil.parseScript(bytes = bytes,
+                                    f = ScriptSignature.fromAsm,
+                                    strict = true)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
@@ -27,6 +27,10 @@ sealed abstract class RawScriptWitnessParser
         val elementSize = CompactSizeUInt.parseCompactSizeUInt(remainingBytes)
         val (_, stackElementBytes) =
           remainingBytes.splitAt(elementSize.byteSize.toInt)
+        require(
+          stackElementBytes.length >= elementSize.num.toInt,
+          s"Witness stack element declares length ${elementSize.num} but only ${stackElementBytes.length} bytes remain"
+        )
         val stackElement = stackElementBytes.take(elementSize.num.toInt)
         val (_, newRemainingBytes) =
           stackElementBytes.splitAt(stackElement.size)

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -206,7 +206,9 @@ trait BitcoinScriptUtil {
         case h :: t =>
           h match {
             case scriptOp: ScriptOperation =>
-              if (scriptOp.opCode < OP_16.opCode) {
+              // Core's IsPushOnly allows all opcodes up to and including
+              // OP_16 (script.cpp), not just strictly less than it
+              if (scriptOp.opCode <= OP_16.opCode) {
                 loop(t)
               } else {
                 false

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -563,15 +563,22 @@ trait BitcoinScriptUtil {
   def removeSignatureFromScript(
       signature: ECDigitalSignature,
       script: Seq[ScriptToken]): Seq[ScriptToken] = {
-    if (script.contains(ScriptConstant(signature.hex))) {
-      // replicates this line in bitcoin core
-      // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L872
-      val sigIndex = script.indexOf(ScriptConstant(signature.hex))
-      // remove sig and it's corresponding BytesToPushOntoStack
-      val sigRemoved =
-        script.slice(0, sigIndex - 1) ++ script.slice(sigIndex + 1, script.size)
-      sigRemoved
-    } else script
+    // Core's FindAndDelete removes ALL occurrences, not just the first, so
+    // we loop until none remain
+    // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L872
+    @tailrec
+    def loop(scriptTokens: Seq[ScriptToken]): Seq[ScriptToken] = {
+      if (scriptTokens.contains(ScriptConstant(signature.hex))) {
+        val sigIndex = scriptTokens.indexOf(ScriptConstant(signature.hex))
+        // remove sig and it's corresponding BytesToPushOntoStack
+        val sigRemoved =
+          scriptTokens.slice(0, sigIndex - 1) ++ scriptTokens.slice(
+            sigIndex + 1,
+            scriptTokens.size)
+        loop(sigRemoved)
+      } else scriptTokens
+    }
+    loop(script)
   }
 
   /** Removes the list of [[ECDigitalSignature ECDigitalSignature]] from the

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -431,16 +431,31 @@ trait BitcoinScriptUtil {
       txSignatureComponent: TxSigComponent,
       signature: ECDigitalSignature,
       script: Seq[ScriptToken]): Seq[ScriptToken] = {
-    val scriptForChecking =
-      calculateScriptForSigning(txSignatureComponent, script)
     txSignatureComponent.sigVersion match {
       case SigVersionBase =>
+        val scriptForChecking =
+          calculateScriptForSigning(txSignatureComponent, script)
         removeSignatureFromScript(signature, scriptForChecking)
       case SigVersionWitnessV0 | SigVersionTaprootKeySpend |
           SigVersionTapscript =>
         // BIP143 removes requirement for calling FindAndDelete
         // https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#no-findanddelete
-        scriptForChecking
+        //
+        // `script` is either (a) the scriptCode as tracked by the
+        // interpreter (BitcoinScriptUtil.removeOpCodeSeparator), i.e. a
+        // suffix of the full witness scriptCode truncated after the last
+        // executed OP_CODESEPARATOR, or (b) a placeholder like the funding
+        // output's raw asm, from callers that expect the full scriptCode to
+        // be rebuilt from the witness stack. calculateScriptForSigning
+        // always rebuilds the latter (it has no notion of OP_CODESEPARATOR
+        // truncation); honor the former when `script` is actually a suffix
+        // of that rebuilt scriptCode, otherwise fall back to the rebuild.
+        val rebuiltScript =
+          calculateScriptForSigning(txSignatureComponent, script)
+        val scriptIsTruncatedSuffix =
+          script.size <= rebuiltScript.size &&
+            rebuiltScript.takeRight(script.size) == script
+        if (scriptIsTruncatedSuffix) script else rebuiltScript
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -658,9 +658,18 @@ trait BitcoinScriptUtil {
     }
   }
 
+  /** @param strict
+    *   when true, require that exactly `len` bytes (the declared script length)
+    *   were actually available, rejecting truncated input. This must default to
+    *   false: some internal callers (e.g. TransactionSignatureSerializer's
+    *   legacy sighash algorithm, which mirrors Bitcoin Core's CScript handling)
+    *   deliberately construct a script from just a length-prefix with no bytes
+    *   following it as a placeholder, and are not parsing untrusted wire data.
+    */
   def parseScript[T <: Script](
       bytes: ByteVector,
-      f: Vector[ScriptToken] => T): T = {
+      f: Vector[ScriptToken] => T,
+      strict: Boolean = false): T = {
     val compactSizeUInt = CompactSizeUInt.parseCompactSizeUInt(bytes)
     // TODO: Figure out a better way to do this, we can theoretically have numbers larger than Int.MaxValue,
     // but scala collections don't allow you to use 'slice' with longs
@@ -668,6 +677,11 @@ trait BitcoinScriptUtil {
     val scriptPubKeyBytes =
       bytes.slice(compactSizeUInt.byteSize.toInt,
                   len + compactSizeUInt.byteSize.toInt)
+    if (strict) {
+      require(
+        scriptPubKeyBytes.length == len,
+        s"Declared script length $len exceeds the ${scriptPubKeyBytes.length} available bytes")
+    }
     val script: Vector[ScriptToken] = ScriptParser.fromBytes(scriptPubKeyBytes)
     f(script)
   }

--- a/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
@@ -197,21 +197,29 @@ abstract class NetworkUtil {
             val newRemainingBytes =
               remainingBytes.drop(NetworkHeader.bytesSize + payloadBytes.size)
 
-            // If it's a message type we know, try to parse it
-            if (NetworkPayload.commandNames.contains(header.commandName)) {
+            val haveFullPayload = payloadBytes.size == header.payloadSize.toInt
+
+            if (!haveFullPayload) {
+              // don't have the full declared payload yet, wait for more bytes
+              (accum, remainingBytes)
+            } else if (
+              NetworkPayload.commandNames.contains(header.commandName)
+            ) {
+              // If it's a message type we know, try to parse it
               Try(NetworkMessage(header.bytes ++ payloadBytes)) match {
                 case Success(message) =>
                   loop(newRemainingBytes, accum :+ message)
                 case Failure(_) =>
-                  // Can't parse message yet, we need to wait for more bytes
-                  (accum, remainingBytes)
+                  // We already have the full declared payload, so this parse
+                  // failure is deterministic -- more bytes will never fix it.
+                  // Drop this message and continue rather than wedging
+                  // forever on the same bytes.
+                  loop(newRemainingBytes, accum)
               }
-            } else if (payloadBytes.size == header.payloadSize.toInt) { // If we've received the entire unknown message
-              loop(newRemainingBytes, accum)
             } else {
-              // If we can't parse the entire unknown message, continue on until we can
-              // so we properly skip it
-              (accum, remainingBytes)
+              // Unknown command, but we've received the entire message --
+              // skip over it
+              loop(newRemainingBytes, accum)
             }
           case Failure(_) =>
             // this case means that our TCP frame was not aligned with bitcoin protocol

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -144,7 +144,10 @@ sealed abstract class NumberUtil extends CryptoNumberUtil {
       noSignBit.toByteVector
     }
 
-    val significand = nBits.bytes.head
+    // unsigned: nBits.bytes.head is a signed Scala Byte, so an exponent
+    // byte >= 0x80 (128-255) would otherwise wrap negative and take the
+    // wrong branch below
+    val significand = nBits.bytes.head & 0xff
 
     // if the most significant bit is set, we have a negative number
     val signum = if (noSignificand.bits.head) {

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -12,7 +12,8 @@ sealed abstract class FeeUnit {
   final def *(cu: CurrencyUnit): CurrencyUnit = this * cu.satoshis.toLong
   final def *(int: Int): CurrencyUnit = this * int.toLong
 
-  final def *(long: Long): CurrencyUnit = Satoshis(toLong * long / scaleFactor)
+  final def *(long: Long): CurrencyUnit = Satoshis(
+    Math.multiplyExact(toLong, long) / scaleFactor)
   def *(tx: Transaction): CurrencyUnit = calc(tx)
 
   def factory: FeeUnitFactory[FeeUnit]

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
@@ -116,8 +116,12 @@ object HashType extends Factory[HashType] {
                            sigHashSingleAnyoneCanPay,
                            sigHashDefault)
 
+  // SIGHASH_DEFAULT (0x00) is deliberately excluded: it is a taproot-only
+  // hash type (see validTaprootHashTypes below). Core's legacy
+  // IsDefinedHashtypeSignature masks off the ANYONECANPAY bit and requires
+  // the remaining value be in [SIGHASH_ALL, SIGHASH_SINGLE] (1-3), which
+  // does not include 0.
   lazy val hashTypeBytes: Vector[Byte] = Vector(
-    sigHashDefaultByte,
     sigHashAllByte,
     sigHashSingleByte,
     sigHashNoneByte,

--- a/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
+++ b/testkit-core/src/main/scala/org/bitcoins/testkitcore/gen/CryptoGenerators.scala
@@ -309,8 +309,14 @@ sealed abstract class CryptoGenerators {
       hash = CryptoUtil.sha256Hash160(pubKey.bytes)
     } yield hash
 
-  /** Generates a random [[HashType HashType]] */
-  def hashType: Gen[HashType] = Gen.oneOf(HashType.hashTypes)
+  /** Generates a random [[HashType HashType]] for legacy/segwit v0 (ECDSA)
+    * signing. SIGHASH_DEFAULT is deliberately excluded: it is a taproot-only
+    * hash type (see [[taprootHashType]] below) and is not a defined hashtype
+    * for ECDSA signatures (HashType.hashTypeBytes /
+    * isDefinedHashtypeSignature).
+    */
+  def hashType: Gen[HashType] =
+    Gen.oneOf(HashType.hashTypes.filterNot(_ == HashType.sigHashDefault))
 
   def extVersion: Gen[ExtKeyVersion] = {
     Gen.oneOf(ExtKeyVersion.all)


### PR DESCRIPTION
## Summary

Fixes 41 of the 43 security findings reproduced for the `core` module in `SECURITY_REPRODUCTIONS.md`, each as its own commit with a paired reproduction test that fails before the fix and passes after. Companion branch/PR to the `crypto` module fixes (#6453).

Findings by file:
- `TlvParsingSecurityTest`: 1/1 fixed
- `TransactionParsingSecurityTest`: 7/8 fixed (finding 7, out-of-money-range `TransactionOutput` values, intentionally skipped — `TransactionOutput` deliberately supports negative values for general data modeling, matching existing `EmptyTransactionOutput`/generator design and Core's own split between raw deserialization and `CheckTransaction`-layer validation)
- `P2pParsingSecurityTest`: 7/7 fixed
- `MerkleConsensusSecurityTest`: 6/7 fixed (finding 2, CVE-2012-2459 duplicate-leaf mutation detection, intentionally skipped — an unconditional duplicate-sibling check broke a real historical 20-tx block fixture with a legitimate duplicate leaf pair; no confident, verified distinguishing rule was found)
- `ScriptArithmeticSecurityTest`: 8/8 fixed
- `SignatureCheckingSecurityTest`: 12/12 fixed

## Notable fixes

- **Taproot SPK classification**: a v1 32-byte witness program with an invalid x-only coordinate was misclassified as an unassigned (anyone-can-spend) witness version instead of taproot. Fixed by making classification purely structural (matching Core) and making `TaprootScriptPubKey.pubKey` lazy so parsing real on-chain data with such outputs doesn't crash.
- **BIP143 sighash / OP_CODESEPARATOR**: the segwit v0 sighash silently ignored an executed `OP_CODESEPARATOR`, always committing to the full witness script instead of the post-separator scriptCode.
- **BIP342 tapscript NULLFAIL**: an invalid non-empty tapscript signature only hard-failed when `SCRIPT_VERIFY_NULLFAIL` was explicitly set, instead of unconditionally as BIP342 requires.
- **OP_CHECKMULTISIG NULLFAIL**: only checked remaining (unconsumed) signatures on failure, missing signatures that matched earlier and were consumed.
- Several parser hardening fixes (CompactSizeUInt canonical encoding, witness stack/flag validation, P2P message checksum/length checks, bloom filter size limits) mirroring Bitcoin Core's actual deserialization behavior.

## Test plan

- [x] Each commit's paired reproduction test passes in isolation
- [x] Full `coreTestJVM/test` run: 1753/1753 passing, zero regressions
- [x] `sbt scalafmtCheckAll` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yT4qDB1VycMnpcNMooCR5