### PR TITLE
core: fix 8 transaction/TLV parsing security findings

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/CompactSizeUIntTest.scala
@@ -79,9 +79,14 @@ class CompactSizeUIntTest extends BitcoinSUnitTest {
       CompactSizeUInt(UInt64(500000))
     )
 
-    val str3 = "ffffffffff"
+    // 0xff prefix + the full 8 bytes it requires, encoding a value that
+    // actually needs the 9-byte form (previously this was tested with
+    // UInt32.max, which canonically belongs to the 5-byte 0xfe form, using
+    // only 4 of the 8 required bytes and relying on parseCompactSizeUInt
+    // silently truncating instead of requiring the full 9 bytes)
+    val str3 = "ff0000000001000000"
     CompactSizeUInt.parseCompactSizeUInt(str3) must be(
-      CompactSizeUInt(UInt64(4294967295L), 9)
+      CompactSizeUInt(UInt64(4294967296L), 9)
     )
   }
 
@@ -127,5 +132,24 @@ class CompactSizeUIntTest extends BitcoinSUnitTest {
       val emptyBytes: ByteVector = ByteVector.empty
       CompactSizeUInt.parseCompactSizeUInt(emptyBytes)
     }
+  }
+
+  it must "reject truncated and non-canonical CompactSizeUInt varints" in {
+    // parseCompactSizeUInt used to silently pad truncated multi-byte varints
+    // and accept non-canonical encodings instead of rejecting them.
+
+    // 0xfd prefix requires 2 more bytes, only 1 is present
+    CompactSizeUInt.fromBytesT(BytesUtil.decodeHex("fd01")).isFailure must be(
+      true)
+
+    // non-canonical: value 1 must use the 1-byte form, not the 0xfd form
+    CompactSizeUInt
+      .fromBytesT(BytesUtil.decodeHex("fd0100"))
+      .isFailure must be(true)
+
+    // non-canonical: value 253 must use the 0xfd form, not the 0xfe form
+    CompactSizeUInt
+      .fromBytesT(BytesUtil.decodeHex("fefd000000"))
+      .isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptWitnessSpec.scala
@@ -2,6 +2,9 @@ package org.bitcoins.core.protocol.script
 
 import org.bitcoins.testkitcore.gen.{ScriptGenerators, WitnessGenerators}
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits._
+
+import scala.util.Try
 
 class ScriptWitnessSpec extends BitcoinSUnitTest {
 
@@ -30,6 +33,13 @@ class ScriptWitnessSpec extends BitcoinSUnitTest {
     ) { case ((spk, _), scriptSig) =>
       assert(P2WSHWitnessV0(spk, scriptSig).scriptSignature == scriptSig)
     }
+  }
+
+  it must "reject a witness stack element whose declared length exceeds the remaining bytes" in {
+    // RawScriptWitnessParser.read used to clamp the stack element length with
+    // ByteVector.take instead of failing, silently truncating witness data.
+    // 1 stack item, declared element length 2, only 1 byte available.
+    Try(ScriptWitness.fromBytes(hex"0102ff")).isFailure must be(true)
   }
 
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/tlv/TLVTest.scala
@@ -1,8 +1,12 @@
 package org.bitcoins.core.protocol.tlv
 
+import org.bitcoins.core.protocol.BigSizeUInt
 import org.bitcoins.core.protocol.dlc.models.ContractInfo
 import org.bitcoins.testkitcore.gen.TLVGen
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import scodec.bits.ByteVector
+
+import scala.util.Try
 
 class TLVTest extends BitcoinSUnitTest {
 
@@ -226,4 +230,71 @@ class TLVTest extends BitcoinSUnitTest {
     // https://test.oracle.suredbits.com/contract/numeric/d4d4df2892fb2cfd2e8f030f0e69a568e19668b5d355e7713f69853db09a4c33
     assert(ContractInfo.fromHexOpt(oldHex).isDefined)
   }
+
+  "ValueIterator.takeBigSizePrefixedList" must
+    "not build a result vector proportional to an attacker-controlled count" in {
+      // ValueIterator.takeBigSizePrefixedList used to materialize
+      // `0.until(len.toInt).toVector` from the declared count before parsing
+      // any element. Correct behavior: the declared count is checked against
+      // the remaining bytes first, parsing fails, and no per-element work runs.
+      val declaredCount = 3000000L // millions: wasteful, but no OOM
+      val bytes =
+        BigSizeUInt(declaredCount).bytes ++ ByteVector(0x01, 0x02, 0x03, 0x04)
+      val iter = ValueIterator(bytes)
+
+      var elementParses = 0
+      val result = Try(iter.takeBigSizePrefixedList { () =>
+        elementParses += 1
+        ()
+      })
+
+      assert(
+        result.isFailure,
+        s"Parsing must fail: declared count $declaredCount exceeds the " +
+          s"remaining bytes, but parsing succeeded with " +
+          s"${result.toOption.map(_.length)} elements"
+      )
+      assert(
+        elementParses == 0,
+        s"The element parse function ran $elementParses times even though " +
+          s"the declared count $declaredCount exceeds the remaining bytes")
+    }
+
+  it must
+    "reject an oversized declared count before parsing any element" in {
+      // Correct behavior: parsing fails before the first element parse runs.
+      val declaredCount = 3000000L
+      val iter = ValueIterator(BigSizeUInt(declaredCount).bytes) // 0 elements
+
+      var elementParses = 0
+      val result = Try(iter.takeBigSizePrefixedList { () =>
+        elementParses += 1
+        iter.takeU16() // minimal element read, throws when out of bytes
+      })
+
+      assert(result.isFailure,
+             "Parsing must fail when the declared count exceeds the " +
+               "remaining bytes")
+      assert(
+        elementParses == 0,
+        s"Element parsing started ($elementParses parse attempts) before " +
+          s"the declared count $declaredCount was checked")
+    }
+
+  "ContractDescriptorV0TLV" must
+    "fail when the declared outcome count exceeds the value bytes" in {
+      // ContractDescriptorV0TLV.fromTLVValue uses
+      // ValueIterator.takeBigSizePrefixedList. Correct behavior: a value that
+      // declares millions of outcomes but contains none must fail to parse
+      // instead of trusting the count.
+      val declaredCount = 3000000L
+      val value = BigSizeUInt(declaredCount).bytes // count only, 0 outcomes
+
+      val result = Try(ContractDescriptorV0TLV.fromTLVValue(value))
+
+      assert(
+        result.isFailure,
+        s"Parsing must fail: declared outcome count $declaredCount exceeds " +
+          s"the ${value.length} value bytes")
+    }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -552,6 +552,16 @@ class TransactionTest extends BitcoinSUnitTest {
     Transaction.fromHexT(genesisCoinbaseTx.dropRight(2)).isFailure must be(true)
   }
 
+  it must "fail with a parse error (not a raw index exception) on very short transaction input" in {
+    // Transaction.fromBytes used to do unchecked bytes(4)/bytes(5) indexing,
+    // so input shorter than 6 bytes threw a raw IndexOutOfBoundsException
+    // instead of a proper parse failure.
+    val ex = intercept[Exception] {
+      Transaction.fromBytes(hex"0100000000")
+    }
+    ex.isInstanceOf[IndexOutOfBoundsException] must be(false)
+  }
+
   private def findInput(
       tx: Transaction,
       outPoint: TransactionOutPoint

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -502,6 +502,34 @@ class TransactionTest extends BitcoinSUnitTest {
     assert(tx.hex == hex)
   }
 
+  it must "reject a malformed witness transaction instead of silently re-parsing it as a base transaction" in {
+    // Transaction.fromBytes used to catch any failure while parsing the
+    // witness section and silently re-parse the SAME bytes as a base
+    // transaction, dropping the witness intent. Correct behavior: parsing
+    // fails.
+    // The bytes below have a valid marker/flag, 1 input and 1 output, but the
+    // witness section declares 2 stack items whose encoding consumes bytes
+    // into the locktime, leaving only 3 locktime bytes. WitnessTransaction
+    // parsing fails; the old fallback would then parse the bytes as a base tx
+    // (0 inputs, 1 garbage output).
+    val malformedWitnessTx =
+      "01000000" + // version
+        "0001" + // witness marker + flag
+        "01" + // 1 input
+        "0000000000000000000000000000000000000000000000000000000000000000" + // prev txid
+        "00000000" + // vout
+        "00" + // empty scriptSig
+        "ffffffff" + // sequence
+        "01" + // 1 output
+        "0000000000000000" + // 0 satoshis
+        "00" + // empty scriptPubKey
+        "02" + // witness: 2 stack items
+        "01" + "aa" + // item 1: len 1
+        // item 2 is parsed out of the locktime bytes below
+        "00000000" // locktime
+    Transaction.fromHexT(malformedWitnessTx).isFailure must be(true)
+  }
+
   private def findInput(
       tx: Transaction,
       outPoint: TransactionOutPoint

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -149,6 +149,20 @@ class TransactionTest extends BitcoinSUnitTest {
     tx2.baseSize must be(106)
   }
 
+  it must "reject a witness transaction with a flag byte other than 1" in {
+    // WitnessTransaction.fromBytes used to only require flag != 0. BIP144
+    // defines the flag as exactly 0x01 and Bitcoin Core rejects any other
+    // value.
+    // Same fixture as the sipa 3rd segwit tx above
+    // (c586389e5e4b3acb9d6c8be1c19ae8ab2795397633176f5a6442a261bbdefc3a),
+    // with the flag byte changed 01 -> 02.
+    val invalidFlagTx =
+      "02000000" + // version
+        "00" + "02" + // marker 0, INVALID flag 2
+        "0140d43a99926d43eb0e619bf0b3d83b4a31f60c176beecfb9d35bf45e54d0f7420100000017160014a4b4ca48de0b3fffc15404a1acdc8dbaae226955ffffffff0100e1f5050000000017a9144a1154d50b03292b3024370901711946cb7cccc387024830450221008604ef8f6d8afa892dee0f31259b6ce02dd70c545cfcfed8148179971876c54a022076d771d6e91bed212783c9b06e0de600fab2d518fad6f15a2b191d7fbd262a3e0121039d25ab79f41f75ceaf882411fd41fa670a4c672c23ffaf0e361a969cde0692e800000000"
+    WitnessTransaction.fromHexT(invalidFlagTx).isFailure must be(true)
+  }
+
   it must "parse a transaction with an OP_PUSHDATA4 op code but not enough data to push" in {
     val hex =
       "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2a03f35c0507062f503253482ffe4ecb3b55fefbde06000963676d696e6572343208040000000000000000ffffffff0100f90295000000001976a91496621bc1c9d1e5a1293e401519365de820792bbc88ac00000000"

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -530,6 +530,28 @@ class TransactionTest extends BitcoinSUnitTest {
     Transaction.fromHexT(malformedWitnessTx).isFailure must be(true)
   }
 
+  it must "reject trailing garbage and a truncated locktime in a base transaction" in {
+    // Transaction.fromHex used to have no way to detect trailing garbage
+    // (fromBytes is also used as the per-element parser when deserializing a
+    // sequence of transactions sharing one buffer, so it can't reject
+    // trailing bytes itself), and BaseTransaction.fromBytes took locktime as
+    // lockTimeBytes.take(4), silently zero-padding a truncated locktime
+    // instead of failing.
+    // genesis block coinbase tx, https://en.bitcoin.it/wiki/Genesis_block
+    val genesisCoinbaseTx =
+      "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4" +
+        "d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e2062726" +
+        "96e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678" +
+        "afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c3" +
+        "84df7ba0b8d578a4c702b6bf11d5fac00000000"
+
+    // trailing garbage after a valid base transaction
+    Transaction.fromHexT(genesisCoinbaseTx + "deadbeef").isFailure must be(true)
+
+    // truncated locktime (last byte removed) must not be zero-padded
+    Transaction.fromHexT(genesisCoinbaseTx.dropRight(2)).isFailure must be(true)
+  }
+
   private def findInput(
       tx: Transaction,
       outPoint: TransactionOutPoint

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TxUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TxUtilTest.scala
@@ -48,6 +48,17 @@ class TxUtilTest extends BitcoinSUnitTest {
       .isFailure must be(true)
   }
 
+  it should "detect Long overflow in fee multiplication instead of silently wrapping" in {
+    // isValidFeeRange used to compute 40 * feeRate.toLong with plain Long
+    // arithmetic, so an extreme fee rate would silently wrap instead of
+    // failing.
+    val hugeFeeRatePerVByte =
+      SatoshisPerVirtualByte(Satoshis(Long.MaxValue / 40 + 1))
+    an[ArithmeticException] must be thrownBy TxUtil
+      .isValidFeeRange(Satoshis(100), Satoshis(50), hugeFeeRatePerVByte)
+      .get
+  }
+
   it should "detect impossibly high fees" in {
     val newOutput = TransactionOutput(Bitcoins.zero, EmptyScriptPubKey)
     val highFeeTx =

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializerTest.scala
@@ -8,6 +8,8 @@ import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
+import scala.util.Try
+
 /** Created by tom on 6/3/16.
   */
 class RawBlockSerializerTest extends BitcoinSUnitTest {
@@ -136,5 +138,11 @@ class RawBlockSerializerTest extends BitcoinSUnitTest {
     block.blockHeader must be(RawBlockHeaderSerializer.read(header))
     block.txCount.num must be(UInt64(txSeq.size))
     block.hex must be(hex)
+  }
+
+  it must "reject trailing garbage after the last transaction in a block" in {
+    // RawBlockSerializer.read used to discard whatever bytes were left over
+    // after parsing the declared transactions instead of failing.
+    Try(RawBlockSerializer.read(hex + "deadbeef")).isFailure must be(true)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParserTest.scala
@@ -10,6 +10,8 @@ import org.bitcoins.testkitcore.util.TestUtil
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 import scodec.bits.ByteVector
 
+import scala.util.Try
+
 /** Created by chris on 1/12/16.
   */
 class RawScriptPubKeyParserTest extends BitcoinSUnitTest {
@@ -59,6 +61,15 @@ class RawScriptPubKeyParserTest extends BitcoinSUnitTest {
       "ca4cae606563686f2022553246736447566b58312b5a536e587574356542793066794778625456415675534a6c376a6a334878416945325364667657734f53474f36633338584d7439435c6e543249584967306a486956304f376e775236644546673d3d22203e20743b206f70656e73736c20656e63202d7061737320706173733a5b314a564d7751432d707269766b65792d6865785d202d64202d6165732d3235362d636263202d61202d696e2074607576a914bfd7436b6265aa9de506f8a994f881ff08cc287288ac"
     )
 
+  }
+
+  it must "reject a scriptPubKey whose declared length exceeds the available bytes" in {
+    // parseScript(strict = true) used to clamp a declared script length to
+    // the available bytes instead of failing. scriptPubKey declares 25 bytes
+    // but only 24 are present.
+    val truncatedScript =
+      "1976a9143b75df7c44a47fed51374aef67bb7e7ae071b0a788"
+    Try(RawScriptPubKeyParser.read(truncatedScript)).isFailure must be(true)
   }
 
 }

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxFinalizerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/builder/RawTxFinalizerTest.scala
@@ -129,11 +129,15 @@ class RawTxFinalizerTest extends BitcoinSUnitTest {
     val sortedOutputs: Vector[TransactionOutput] = Vector(
       TransactionOutput(
         Satoshis(400057456),
-        ScriptPubKey("76a9144a5fba237213a062f6f57978f796390bdcf8d01588ac")
+        // fromAsmHex, not the CompactSizeUInt-prefixed apply(hex): this hex
+        // is raw script bytes with no length prefix
+        ScriptPubKey.fromAsmHex(
+          "76a9144a5fba237213a062f6f57978f796390bdcf8d01588ac")
       ),
       TransactionOutput(
         Satoshis(40000000000L),
-        ScriptPubKey("76a9145be32612930b8323add2212a4ec03c1562084f8488ac")
+        ScriptPubKey.fromAsmHex(
+          "76a9145be32612930b8323add2212a4ec03c1562084f8488ac")
       )
     )
 

--- a/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/wallet/fee/FeeUnitTest.scala
@@ -168,4 +168,11 @@ class FeeUnitTest extends BitcoinSUnitTest {
         .fromLong(98494)
     )
   }
+
+  it must "detect Long overflow in fee multiplication instead of silently wrapping" in {
+    // FeeUnit.* used to multiply with plain Long arithmetic, so extreme fee
+    // rates would silently wrap to a small/negative fee instead of failing.
+    val hugeFeeRate = SatoshisPerByte(Satoshis(Long.MaxValue / 2))
+    an[ArithmeticException] must be thrownBy (hugeFeeRate * 4L)
+  }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -90,8 +90,15 @@ sealed abstract class TransactionSignatureSerializer {
           s = input.scriptSignature
         } yield TransactionInput(
           input.previousOutput,
-          NonStandardScriptSignature(s.compactSizeUInt.hex),
-          input.sequence)
+          // strict=false: this is a deliberate placeholder consisting of just
+          // s's compactSizeUInt length-prefix with no script bytes following
+          // it, mirroring Bitcoin Core's CScript retaining only its compact
+          // size while clearing out the actual asm -- not untrusted wire data
+          NonStandardScriptSignature.fromBytes(
+            BytesUtil.decodeHex(s.compactSizeUInt.hex),
+            strict = false),
+          input.sequence
+        )
 
         // make sure all scriptSigs have empty asm
         inputSigsRemoved.foreach(input =>

--- a/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/CompactSizeUInt.scala
@@ -126,13 +126,38 @@ object CompactSizeUInt extends Factory[CompactSizeUInt] {
     if (firstByte < 253)
       CompactSizeUInt(UInt64(firstByte), 1)
     // 16 bit number
-    else if (firstByte.toInt == 253)
-      CompactSizeUInt(UInt64(bytes.slice(1, 3).reverse), 3)
+    else if (firstByte.toInt == 253) {
+      require(
+        bytes.length >= 3,
+        s"Not enough bytes to parse a 16 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 3).reverse)
+      require(
+        num.toBigInt >= 253,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xfd prefix")
+      CompactSizeUInt(num, 3)
+    }
     // 32 bit number
-    else if (firstByte.toInt == 254)
-      CompactSizeUInt(UInt64(bytes.slice(1, 5).reverse), 5)
+    else if (firstByte.toInt == 254) {
+      require(
+        bytes.length >= 5,
+        s"Not enough bytes to parse a 32 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 5).reverse)
+      require(
+        num.toBigInt > 0xffffL,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xfe prefix")
+      CompactSizeUInt(num, 5)
+    }
     // 64 bit number
-    else CompactSizeUInt(UInt64(bytes.slice(1, 9).reverse), 9)
+    else {
+      require(
+        bytes.length >= 9,
+        s"Not enough bytes to parse a 64 bit CompactSizeUInt, got ${bytes.length}")
+      val num = UInt64(bytes.slice(1, 9).reverse)
+      require(
+        num.toBigInt > UInt32.max.toBigInt,
+        s"Non-canonical CompactSizeUInt encoding, $num does not need the 0xff prefix")
+      CompactSizeUInt(num, 9)
+    }
   }
 
   def parse(bytes: ByteVector): CompactSizeUInt = parseCompactSizeUInt(bytes)

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptFactory.scala
@@ -27,8 +27,15 @@ trait ScriptFactory[T <: Script] extends Factory[T] {
     */
   def fromAsm(asm: Seq[ScriptToken]): T
 
-  def fromBytes(bytes: ByteVector): T = {
-    BitcoinScriptUtil.parseScript(bytes = bytes, f = fromAsm)
+  def fromBytes(bytes: ByteVector): T = fromBytes(bytes, strict = true)
+
+  /** @param strict
+    *   see [[org.bitcoins.core.util.BitcoinScriptUtil.parseScript]]. Only pass
+    *   false for a deliberate, non-wire-data placeholder construction -- never
+    *   when parsing untrusted bytes.
+    */
+  def fromBytes(bytes: ByteVector, strict: Boolean): T = {
+    BitcoinScriptUtil.parseScript(bytes = bytes, f = fromAsm, strict = strict)
   }
 
   /** Scripts are serialized with a

--- a/core/src/main/scala/org/bitcoins/core/protocol/tlv/ValueIterator.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/tlv/ValueIterator.scala
@@ -66,9 +66,21 @@ case class ValueIterator(value: ByteVector) {
 
   def takeBigSizePrefixedList[E](takeFunc: () => E): Vector[E] = {
     val len = takeBigSize()
-    0.until(len.toInt).toVector.map { _ =>
-      takeFunc()
+    val declaredCount = len.toInt
+    // every element consumes at least one byte, so a declared count greater
+    // than the remaining bytes can never be satisfied -- reject it before
+    // allocating anything proportional to the (attacker-controlled) count
+    require(
+      declaredCount <= current.length,
+      s"Declared count $declaredCount exceeds the ${current.length} remaining bytes"
+    )
+    val builder = Vector.newBuilder[E]
+    var i = 0
+    while (i < declaredCount) {
+      builder += takeFunc()
+      i += 1
     }
+    builder.result()
   }
 
   def takeU16(): UInt16 = {

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -180,6 +180,27 @@ object Transaction extends Factory[Transaction] {
     tx
   }
 
+  /** Note: unlike [[fromBytes]], this requires `hex` to decode to EXACTLY one
+    * transaction with no trailing bytes left over. [[fromBytes]] itself cannot
+    * enforce that: it also serves as the per-element parser when deserializing
+    * a sequence of transactions sharing one buffer (e.g. a block's transaction
+    * list in RawBlockSerializer), where bytes trailing a single parsed
+    * transaction are the start of the next one, not garbage. A hex string, by
+    * contrast, is always meant to represent exactly one transaction --
+    * mirroring Bitcoin Core's own split between its stream-based tx
+    * deserializer (never checks for leftover bytes) and DecodeHexTx (which
+    * explicitly checks the stream is empty afterward).
+    */
+  override def fromHex(hex: String): Transaction = {
+    val bytes = org.bitcoins.crypto.CryptoBytesUtil.decodeHex(hex)
+    val tx = fromBytes(bytes)
+    require(
+      tx.bytes.length == bytes.length,
+      s"${bytes.length - tx.bytes.length} trailing bytes after a complete transaction"
+    )
+    tx
+  }
+
   /** This allows us to accurately type transaction input's
     * [[org.bitcoins.core.protocol.script.ScriptSignature]] as we have the
     * corresponding [[org.bitcoins.core.protocol.script.ScriptPubKey]] the input
@@ -241,6 +262,15 @@ object BaseTransaction extends Factory[BaseTransaction] {
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)
     val (outputs, lockTimeBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(outputBytes, TransactionOutput)
+    // intentionally >= rather than ==: fromBytes is used to parse a single
+    // transaction out of a longer byte string that may have more data
+    // trailing the locktime (e.g. the next transaction in a block), and is
+    // not itself responsible for rejecting trailing garbage -- see the
+    // Transaction.fromHex doc comment above, which is the entry point that
+    // enforces "exactly one transaction, no trailing bytes"
+    require(
+      lockTimeBytes.length >= 4,
+      s"Must have at least 4 bytes for locktime, got=${lockTimeBytes.length}")
     val lockTime = UInt32(lockTimeBytes.take(4).reverse)
 
     BaseTransaction(version, inputs, outputs, lockTime)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -405,8 +405,8 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
       "Incorrect marker for witness transaction, the marker MUST be 0 for the marker according to BIP141, got: " + marker)
     val flag = bytes(5)
     require(
-      flag.toInt != 0,
-      "Incorrect flag for witness transaction, this must NOT be 0 according to BIP141, got: " + flag)
+      flag == WitnessTransaction.flag,
+      "Incorrect flag for witness transaction, BIP141 defines the flag as exactly 1, got: " + flag)
     val txInputBytes = bytes.slice(6, bytes.size)
     val (inputs, outputBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -124,7 +124,7 @@ object Transaction extends Factory[Transaction] {
     // https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-id
     val tx = {
       if (
-        bytes(4) == WitnessTransaction.marker && bytes(
+        bytes.length > 5 && bytes(4) == WitnessTransaction.marker && bytes(
           5) == WitnessTransaction.flag
       ) {
         // this throw/catch is _still_ necessary for the case where we have unsigned base transactions

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/Transaction.scala
@@ -132,11 +132,46 @@ object Transaction extends Factory[Transaction] {
         // these transactions will not have a script witness associated with them making them invalid
         // witness transactions (you need to have a witness to be considered a witness tx)
         // see: https://github.com/bitcoin-s/bitcoin-s/blob/01d89df1b7c6bc4b1594406d54d5e6019705c654/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala#L88
-        try {
-          WitnessTransaction.fromBytes(bytes)
-        } catch {
-          case scala.util.control.NonFatal(_) =>
+        //
+        // This mirrors how Bitcoin Core actually disambiguates the
+        // marker/flag bytes: Core reads the input vector first, and only
+        // reinterprets the following byte as a witness flag if that read
+        // comes back empty (see UnserializeTransaction in
+        // primitives/transaction.h). So the fallback to reinterpreting as a
+        // base transaction is only ever considered when the witness-format
+        // input vector itself came back empty; once a non-empty input
+        // vector has parsed successfully, the bytes are unambiguously meant
+        // to be a witness transaction, and any later failure (e.g. a
+        // malformed witness stack or truncated locktime) is a genuine parse
+        // error that must not be silently reinterpreted as an unrelated
+        // base transaction.
+        scala.util.Try(WitnessTransaction.parseInputsAndOutputs(bytes)) match {
+          case scala.util.Failure(_) =>
             BaseTransaction.fromBytes(bytes)
+          // inputs.isEmpty here means there are zero outpoints/sequence
+          // numbers to build a witness for, which is fine on its own --
+          // TransactionWitness(witnessBytes, inputs.size = 0) trivially
+          // consumes zero witness stacks. This branch exists for the
+          // marker/flag ambiguity above: retry the witness/locktime parse
+          // in case this really is a valid, if unusual, zero-input witness
+          // tx, and only fall back to the base-tx reinterpretation if that
+          // retry itself fails (e.g. the remaining bytes are not a valid
+          // 4+ byte locktime).
+          case scala.util.Success((version, inputs, outputs, witnessBytes))
+              if inputs.isEmpty =>
+            scala.util
+              .Try {
+                WitnessTransaction.fromParsedInputsAndOutputs(version,
+                                                              inputs,
+                                                              outputs,
+                                                              witnessBytes)
+              }
+              .getOrElse(BaseTransaction.fromBytes(bytes))
+          case scala.util.Success((version, inputs, outputs, witnessBytes)) =>
+            WitnessTransaction.fromParsedInputsAndOutputs(version,
+                                                          inputs,
+                                                          outputs,
+                                                          witnessBytes)
         }
       } else {
         BaseTransaction.fromBytes(bytes)
@@ -311,6 +346,27 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
     * [[https://github.com/bitcoin/bitcoin/blob/e8cfe1ee2d01c493b758a67ad14707dca15792ea/src/primitives/transaction.h#L244-L251]]
     */
   override def fromBytes(bytes: ByteVector): WitnessTransaction = {
+    val (version, inputs, outputs, witnessBytes) =
+      parseInputsAndOutputs(bytes)
+    fromParsedInputsAndOutputs(version, inputs, outputs, witnessBytes)
+  }
+
+  /** Parses the version and BIP141 marker/flag/input-vector/output-vector
+    * portion of a witness-serialized transaction, without parsing the witness
+    * stacks or locktime that follow.
+    *
+    * Exposed separately (rather than folded into [[fromBytes]]) so
+    * [[Transaction.fromBytes]] can distinguish a failure here -- which can mean
+    * the bytes were never really witness-formatted to begin with, see the
+    * marker/flag ambiguity noted there -- from a failure while parsing the
+    * witness/locktime section of bytes that unambiguously did parse as a
+    * witness transaction's input/output vectors.
+    */
+  private[transaction] def parseInputsAndOutputs(
+      bytes: ByteVector): (Int32,
+                           Vector[TransactionInput],
+                           Vector[TransactionOutput],
+                           ByteVector) = {
     val versionBytes = bytes.take(4)
     val version = Int32(versionBytes.reverse)
     val marker = bytes(4)
@@ -326,6 +382,18 @@ object WitnessTransaction extends Factory[WitnessTransaction] {
       BytesUtil.parseCmpctSizeUIntSeq(txInputBytes, TransactionInput)
     val (outputs, witnessBytes) =
       BytesUtil.parseCmpctSizeUIntSeq(outputBytes, TransactionOutput)
+    (version, inputs, outputs, witnessBytes)
+  }
+
+  /** Parses the witness stacks and locktime following an already-parsed
+    * input/output vector pair (see [[parseInputsAndOutputs]]) and builds the
+    * resulting [[WitnessTransaction]].
+    */
+  private[transaction] def fromParsedInputsAndOutputs(
+      version: Int32,
+      inputs: Vector[TransactionInput],
+      outputs: Vector[TransactionOutput],
+      witnessBytes: ByteVector): WitnessTransaction = {
     val witness = TransactionWitness(witnessBytes, inputs.size)
     val lockTimeBytes = witnessBytes.drop(witness.byteSize)
     require(

--- a/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/transaction/TxUtil.scala
@@ -326,7 +326,7 @@ object TxUtil {
       // See this link for more info on variance in size on ECDigitalSignatures
       // https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm
 
-      val acceptableVariance = 40 * feeRate.toLong
+      val acceptableVariance = Math.multiplyExact(40L, feeRate.toLong)
       val min = Satoshis(-acceptableVariance)
       val max = Satoshis(acceptableVariance)
       val difference = estimatedFee - actualFee

--- a/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/blockchain/RawBlockSerializer.scala
@@ -14,8 +14,11 @@ sealed abstract class RawBlockSerializer extends RawBitcoinSerializer[Block] {
   def read(bytes: ByteVector): Block = {
     val blockHeader: BlockHeader = BlockHeader(bytes.take(80))
     val txBytes: ByteVector = bytes.splitAt(80)._2
-    val (transactions, _) = RawSerializerHelper
+    val (transactions, remaining) = RawSerializerHelper
       .parseCmpctSizeUIntSeq[Transaction](txBytes, Transaction(_: ByteVector))
+    require(
+      remaining.isEmpty,
+      s"${remaining.length} trailing bytes after the last transaction in a block")
     Block(blockHeader, transactions)
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptPubKeyParser.scala
@@ -12,7 +12,9 @@ trait RawScriptPubKeyParser extends RawBitcoinSerializer[ScriptPubKey] {
   override def read(bytes: ByteVector): ScriptPubKey = {
     if (bytes.isEmpty) EmptyScriptPubKey
     else {
-      BitcoinScriptUtil.parseScript(bytes = bytes, f = ScriptPubKey.fromAsm)
+      BitcoinScriptUtil.parseScript(bytes = bytes,
+                                    f = ScriptPubKey.fromAsm,
+                                    strict = true)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptSignatureParser.scala
@@ -13,7 +13,9 @@ sealed abstract class RawScriptSignatureParser
   def read(bytes: ByteVector): ScriptSignature = {
     if (bytes.isEmpty) EmptyScriptSignature
     else {
-      BitcoinScriptUtil.parseScript(bytes = bytes, f = ScriptSignature.fromAsm)
+      BitcoinScriptUtil.parseScript(bytes = bytes,
+                                    f = ScriptSignature.fromAsm,
+                                    strict = true)
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
+++ b/core/src/main/scala/org/bitcoins/core/serializers/script/RawScriptWitnessParser.scala
@@ -27,6 +27,10 @@ sealed abstract class RawScriptWitnessParser
         val elementSize = CompactSizeUInt.parseCompactSizeUInt(remainingBytes)
         val (_, stackElementBytes) =
           remainingBytes.splitAt(elementSize.byteSize.toInt)
+        require(
+          stackElementBytes.length >= elementSize.num.toInt,
+          s"Witness stack element declares length ${elementSize.num} but only ${stackElementBytes.length} bytes remain"
+        )
         val stackElement = stackElementBytes.take(elementSize.num.toInt)
         val (_, newRemainingBytes) =
           stackElementBytes.splitAt(stackElement.size)

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -658,9 +658,20 @@ trait BitcoinScriptUtil {
     }
   }
 
+  /** @param strict
+    *   when true (the default, and the correct choice for parsing untrusted
+    *   wire data), require that exactly `len` bytes (the declared script
+    *   length) were actually available, rejecting truncated input. Only pass
+    *   false for a deliberate, non-wire-data construction like
+    *   TransactionSignatureSerializer's legacy sighash algorithm, which mirrors
+    *   Bitcoin Core's CScript handling by constructing a script from just a
+    *   length-prefix with no bytes following it as a placeholder -- see the
+    *   `strict` overload of `ScriptFactory.fromBytes`.
+    */
   def parseScript[T <: Script](
       bytes: ByteVector,
-      f: Vector[ScriptToken] => T): T = {
+      f: Vector[ScriptToken] => T,
+      strict: Boolean = true): T = {
     val compactSizeUInt = CompactSizeUInt.parseCompactSizeUInt(bytes)
     // TODO: Figure out a better way to do this, we can theoretically have numbers larger than Int.MaxValue,
     // but scala collections don't allow you to use 'slice' with longs
@@ -668,6 +679,11 @@ trait BitcoinScriptUtil {
     val scriptPubKeyBytes =
       bytes.slice(compactSizeUInt.byteSize.toInt,
                   len + compactSizeUInt.byteSize.toInt)
+    if (strict) {
+      require(
+        scriptPubKeyBytes.length == len,
+        s"Declared script length $len exceeds the ${scriptPubKeyBytes.length} available bytes")
+    }
     val script: Vector[ScriptToken] = ScriptParser.fromBytes(scriptPubKeyBytes)
     f(script)
   }

--- a/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
+++ b/core/src/main/scala/org/bitcoins/core/wallet/fee/FeeUnit.scala
@@ -12,7 +12,8 @@ sealed abstract class FeeUnit {
   final def *(cu: CurrencyUnit): CurrencyUnit = this * cu.satoshis.toLong
   final def *(int: Int): CurrencyUnit = this * int.toLong
 
-  final def *(long: Long): CurrencyUnit = Satoshis(toLong * long / scaleFactor)
+  final def *(long: Long): CurrencyUnit = Satoshis(
+    Math.multiplyExact(toLong, long) / scaleFactor)
   def *(tx: Transaction): CurrencyUnit = calc(tx)
 
   def factory: FeeUnitFactory[FeeUnit]


### PR DESCRIPTION
## Summary
- Fixes 8 security-reproduction findings in the core module's transaction/TLV/block parsing paths (unbounded allocation from attacker-controlled counts, malformed witness tx reinterpretation, trailing-garbage/truncated-field acceptance, short-input crashes, non-canonical CompactSizeUInt varints, oversized witness stack elements, invalid witness flag bytes, and Long-overflow in fee-rate multiplication).
- Each fix is its own commit (1 bug per commit) with its reproduction test relocated into an existing test suite (`TxUtilTest`, `FeeUnitTest`, and others touched by the fixes) rather than a new test file.
- One additional finding from the original investigation (out-of-money-range transaction output values accepted at parse time) was intentionally left unfixed — see the last commit's message for the rationale (mirrors Bitcoin Core's own separation between raw deserialization and `CheckTransaction`-level consensus validation).

## Test plan
- [x] Each commit's relocated test passes individually
- [x] Full `coreTestJVM/test`: 1722/1722 passed
- [x] `scalafmtCheckAll`: clean
- [x] No new test files added — confirmed no `core-test/.../security/` paths in this branch's history

This is part of a 5-PR split of #6454 (closed in favor of these smaller, logically-grouped PRs) — this one covers transaction/TLV parsing. The other four cover P2P networking (#6458), merkle/consensus, script arithmetic (#6457), and signature checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)