### PR TITLE
Fix P2P message parsing security findings (7 bugs, 1 commit per bug)

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/bloom/BloomFilterTest.scala
@@ -1,7 +1,8 @@
 package org.bitcoins.core.bloom
 
 import org.bitcoins.core.crypto._
-import org.bitcoins.core.number.UInt32
+import org.bitcoins.core.number.{UInt32, UInt64}
+import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.blockchain.Block
 import org.bitcoins.core.protocol.transaction.{Transaction, TransactionOutPoint}
 import org.bitcoins.crypto._
@@ -303,5 +304,29 @@ class BloomFilterTest extends BitcoinSUnitTest {
 
     empty.data must be(ByteVector.empty)
     BloomFilter.fromBytes(empty.bytes) must be(empty)
+  }
+
+  it must "reject a filterSize larger than the BIP37 maxSize limit" in {
+    Try(
+      BloomFilter(
+        filterSize = CompactSizeUInt(UInt64(BloomFilter.maxSize.toLong + 1)),
+        data = ByteVector.empty,
+        hashFuncs = UInt32.one,
+        tweak = UInt32.zero,
+        flags = BloomUpdateAll
+      )
+    ).isFailure must be(true)
+  }
+
+  it must "reject a hashFuncs count larger than the BIP37 maxHashFuncs limit" in {
+    Try(
+      BloomFilter(
+        filterSize = CompactSizeUInt(UInt64.one),
+        data = ByteVector(0.toByte),
+        hashFuncs = UInt32(BloomFilter.maxHashFuncs.toLong + 1),
+        tweak = UInt32.zero,
+        flags = BloomUpdateAll
+      )
+    ).isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/FeeFilterMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/FeeFilterMessageTest.scala
@@ -1,12 +1,34 @@
 package org.bitcoins.core.p2p
 
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.testkitcore.gen.p2p.ControlMessageGenerator
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits._
 
 class FeeFilterMessageTest extends BitcoinSUnitTest {
   it must "have serialization symmetry" in {
     forAll(ControlMessageGenerator.feeFilterMessage) { fee =>
       assert(FeeFilterMessage.fromBytes(fee.bytes) == fee)
     }
+  }
+
+  it must "parse the wire's little-endian feerate correctly, not double-reversed" in {
+    // 999 sat/kb, little endian, as it appears on the wire. Round-trip
+    // symmetry alone can't catch a double-reversal bug (both directions
+    // would be equally wrong), so this asserts the actual decoded value.
+    val feeFilterBytes = hex"e703000000000000"
+    val feeFilterMessage = FeeFilterMessage.fromBytes(feeFilterBytes)
+
+    feeFilterMessage.feeRate.currencyUnit.satoshis must be(Satoshis(999))
+  }
+
+  it must "parse a feefilter message with a feerate not divisible by 1000 without throwing" in {
+    // a peer-supplied feerate has no guarantee of being evenly divisible by
+    // 1000, so satPerByte must round rather than throw
+    val feeFilterBytes = hex"e703000000000000"
+    val feeFilterMessage = FeeFilterMessage.fromBytes(feeFilterBytes)
+
+    val satPerByte = feeFilterMessage.satPerByte
+    satPerByte.currencyUnit.satoshis must be(Satoshis(0))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
@@ -1,7 +1,11 @@
 package org.bitcoins.core.p2p
 
+import org.bitcoins.core.config.RegTest
+import org.bitcoins.core.number.UInt32
+import org.bitcoins.crypto.CryptoUtil
 import org.bitcoins.testkitcore.node.P2PMessageTestUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
 
 class NetworkMessageTest extends BitcoinSUnitTest {
 
@@ -47,5 +51,24 @@ class NetworkMessageTest extends BitcoinSUnitTest {
     assertThrows[IllegalArgumentException] {
       NetworkMessage.fromHex(corruptedChecksumHex)
     }
+  }
+
+  it must "not interpret trailing bytes beyond payloadSize as part of the payload" in {
+    // RejectMessage is used because its `extra` field consumes all
+    // remaining bytes, so trailing bytes not sliced off at payloadSize
+    // would leak into the parsed payload.
+    // payload: message="tx", code=0x10, reason="", no extra data
+    val payloadBytes = ByteVector.fromValidHex("0274781000")
+    val header =
+      NetworkHeader(RegTest,
+                    "reject",
+                    UInt32(payloadBytes.size),
+                    CryptoUtil.doubleSHA256(payloadBytes).bytes.take(4))
+    // simulate framing where the next message's bytes follow immediately
+    val trailingBytes = ByteVector.fromValidHex("f9beb4d976657261")
+    val streamBytes = header.bytes ++ payloadBytes ++ trailingBytes
+
+    val msg = NetworkMessage.fromBytes(streamBytes)
+    msg.payload.bytes.size must be(header.payloadSize.toInt)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkMessageTest.scala
@@ -19,11 +19,33 @@ class NetworkMessageTest extends BitcoinSUnitTest {
       // since we only support protocol version > 7, i added it manually
       // this means the payload size is bumped by 1 byte in the NetworkHeader from 100 -> 101
       // and a relay byte "00" is appended to the end of the payload
-      "F9BEB4D976657273696F6E000000000065000000358d4932" +
+      //
+      // Since checksums are now verified at parse time, the checksum field
+      // below is the correct doubleSHA256 of the actual (101 byte, with the
+      // appended relay byte) payload -- the wiki page's original checksum
+      // was only ever valid for the unmodified 100 byte payload, which
+      // can't round-trip through VersionMessage: write() always re-emits
+      // the (optional-on-read, always-written) relay byte.
+      "F9BEB4D976657273696F6E000000000065000000030ecc57" +
         "62EA0000010000000000000011B2D05000000000010000000000000000000000000000000000FFFF000000000000010000000000000000000000000000000000FFFF0000000000003B2EB35D8CE617650F2F5361746F7368693A302E372E322FC03E0300" +
         "00"
     }.toLowerCase
     val networkMsg = NetworkMessage.fromHex(hex)
     networkMsg.hex must be(hex)
+  }
+
+  it must "reject a network message with a corrupted checksum" in {
+    // the version message from the bitcoin wiki example above, with the
+    // last checksum nibble flipped (57 -> 58) so it no longer matches
+    // doubleSHA256 of the payload
+    val corruptedChecksumHex = {
+      "F9BEB4D976657273696F6E000000000065000000030ecc58" +
+        "62EA0000010000000000000011B2D05000000000010000000000000000000000000000000000FFFF000000000000010000000000000000000000000000000000FFFF0000000000003B2EB35D8CE617650F2F5361746F7368693A302E372E322FC03E0300" +
+        "00"
+    }.toLowerCase
+
+    assertThrows[IllegalArgumentException] {
+      NetworkMessage.fromHex(corruptedChecksumHex)
+    }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkPayloadTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/NetworkPayloadTest.scala
@@ -1,9 +1,11 @@
 package org.bitcoins.core.p2p
 
 import org.bitcoins.core.config.TestNet3
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.testkitcore.gen.p2p.P2PGenerator
 import org.bitcoins.testkitcore.node.P2PMessageTestUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
 
 class NetworkPayloadTest extends BitcoinSUnitTest {
 
@@ -33,6 +35,19 @@ class NetworkPayloadTest extends BitcoinSUnitTest {
       val bytes = p2p.bytes
       val parser = NetworkPayload.readers(p2p.commandName)
       assert(parser(bytes) == p2p)
+    }
+  }
+
+  it must "produce a clean parse error for an unknown command name" in {
+    // an empty payload's checksum is always doubleSHA256("") -- see
+    // NetworkHeader's scaladoc
+    val header = NetworkHeader(TestNet3,
+                               "madeup",
+                               UInt32.zero,
+                               ByteVector.fromValidHex("5df6e0e2"))
+
+    assertThrows[IllegalArgumentException] {
+      NetworkPayload(header, ByteVector.empty)
     }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/p2p/VersionMessageTest.scala
@@ -56,4 +56,18 @@ class VersionMessageTest extends BitcoinSUnitTest {
     assert(versionMessage.services.nodeNetworkLimited)
     assert(!versionMessage.services.nodeNone)
   }
+
+  it must "handle a version message missing the optional relay byte gracefully" in {
+    // the relay byte is optional (added in protocol version 70001, BIP37);
+    // pre-70001 peers omit it entirely. RawVersionMessageSerializer.read
+    // previously indexed it unconditionally, throwing a raw
+    // IndexOutOfBoundsException instead of defaulting to relay=true the way
+    // Bitcoin Core does when the field is absent. Same message as above,
+    // minus the trailing "01" relay byte.
+    val payloadWithoutRelay =
+      hex"7f1101000d040000000000004ea1035d0000000000000000000000000000000000000000000000000000000000000d04000000000000000000000000000000000000000000000000fa562b93b3113e02122f5361746f7368693a302e31372e302e312f68000000"
+
+    val versionMessage = VersionMessage.fromBytes(payloadWithoutRelay)
+    versionMessage.relay must be(true)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NetworkUtilTest.scala
@@ -2,7 +2,12 @@ package org.bitcoins.core.util
 
 import org.bitcoins.core.config.{RegTest, TestNet3}
 import org.bitcoins.core.number.{Int32, UInt32, UInt64}
-import org.bitcoins.core.p2p.{HeadersMessage, NetworkHeader, NetworkMessage}
+import org.bitcoins.core.p2p.{
+  HeadersMessage,
+  NetworkHeader,
+  NetworkMessage,
+  VerAckMessage
+}
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.blockchain.{BlockHeader, MainNetChainParams}
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
@@ -169,5 +174,32 @@ class NetworkUtilTest extends BitcoinSUtilTest {
     val (messages, leftover) = NetworkUtil.parseIndividualMessages(header.bytes)
     assert(messages.isEmpty)
     assert(leftover.isEmpty)
+  }
+
+  it must "not wedge forever on unparseable bytes at the start of the stream" in {
+    // A "filterload" message whose declared payload (1 byte) is too short
+    // to contain a bloom filter: the header parses fine, but the payload
+    // parse fails deterministically (RawBloomFilterSerializer reads the
+    // flags byte at index 9). Once the full declared payload is present,
+    // this failure can never be fixed by waiting for more bytes -- the
+    // parser must skip it and keep going rather than wedging forever.
+    val badPayload = ByteVector(0.toByte)
+    val badHeader =
+      NetworkHeader(np,
+                    "filterload",
+                    UInt32(badPayload.size),
+                    CryptoUtil.doubleSHA256(badPayload).bytes.take(4))
+    val badBytes = badHeader.bytes ++ badPayload
+
+    val validMessage = NetworkMessage(np, VerAckMessage)
+
+    // feed the stream chunk by chunk, as a TCP stream would arrive
+    val (firstMessages, leftover) =
+      NetworkUtil.parseIndividualMessages(badBytes)
+    val (secondMessages, _) =
+      NetworkUtil.parseIndividualMessages(leftover ++ validMessage.bytes)
+
+    // the valid trailing message must eventually be surfaced
+    (firstMessages ++ secondMessages).map(_.payload) must contain(VerAckMessage)
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
+++ b/core/src/main/scala/org/bitcoins/core/bloom/BloomFilter.scala
@@ -402,6 +402,13 @@ object BloomFilter extends Factory[BloomFilter] {
       hashFuncs: UInt32,
       tweak: UInt32,
       flags: BloomFlag): BloomFilter = {
+    require(
+      filterSize.num.toLong <= maxSize.toLong,
+      s"Bloom filter size cannot be larger than $maxSize, got $filterSize")
+    require(
+      hashFuncs.toLong <= maxHashFuncs.toLong,
+      s"Bloom filter hashFuncs cannot be larger than $maxHashFuncs, got $hashFuncs"
+    )
     BloomFilterImpl(filterSize, data, hashFuncs, tweak, flags)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -1671,8 +1671,11 @@ object NetworkPayload {
       networkHeader: NetworkHeader,
       payloadBytes: ByteVector): NetworkPayload = {
     // the commandName in the network header tells us what payload type this is
-    val deserializer: ByteVector => NetworkPayload = readers(
-      networkHeader.commandName)
+    val deserializer: ByteVector => NetworkPayload = readers.getOrElse(
+      networkHeader.commandName,
+      throw new IllegalArgumentException(
+        s"Unknown command name for network payload: ${networkHeader.commandName}")
+    )
     deserializer(payloadBytes)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
+++ b/core/src/main/scala/org/bitcoins/core/p2p/NetworkPayload.scala
@@ -810,7 +810,10 @@ sealed trait FeeFilterMessage extends ControlPayload {
   def feeRate: SatoshisPerKiloByte
 
   def satPerByte: SatoshisPerByte = {
-    feeRate.toSatPerByte
+    // a peer-supplied fee rate is not guaranteed to be evenly divisible by
+    // 1000, so round rather than demanding exact divisibility (which would
+    // throw for a perfectly valid, just non-round, feerate)
+    feeRate.toSatPerByteRounded
   }
 
   override def commandName: String = NetworkPayload.feeFilterCommandName

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
@@ -2,6 +2,7 @@ package org.bitcoins.core.serializers.p2p
 
 import org.bitcoins.core.p2p._
 import org.bitcoins.core.serializers.RawBitcoinSerializer
+import org.bitcoins.crypto.CryptoUtil
 import scodec.bits.ByteVector
 
 trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
@@ -14,6 +15,13 @@ trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
       throw new RuntimeException(
         s"We do not have enough bytes for payload! Expected=${header.payloadSize.toInt} got=${payloadBytes.length}")
     } else {
+      val declaredPayloadBytes = payloadBytes.take(header.payloadSize.toInt)
+      val actualChecksum =
+        CryptoUtil.doubleSHA256(declaredPayloadBytes).bytes.take(4)
+      require(
+        actualChecksum == header.checksum,
+        s"Checksum does not match, expected=${header.checksum}, got=$actualChecksum"
+      )
       val payload = NetworkPayload(header, payloadBytes)
       val n = NetworkMessage(header, payload)
       n

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/RawNetworkMessageSerializer.scala
@@ -22,7 +22,7 @@ trait RawNetworkMessageSerializer extends RawBitcoinSerializer[NetworkMessage] {
         actualChecksum == header.checksum,
         s"Checksum does not match, expected=${header.checksum}, got=$actualChecksum"
       )
-      val payload = NetworkPayload(header, payloadBytes)
+      val payload = NetworkPayload(header, declaredPayloadBytes)
       val n = NetworkMessage(header, payload)
       n
     }

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawFeeFilterMessageSerializer.scala
@@ -10,14 +10,22 @@ sealed abstract class RawFeeFilterMessageSerializer
     extends RawBitcoinSerializer[FeeFilterMessage] {
 
   override def read(bytes: ByteVector): FeeFilterMessage = {
-    val satBytes = bytes.take(8).reverse
+    // Satoshis(bytes: ByteVector) already reverses (it's read via
+    // RawSatoshisSerializer.read, which expects big-endian and reverses a
+    // little-endian input); reversing here too was a double-reversal bug
+    // that read this little-endian wire field as if big-endian
+    val satBytes = bytes.take(8)
     val sat = Satoshis(satBytes)
     val satPerKb = SatoshisPerKiloByte(sat)
     FeeFilterMessage(satPerKb)
   }
 
   override def write(feeFilterMessage: FeeFilterMessage): ByteVector = {
-    feeFilterMessage.feeRate.currencyUnit.satoshis.bytes.reverse
+    // Satoshis.bytes already produces little-endian wire bytes (via
+    // RawSatoshisSerializer.write, which reverses its big-endian internal
+    // representation); reversing here too was the write-side half of the
+    // same double-reversal bug
+    feeFilterMessage.feeRate.currencyUnit.satoshis.bytes
   }
 }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/p2p/messages/RawVersionMessageSerializer.scala
@@ -53,7 +53,13 @@ trait RawVersionMessageSerializer extends RawBitcoinSerializer[VersionMessage] {
     val startHeight = Int32(
       bytes.slice(startHeightStartIndex, startHeightStartIndex + 4).reverse)
 
-    val relay = bytes(startHeightStartIndex + 4) != 0
+    // the relay byte is optional (added in protocol version 70001, BIP37);
+    // older peers omit it entirely, so default to relay=true rather than
+    // indexing unconditionally and throwing when it's absent
+    val relay =
+      if (bytes.size > startHeightStartIndex + 4)
+        bytes(startHeightStartIndex + 4) != 0
+      else true
 
     VersionMessage(
       version = version,

--- a/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NetworkUtil.scala
@@ -197,21 +197,29 @@ abstract class NetworkUtil {
             val newRemainingBytes =
               remainingBytes.drop(NetworkHeader.bytesSize + payloadBytes.size)
 
-            // If it's a message type we know, try to parse it
-            if (NetworkPayload.commandNames.contains(header.commandName)) {
+            val haveFullPayload = payloadBytes.size == header.payloadSize.toInt
+
+            if (!haveFullPayload) {
+              // don't have the full declared payload yet, wait for more bytes
+              (accum, remainingBytes)
+            } else if (
+              NetworkPayload.commandNames.contains(header.commandName)
+            ) {
+              // If it's a message type we know, try to parse it
               Try(NetworkMessage(header.bytes ++ payloadBytes)) match {
                 case Success(message) =>
                   loop(newRemainingBytes, accum :+ message)
                 case Failure(_) =>
-                  // Can't parse message yet, we need to wait for more bytes
-                  (accum, remainingBytes)
+                  // We already have the full declared payload, so this parse
+                  // failure is deterministic -- more bytes will never fix it.
+                  // Drop this message and continue rather than wedging
+                  // forever on the same bytes.
+                  loop(newRemainingBytes, accum)
               }
-            } else if (payloadBytes.size == header.payloadSize.toInt) { // If we've received the entire unknown message
-              loop(newRemainingBytes, accum)
             } else {
-              // If we can't parse the entire unknown message, continue on until we can
-              // so we properly skip it
-              (accum, remainingBytes)
+              // Unknown command, but we've received the entire message --
+              // skip over it
+              loop(newRemainingBytes, accum)
             }
           case Failure(_) =>
             // this case means that our TCP frame was not aligned with bitcoin protocol


### PR DESCRIPTION
## Summary

Seven p2p message-parsing bugs found during a security review of `core`'s network message layer, each fixed in its own commit. Together they cover: a crash on messages from pre-BIP37 peers, an unverified message checksum, an unhandled unknown command name, unbounded payload slicing, a parser that could wedge forever on malformed bytes, missing BIP37 bloom-filter size limits, and a serializer double-reversal bug (masked by a symmetry-only test) plus an unrelated crash on non-round feerates.

- `core: handle a version message missing the optional relay byte gracefully` — `RawVersionMessageSerializer.read` indexed the relay byte unconditionally, throwing `IndexOutOfBoundsException` for pre-70001 (pre-BIP37) peers that omit it. Now defaults `relay = true` when absent, matching Bitcoin Core.
- `core: reject a network message with a corrupted checksum` — `RawNetworkMessageSerializer.read` never verified the header checksum against the payload, silently accepting corrupted/forged messages. Also fixed a latent stale-checksum bug this surfaced in `NetworkMessageTest`'s bitcoin-wiki fixture.
- `core: produce a clean parse error for an unknown p2p command name` — `NetworkPayload.apply` used a plain `Map.apply` lookup, throwing a raw `NoSuchElementException` for unknown command names instead of a clean error.
- `core: don't interpret trailing bytes beyond payloadSize as part of the payload` — the full remaining buffer (not sliced to the declared `payloadSize`) was passed into `NetworkPayload`, so variable-length trailing fields (e.g. `RejectMessage.extra`) could consume the next message's bytes off the stream.
- `core: don't wedge forever on unparseable bytes at the start of the stream` — `NetworkUtil.parseIndividualMessages` returned unchanged leftover bytes on any parse failure, even with the full declared payload present, so a deterministic parse failure retried forever and hid every later valid message in the stream.
- `core: enforce BIP37 maxSize/maxHashFuncs limits on parsed bloom filters` — `BloomFilter`'s direct construction factory (used when parsing a peer-supplied `filterload`) never enforced BIP37's `maxSize`/`maxHashFuncs` caps, even though the constants already existed and were enforced elsewhere. A crafted filter bypassing the higher-level wrapper could make later `contains`/`insert` calls burn CPU.
- `core: parse a feefilter message with a non-round feerate without throwing` — `FeeFilterMessage.satPerByte` used the exact-conversion variant, throwing on any peer-supplied feerate not evenly divisible by 1000. Fixing this surfaced an unrelated, pre-existing double-reversal bug in `RawFeeFilterMessageSerializer` (read/write each reversed wire bytes that were already reversed internally by `Satoshis`), never caught because the only existing test checked round-trip symmetry, which holds even when both directions are equally wrong.

## Test plan

Each fix's regression test was added directly to the existing suite covering that code path, rather than a new dedicated file:

- [x] `VersionMessageTest` — relay-byte-absent case
- [x] `NetworkMessageTest` — corrupted checksum rejection; trailing-bytes-beyond-payloadSize case
- [x] `NetworkPayloadTest` — unknown command name produces a clean error
- [x] `NetworkUtilTest` — parser doesn't wedge on deterministic parse failure
- [x] `BloomFilterTest` — filterSize/hashFuncs BIP37 limit enforcement
- [x] `FeeFilterMessageTest` — correct (non-double-reversed) endianness decoding; non-round feerate doesn't throw
- [x] Full `coreTestJVM/test` suite: 1718/1718 passed
- [x] `scalafmtCheckAll`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
