### PR TITLE
core: fix 8 script interpreter findings in locktime/arithmetic/stack opcodes

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -86,6 +86,26 @@ class ArithmeticInterpreterTest extends BitcoinSUnitTest {
       .error must be(Some(ScriptErrorUnknownError))
   }
 
+  it must "fail gracefully with a ScriptError on numeric operands larger than 8 bytes instead of throwing NumberFormatException" in {
+    // ScriptNumber construction eagerly derives a Long value via ScriptNumberUtil.toLong, which
+    // parses the operand's hex with java.lang.Long.parseLong -- a >8-byte operand overflows that
+    // parse and throws NumberFormatException. That must be caught and turned into a script error
+    // rather than escaping the interpreter as an uncaught crash.
+    val stack = List(ScriptConstant("ffffffffffffffff7f")) // 9-byte operand
+    val script = List(OP_1ADD)
+    val t = buildTxSigComponent(Seq(ScriptVerifyNone))
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    val newProgram = AI.op1Add(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    // matches Bitcoin Core: CScriptNum parsing failures are caught and
+    // mapped to SCRIPT_ERR_UNKNOWN_ERROR, same as the oversized-operand
+    // case above
+    newProgram
+      .asInstanceOf[ExecutedScriptProgram]
+      .error must be(Some(ScriptErrorUnknownError))
+  }
+
   private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {
     BaseTxSigComponent(
       transaction = TestUtil.transaction,

--- a/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreterTest.scala
@@ -1,10 +1,15 @@
 package org.bitcoins.core.script.arithmetic
 
+import org.bitcoins.core.crypto.{BaseTxSigComponent, TxSigComponent}
+import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.protocol.transaction.TransactionOutput
 import org.bitcoins.core.script.constant._
+import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNone}
 import org.bitcoins.core.script.result._
 import org.bitcoins.core.script.{
   ExecutedScriptProgram,
-  ExecutionInProgressScriptProgram
+  ExecutionInProgressScriptProgram,
+  PreExecutionScriptProgram
 }
 import org.bitcoins.core.util.ScriptProgramTestUtil
 import org.bitcoins.testkitcore.util.TestUtil
@@ -58,6 +63,39 @@ class ArithmeticInterpreterTest extends BitcoinSUnitTest {
       ScriptProgramTestUtil.toExecutedScriptProgram(AI.op1Add(program))
     newProgram.error must be(Some(ScriptErrorInvalidStackOperation))
 
+  }
+
+  it must "fail a 5-byte numeric operand to OP_1ADD like Bitcoin Core's 4-byte CScriptNum limit" in {
+    // a non-minimal 5-byte encoding of a small number (e.g. 255) must not be silently
+    // shrunk to <= 4 bytes before the isLargerThan4Bytes consensus check runs, or that
+    // check is bypassed whenever SCRIPT_VERIFY_MINIMALDATA is not set
+    val stack =
+      List(ScriptConstant("ff00000000")) // 5-byte non-minimal encoding of 255
+    val script = List(OP_1ADD)
+    val t = buildTxSigComponent(Seq(ScriptVerifyNone))
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    val newProgram = AI.op1Add(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    // matches Bitcoin Core: the CScriptNum constructor throws
+    // scriptnum_error for an oversized operand, which interpreter.cpp
+    // catches and maps to SCRIPT_ERR_UNKNOWN_ERROR
+    // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002
+    newProgram
+      .asInstanceOf[ExecutedScriptProgram]
+      .error must be(Some(ScriptErrorUnknownError))
+  }
+
+  private def buildTxSigComponent(flags: Seq[ScriptFlag]): TxSigComponent = {
+    BaseTxSigComponent(
+      transaction = TestUtil.transaction,
+      inputIndex = TestUtil.testProgram.txSignatureComponent.inputIndex,
+      output = TransactionOutput(
+        CurrencyUnits.zero,
+        TestUtil.testProgram.txSignatureComponent.scriptPubKey
+      ),
+      flags = flags
+    )
   }
 
   it must "perform an OP_1SUB correctly" in {

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -190,6 +190,43 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     )
   }
 
+  it must "mark the transaction as invalid if the stack top is a non-minimally encoded locktime and the minimal data flag is set" in {
+    // opCheckLockTimeVerify never checked ScriptFlagUtil.requireMinimalData / isShortestEncoding on
+    // its operand, unlike opCheckSequenceVerify which already enforces this for CSV. Bitcoin Core's
+    // CScriptNum constructor enforces fRequireMinimal for both CLTV and CSV operands identically.
+    val stack = Seq(ScriptNumber("0100")) // non-minimal encoding of 1
+    val script = Seq(OP_CHECKLOCKTIMEVERIFY)
+    val oldInput = TestUtil.transaction.inputs.head
+    val input = TransactionInput(
+      oldInput.previousOutput,
+      oldInput.scriptSignature,
+      UInt32.zero
+    )
+    val tx = BaseTransaction(
+      EmptyTransaction.version,
+      Vector(input),
+      EmptyTransaction.outputs,
+      UInt32(1)
+    )
+    val t = BaseTxSigComponent(
+      transaction = tx,
+      inputIndex = TestUtil.testProgram.txSignatureComponent.inputIndex,
+      output = TransactionOutput(
+        CurrencyUnits.zero,
+        TestUtil.testProgram.txSignatureComponent.scriptPubKey
+      ),
+      // standard flags include ScriptVerifyMinimalData
+      flags = TestUtil.testProgram.flags
+    )
+    val program = PreExecutionScriptProgram(t).toExecutionInProgress
+      .updateStackAndScript(stack, script)
+    val newProgram = LTI.opCheckLockTimeVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error.isDefined must be(
+      true
+    )
+  }
+
   it must "mark the transaction as valid if the locktime on the tx is < 500000000 && stack top is < 500000000" in {
     val stack = Seq(ScriptNumber(0))
     val script = Seq(OP_CHECKLOCKTIMEVERIFY)

--- a/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/locktime/LockTimeInterpreterTest.scala
@@ -288,6 +288,24 @@ class LockTimeInterpreterTest extends BitcoinSUnitTest {
     )
   }
 
+  it must "mark the script as invalid for OP_CHECKSEQUENCEVERIFY if the stack top is any negative value, not just negativeOne" in {
+    // negatives other than -1 (e.g. -2) have the BIP68 disable flag (1 << 31) set in their
+    // two's-complement bit pattern, so they must still fail with ScriptErrorNegativeLockTime
+    // rather than falling through to the "disable flag set, treat as NOP" branch.
+    val stack = List(ScriptNumber(-2))
+    val script = List(OP_CHECKSEQUENCEVERIFY)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = LTI.opCheckSequenceVerify(program)
+    newProgram.isInstanceOf[ExecutedScriptProgram] must be(true)
+    newProgram.asInstanceOf[ExecutedScriptProgram].error must be(
+      Some(ScriptErrorNegativeLockTime)
+    )
+  }
+
   it must "mark the script as invalid for OP_CHECKSEQUENCEVERIFY if we are requiring minimal encoding of numbers and the stack top is not minimal" in {
     val stack = List(ScriptNumber("0100"))
     val script = List(OP_CHECKSEQUENCEVERIFY)

--- a/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/reserved/ReservedOperationsFactoryTest.scala
@@ -15,6 +15,8 @@ class ReservedOperationsFactoryTest extends BitcoinSUnitTest {
     ReservedOperation("b0") must be(Some(OP_NOP1))
   }
   it must "find an undefined operation from its hex value" in {
-    ReservedOperation("bb").isDefined must be(true)
+    // 0xbb (187) is no longer undefined -- per BIP342 it is OP_SUCCESS187,
+    // see OpSuccessOperation. 0xff (255) remains genuinely unassigned.
+    ReservedOperation("ff").isDefined must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -347,6 +347,24 @@ class StackInterpreterTest extends BitcoinSUnitTest {
     )
   }
 
+  it must "move the nth stack element to the top with OP_ROLL even when duplicate values are on the stack" in {
+    // removing the rolled element by value (stack.tail.diff(List(newStackTop))) removes the FIRST
+    // equal element instead of the element at depth n; Bitcoin Core's OP_ROLL removes and reinserts
+    // strictly by index
+    val a = ScriptConstant("aa")
+    val b = ScriptConstant("bb")
+    val stack = List(ScriptNumber(2), a, b, a)
+    val script = List(OP_ROLL)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = SI.opRoll(program)
+    // the second 'a' (depth 2) moves to the top; the first 'a' stays at depth 1
+    newProgram.stack must be(List(a, a, b))
+  }
+
   it must "evaluate an OP_ROT correctly" in {
     val stack =
       List(ScriptConstant("14"), ScriptConstant("15"), ScriptConstant("16"))

--- a/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/stack/StackInterpreterTest.scala
@@ -149,6 +149,21 @@ class StackInterpreterTest extends BitcoinSUnitTest {
 
   }
 
+  it must "not duplicate a non-canonical zero encoding with OP_IFDUP (Bitcoin Core treats it as false)" in {
+    // Core's CastToBool treats every all-zero byte encoding (and negative zero) as false, not just
+    // the canonical empty-vector zero, so a non-canonical zero like "00" must leave the stack
+    // unchanged rather than being duplicated
+    val stack = List(ScriptConstant("00"))
+    val script = List(OP_IFDUP)
+    val program =
+      TestUtil.testProgramExecutionInProgress.updateStackAndScript(
+        stack,
+        script
+      )
+    val newProgram = SI.opIfDup(program)
+    newProgram.stack must be(stack)
+  }
+
   it must "evaluate an OP_NIP correctly" in {
     val stack = List(OP_0, OP_1)
     val script = List(OP_NIP)

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/ScriptParserTest.scala
@@ -429,4 +429,14 @@ class ScriptParserTest extends BitcoinSUnitTest {
     asm must be(expectedAsm)
   }
 
+  it must "parse opcode bytes 0xbb-0xfe as OP_SUCCESS187-254 operations" in {
+    // per BIP342 (Tapscript), bytes 187-254 are individually named OP_SUCCESS187 through
+    // OP_SUCCESS254, distinct from ordinary reserved/NOP opcodes
+    (187 to 254).foreach { opCode =>
+      val parsed = ScriptParser.fromBytes(ByteVector(opCode.toByte))
+      parsed.size must be(1)
+      parsed.head.toString.startsWith("OP_SUCCESS") must be(true)
+    }
+  }
+
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
@@ -205,6 +205,15 @@ class BitcoinScriptUtilTest extends BitcoinSUnitTest {
     ) must be(false)
   }
 
+  it must "count a scriptSig ending in OP_16 as push-only" in {
+    // Bitcoin Core's IsPushOnly (script.cpp) allows all opcodes up to and including OP_16 -- OP_16
+    // pushes the number 16 onto the stack just like OP_1 through OP_15, so it belongs in the
+    // push-only category with them
+    BitcoinScriptUtil.isPushOnly(
+      Seq(BytesToPushOntoStack(1), ScriptConstant("ff"), OP_16)
+    ) must be(true)
+  }
+
   it must "determine that the script is not push only if it contains an script number operation" in {
     BitcoinScriptUtil.isMinimalPush(BytesToPushOntoStack(1), OP_1) must be(
       false

--- a/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/ScriptOperationFactory.scala
@@ -6,7 +6,7 @@ import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.control.ControlOperations
 import org.bitcoins.core.script.crypto.CryptoOperation
 import org.bitcoins.core.script.locktime.LocktimeOperation
-import org.bitcoins.core.script.reserved.ReservedOperation
+import org.bitcoins.core.script.reserved.{OpSuccessOperation, ReservedOperation}
 import org.bitcoins.core.script.splice.SpliceOperation
 import org.bitcoins.core.script.stack.StackOperation
 import org.bitcoins.core.util.BytesUtil
@@ -94,7 +94,8 @@ object ScriptOperation extends ScriptOperationFactory[ScriptOperation] {
       ArithmeticOperation.operations ++
       BytesToPushOntoStack.operations ++
       SpliceOperation.operations ++
-      ScriptNumberOperation.operations
+      ScriptNumberOperation.operations ++
+      OpSuccessOperation.operations
   }
 
   /** This contains duplicate operations There is an optimization here by moving

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -303,7 +303,12 @@ sealed abstract class ArithmeticInterpreter {
         ) {
           program.failExecution(ScriptErrorUnknownError)
         } else {
-          val interpretedNumber = ScriptNumber(ScriptNumberUtil.toLong(s.hex))
+          // preserve the original byte-level encoding (as the binary
+          // arithmetic operations below already do) rather than
+          // re-deriving a ScriptNumber from its Long value, which would
+          // silently minimize a non-minimal operand's size and bypass the
+          // isLargerThan4Bytes consensus check that runs next
+          val interpretedNumber = ScriptNumber(s.hex)
           val newProgram =
             program.updateStack(interpretedNumber :: program.stack.tail)
           performUnaryArithmeticOperation(newProgram, op)

--- a/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/arithmetic/ArithmeticInterpreter.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.script.{
 import org.bitcoins.core.util.BitcoinScriptUtil
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 1/25/16.
   */
@@ -263,6 +264,17 @@ sealed abstract class ArithmeticInterpreter {
   private def isLargerThan4Bytes(scriptNumber: ScriptNumber): Boolean =
     scriptNumber.bytes.size > 4
 
+  /** Safely interprets a ScriptConstant as a ScriptNumber. ScriptNumber
+    * construction eagerly derives a Long value from the operand's bytes
+    * (ScriptNumberUtil.toLong), which throws NumberFormatException for a
+    * non-minimal operand wider than 8 bytes -- an untrusted, attacker
+    * controlled scriptSig/witness value. Bitcoin Core's CScriptNum constructor
+    * rejects such operands with a caught scriptnum_error instead of letting an
+    * unrepresentable value escape as a crash, so we do the same here.
+    */
+  private def interpretNumber(constant: ScriptConstant): Try[ScriptNumber] =
+    Try(ScriptNumber(constant.hex))
+
   /** Performs the given arithmetic operation on the stack head
     * @param program
     *   the program whose stack top is used as an argument for the arithmetic
@@ -308,10 +320,14 @@ sealed abstract class ArithmeticInterpreter {
           // re-deriving a ScriptNumber from its Long value, which would
           // silently minimize a non-minimal operand's size and bypass the
           // isLargerThan4Bytes consensus check that runs next
-          val interpretedNumber = ScriptNumber(s.hex)
-          val newProgram =
-            program.updateStack(interpretedNumber :: program.stack.tail)
-          performUnaryArithmeticOperation(newProgram, op)
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              val newProgram =
+                program.updateStack(interpretedNumber :: program.stack.tail)
+              performUnaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         }
       case Some(_: ScriptToken) =>
         // pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
@@ -359,22 +375,34 @@ sealed abstract class ArithmeticInterpreter {
           }
         case (x: ScriptConstant, _: ScriptNumber) =>
           // interpret x as a number
-          val interpretedNumber = ScriptNumber(x.hex)
-          val newProgram =
-            program.updateStack(interpretedNumber :: program.stack.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          interpretNumber(x) match {
+            case Success(interpretedNumber) =>
+              val newProgram =
+                program.updateStack(interpretedNumber :: program.stack.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (x: ScriptNumber, y: ScriptConstant) =>
-          val interpretedNumber = ScriptNumber(y.hex)
-          val newProgram =
-            program.updateStack(x :: interpretedNumber :: program.stack.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          interpretNumber(y) match {
+            case Success(interpretedNumber) =>
+              val newProgram = program.updateStack(
+                x :: interpretedNumber :: program.stack.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (x: ScriptConstant, y: ScriptConstant) =>
           // interpret x and y as a number
-          val interpretedNumberX = ScriptNumber(x.hex)
-          val interpretedNumberY = ScriptNumber(y.hex)
-          val newProgram = program.updateStack(
-            interpretedNumberX :: interpretedNumberY :: program.stack.tail.tail)
-          performBinaryArithmeticOperation(newProgram, op)
+          (interpretNumber(x), interpretNumber(y)) match {
+            case (Success(interpretedNumberX), Success(interpretedNumberY)) =>
+              val newProgram = program.updateStack(
+                interpretedNumberX ::
+                  interpretedNumberY :: program.stack.tail.tail)
+              performBinaryArithmeticOperation(newProgram, op)
+            case _ =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case (_: ScriptToken, _: ScriptToken) =>
           // pretty sure that an error is thrown inside of CScriptNum which in turn is caught by interpreter.cpp here
           // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L999-L1002

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1320,6 +1320,14 @@ sealed abstract class ScriptInterpreter {
         case (reservedOperation: ReservedOperation) :: _ =>
           (program.failExecution(ScriptErrorBadOpCode),
            calcOpCount(opCount, reservedOperation))
+        // BIP342 OP_SUCCESSx opcodes only take on their "succeed immediately"
+        // semantics inside Tapscript, which this generic interpreter loop
+        // does not (yet) evaluate with awareness of; outside that context
+        // they remain invalid opcodes, matching their pre-BIP342 behavior as
+        // unassigned/reserved opcodes.
+        case (opSuccess: OP_SUCCESSx) :: _ =>
+          (program.failExecution(ScriptErrorBadOpCode),
+           calcOpCount(opCount, opSuccess))
         // splice operations
         case OP_SIZE :: _ =>
           val programOrError = SpliceInterpreter.opSize(program)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -47,6 +47,10 @@ sealed abstract class LockTimeInterpreter {
         case s: ScriptNumber if s < ScriptNumber.zero =>
           program.failExecution(ScriptErrorNegativeLockTime)
         case s: ScriptNumber
+            if ScriptFlagUtil.requireMinimalData(
+              program.flags) && !s.isShortestEncoding =>
+          program.failExecution(ScriptErrorUnknownError)
+        case s: ScriptNumber
             if s >= ScriptNumber(500000000) && transaction.lockTime < UInt32(
               500000000) =>
           program.failExecution(ScriptErrorUnsatisfiedLocktime)

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -89,7 +89,7 @@ sealed abstract class LockTimeInterpreter {
       program.failExecution(ScriptErrorInvalidStackOperation)
     } else {
       program.stack.head match {
-        case ScriptNumber.negativeOne =>
+        case s: ScriptNumber if s < ScriptNumber.zero =>
           program.failExecution(ScriptErrorNegativeLockTime)
         case s: ScriptNumber
             if ScriptFlagUtil.requireMinimalData(

--- a/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/locktime/LockTimeInterpreter.scala
@@ -15,6 +15,7 @@ import org.bitcoins.core.script.{
 }
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 2/8/16.
   */
@@ -63,8 +64,13 @@ sealed abstract class LockTimeInterpreter {
             program.failExecution(ScriptErrorUnsatisfiedLocktime)
           }
         case s: ScriptConstant =>
-          opCheckLockTimeVerify(
-            program.updateStack(ScriptNumber(s.hex) :: program.stack.tail))
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              opCheckLockTimeVerify(
+                program.updateStack(interpretedNumber :: program.stack.tail))
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case _: ScriptToken => program.failExecution(ScriptErrorUnknownError)
       }
     }
@@ -112,8 +118,13 @@ sealed abstract class LockTimeInterpreter {
             program.failExecution(ScriptErrorUnsatisfiedLocktime)
           }
         case s: ScriptConstant =>
-          opCheckSequenceVerify(
-            program.updateStack(ScriptNumber(s.hex) :: program.stack.tail))
+          interpretNumber(s) match {
+            case Success(interpretedNumber) =>
+              opCheckSequenceVerify(
+                program.updateStack(interpretedNumber :: program.stack.tail))
+            case Failure(_) =>
+              program.failExecution(ScriptErrorUnknownError)
+          }
         case token: ScriptToken =>
           throw new RuntimeException(
             "Stack top must be either a ScriptConstant or a ScriptNumber, we got: " + token)
@@ -298,6 +309,17 @@ sealed abstract class LockTimeInterpreter {
 
   def isLockTimeBitOff(num: Int64): Boolean =
     isLockTimeBitOff(ScriptNumber(num.hex))
+
+  /** Safely interprets a ScriptConstant as a ScriptNumber. ScriptNumber
+    * construction eagerly derives a Long value from the operand's bytes
+    * (ScriptNumberUtil.toLong), which throws NumberFormatException for a
+    * non-minimal operand wider than 8 bytes -- an untrusted, attacker
+    * controlled scriptSig/witness value. Bitcoin Core's CScriptNum constructor
+    * rejects such operands with a caught scriptnum_error instead of letting an
+    * unrepresentable value escape as a crash, so we do the same here.
+    */
+  private def interpretNumber(constant: ScriptConstant): Try[ScriptNumber] =
+    Try(ScriptNumber(constant.hex))
 }
 
 object LockTimeInterpreter extends LockTimeInterpreter

--- a/core/src/main/scala/org/bitcoins/core/script/reserved/OpSuccessOperations.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/reserved/OpSuccessOperations.scala
@@ -1,0 +1,23 @@
+package org.bitcoins.core.script.reserved
+
+import org.bitcoins.core.script.ScriptOperationFactory
+import org.bitcoins.core.script.constant.ScriptOperation
+
+/** The OP_SUCCESSx opcodes introduced by BIP342 (Tapscript). Encountering any
+  * of these opcodes during Tapscript execution causes script validation to
+  * succeed immediately, unlike the other reserved/NOP opcodes.
+  * @see
+  *   [[https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki#new-op_success-opcodes BIP342]]
+  */
+case class OP_SUCCESSx(opCode: Int) extends ScriptOperation {
+  require(opCode >= 187 && opCode <= 254,
+          s"OP_SUCCESSx opcode must be in [187, 254], got $opCode")
+
+  override def toString: String = s"OP_SUCCESS$opCode"
+}
+
+object OpSuccessOperation extends ScriptOperationFactory[OP_SUCCESSx] {
+
+  override val operations: Vector[OP_SUCCESSx] =
+    (187 to 254).map(OP_SUCCESSx(_)).toVector
+}

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -170,10 +170,15 @@ sealed abstract class StackInterpreter {
         else if (
           number.toLong >= 0 && number.toLong < program.stack.tail.size
         ) {
-          val newStackTop = program.stack.tail(number.toInt)
-          // removes the old instance of the stack top, appends the new index to the head
-          val newStack = newStackTop :: program.stack.tail
-            .diff(List(newStackTop))
+          val idx = number.toInt
+          val rest = program.stack.tail
+          val newStackTop = rest(idx)
+          // remove the element at depth idx by position, not by value --
+          // rest.diff(List(newStackTop)) would remove the FIRST element
+          // equal to newStackTop, which is wrong when duplicate values
+          // are on the stack
+          val newStack =
+            newStackTop :: (rest.take(idx) ++ rest.drop(idx + 1))
           program.updateStackAndScript(newStack, program.script.tail)
         } else {
           program.failExecution(ScriptErrorInvalidStackOperation)

--- a/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/stack/StackInterpreter.scala
@@ -7,6 +7,7 @@ import org.bitcoins.core.script.{
   ExecutionInProgressScriptProgram,
   StartedScriptProgram
 }
+import org.bitcoins.core.util.BitcoinScriptUtil
 
 import scala.util.{Failure, Success, Try}
 
@@ -35,7 +36,9 @@ sealed abstract class StackInterpreter {
     require(program.script.headOption.contains(OP_IFDUP),
             "Top of the script stack must be OP_DUP")
     if (program.stack.nonEmpty) {
-      if (program.stack.head == ScriptNumber.zero)
+      // Core's CastToBool treats every all-zero byte encoding (and negative
+      // zero) as false, not just the canonical empty-vector zero
+      if (!BitcoinScriptUtil.castToBool(program.stack.head))
         return program.updateScript(program.script.tail)
       program.updateStackAndScript(program.stack.head :: program.stack,
                                    program.script.tail)

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -206,7 +206,9 @@ trait BitcoinScriptUtil {
         case h :: t =>
           h match {
             case scriptOp: ScriptOperation =>
-              if (scriptOp.opCode < OP_16.opCode) {
+              // Core's IsPushOnly allows all opcodes up to and including
+              // OP_16 (script.cpp), not just strictly less than it
+              if (scriptOp.opCode <= OP_16.opCode) {
                 loop(t)
               } else {
                 false


### PR DESCRIPTION
## Summary

Fixes 8 of the findings reported against the script interpreter (see the security reproduction report this branch was built against, and split out of #6454 into a smaller, independently-reviewable PR). Each commit pairs one production fix with the reproduction test that proves it, relocated into the relevant existing test suite rather than a new dedicated test file — the tests were written to assert the *correct* (Bitcoin Core compatible) behavior, so each failed until its corresponding fix landed.

- `LockTimeInterpreter.opCheckSequenceVerify` only rejected the exact value `ScriptNumber.negativeOne` with `SCRIPT_ERR_NEGATIVE_LOCKTIME`; any other negative operand (e.g. -2) has the BIP68 disable flag set in its two's-complement bit pattern and fell through to the "treat as NOP" branch, bypassing BIP112's negative-locktime check entirely.
- `ArithmeticInterpreter.performUnaryArithmeticOperation`'s `ScriptConstant` branch re-derived the operand via `ScriptNumber(ScriptNumberUtil.toLong(s.hex))`, silently minimizing a non-minimal 5-byte encoding down to ≤4 bytes before the `isLargerThan4Bytes` consensus check ran, bypassing it whenever `SCRIPT_VERIFY_MINIMALDATA` was not set.
- `ScriptNumber` construction from a `ScriptConstant` eagerly parses the operand's hex with `java.lang.Long.parseLong`; an operand wider than 8 bytes overflowed that parse and threw an uncaught `NumberFormatException` instead of a script evaluation error, across every `ScriptConstant`-interpreting branch in both `ArithmeticInterpreter` and `LockTimeInterpreter`. Added a shared `interpretNumber` helper in each interpreter that wraps the construction in a `Try` and fails execution with `ScriptErrorUnknownError`.
- Opcode bytes 187-254 parsed to `ReservedOperation.UndefinedOP_NOP`, a generic catch-all. Per BIP342 (Tapscript) these are individually named `OP_SUCCESS187`-`OP_SUCCESS254` opcodes; added a new `OP_SUCCESSx` operation type and wired it into opcode parsing (0xff/255 remains the only genuinely unassigned byte). The base interpreter loop doesn't yet evaluate Tapscript-aware "succeed immediately" semantics, so execution behavior outside that context is unchanged — only the parsed opcode identity changes.
- `LockTimeInterpreter.opCheckLockTimeVerify` never checked `ScriptFlagUtil.requireMinimalData`/`isShortestEncoding` on its operand, unlike `opCheckSequenceVerify` which already enforces this for CSV; Core's `CScriptNum` constructor enforces `fRequireMinimal` identically for both CLTV and CSV.
- `StackInterpreter.opIfDup` only compared the stack top against `ScriptNumber.zero` (the canonical empty-vector encoding), so a non-canonical zero like `"00"` fell through and got duplicated; switched to `BitcoinScriptUtil.castToBool`, which correctly treats every all-zero byte encoding as false.
- `StackInterpreter.opRoll` removed the rolled element with `stack.tail.diff(List(newStackTop))`, which removes the first element equal to `newStackTop` by *value*, not the element at depth n by *position* — corrupting stack order when duplicate values are present. Fixed by splitting the stack at the target index and reassembling it.
- `BitcoinScriptUtil.isPushOnly` rejected `OP_16` itself via a strict `scriptOp.opCode < OP_16.opCode` comparison; Core's `IsPushOnly` allows all opcodes up to and including `OP_16`, since it pushes the number 16 just like `OP_1`-`OP_15`.

## Test plan

- [x] Targeted test suites for each fix (`LockTimeInterpreterTest`, `ArithmeticInterpreterTest`, `StackInterpreterTest`, `ScriptParserTest`, `ReservedOperationsFactoryTest`, `BitcoinScriptUtilTest`) — all passing
- [x] `ScriptInterpreterTest` (full `script_tests.json` BIP test-vector suite) — passing after every commit
- [x] `sbt coreTestJVM/test` — 1717/1717 passing
- [x] `sbt scalafmtCheckAll` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yT4qDB1VycMnpcNMooCR5