### PR TITLE
core: fix 12 sighash/taproot signature-checking security findings

### DIFF
--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -6,15 +6,16 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.PreExecutionScriptProgram
-import org.bitcoins.core.script.constant.ScriptToken
+import org.bitcoins.core.script.constant.{OP_0, ScriptConstant, ScriptToken}
 import org.bitcoins.core.script.flag.{
   ScriptFlag,
   ScriptVerifyLowS,
   ScriptVerifyNullFail
 }
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
-import org.bitcoins.core.script.result.ScriptOk
+import org.bitcoins.core.script.result.{ScriptErrorSigNullFail, ScriptOk}
 import org.bitcoins.core.script.util.PreviousOutputMap
+import org.bitcoins.core.util.BitcoinScriptUtil
 import org.bitcoins.crypto._
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
@@ -211,7 +212,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2shMultiSig1, p2shMultiSig2),
         List(p2shMultiPubKey1, p2shMultiPubKey2),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2shMultiSig1, p2shMultiSig2)
       )
 
     assert(result3.isValid, s"result: $result3")
@@ -363,7 +365,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2wshSig1, p2wshSig2),
         List(p2wshPubKey1, p2wshPubKey2),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2wshSig1, p2wshSig2)
       )
 
     assert(result3.isValid, s"result: $result3")
@@ -566,7 +569,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2shMultiSig1, p2shMultiSig2),
         List(incorrectPubKey, p2shMultiPubKey2),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2shMultiSig1, p2shMultiSig2)
       )
 
     assert(!result3.isValid, s"result: $result3")
@@ -610,7 +614,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2shMultiSig1, p2shMultiSig2),
         List(p2shMultiPubKey1, incorrectPubKey),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2shMultiSig1, p2shMultiSig2)
       )
 
     assert(!result3.isValid, s"result: $result3")
@@ -632,7 +637,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2shMultiSig1, p2shMultiSig2),
         List(p2shMultiPubKey1, p2shMultiPubKey2),
         Policy.standardFlags,
-        1
+        1,
+        originalSigs = List(p2shMultiSig1, p2shMultiSig2)
       )
     )
 
@@ -643,7 +649,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2shMultiSig1, p2shMultiSig2),
         List(p2shMultiPubKey1, p2shMultiPubKey2),
         Policy.standardFlags,
-        -1
+        -1,
+        originalSigs = List(p2shMultiSig1, p2shMultiSig2)
       )
     )
   }
@@ -763,7 +770,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2wshSig1, p2wshSig2),
         List(incorrectPubKey, p2wshPubKey2),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2wshSig1, p2wshSig2)
       )
 
     assert(!result3.isValid, s"result: $result3")
@@ -808,7 +816,8 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
         List(p2wshSig1, p2wshSig2),
         List(p2wshPubKey1, incorrectPubKey),
         Policy.standardFlags,
-        2
+        2,
+        originalSigs = List(p2wshSig1, p2wshSig2)
       )
 
     assert(!result3.isValid, s"result: $result3")
@@ -915,5 +924,47 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       signature = ECDigitalSignature.empty,
       flags = Seq(ScriptVerifyLowS))
     result must be(SignatureValidationErrorIncorrectSignatures)
+  }
+
+  it must "apply NULLFAIL to all signatures in OP_CHECKMULTISIG, including consumed ones" in {
+    // NULLFAIL (BIP146) applies to every signature originally provided to
+    // OP_CHECKMULTISIG, not just the ones remaining once validation is
+    // determined to have failed -- a signature that matched earlier and was
+    // consumed must still fail the script if overall validation fails.
+    // LOW_S is removed to decouple this test from the empty-signature LOW_S case.
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyLowS)
+    val pubKey1 = privKey1.publicKey
+    val pubKey2 = privKey2.publicKey
+    val multiSigSPK = MultiSignatureScriptPubKey(2, Vector(pubKey1, pubKey2))
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(multiSigSPK, Some(amount))
+    val (placeholderTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex)
+    val output = TransactionOutput(amount, multiSigSPK)
+    val placeholderComponent =
+      BaseTxSigComponent(placeholderTx, inputIndex, output, flags)
+    val hash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    // pubKey2 is pushed last in the multisig script, so it is checked first
+    val validSig =
+      privKey2.sign(hash.bytes).appendHashType(HashType.sigHashAll)
+    val sigPush = BitcoinScriptUtil.calculatePushOp(validSig.bytes) ++ Vector(
+      ScriptConstant(validSig.bytes))
+    // dummy, empty signature, valid signature — the valid signature is on top
+    // of the stack and is checked (and consumed) first
+    val scriptSig =
+      NonStandardScriptSignature.fromAsm(Vector(OP_0, OP_0) ++ sigPush)
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   scriptSig,
+                                                   outputIndex)
+    val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptErrorSigNullFail)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -1,22 +1,25 @@
 package org.bitcoins.core.crypto
 
+import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
-import org.bitcoins.core.protocol.script.{
-  MultiSignatureScriptPubKey,
-  ScriptPubKey
-}
+import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.constant.ScriptToken
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.crypto.{ECDigitalSignature, ECPublicKey, ECPublicKeyBytes}
-import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import org.bitcoins.crypto._
+import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
+import scodec.bits.ByteVector
 
 /** Created by chris on 2/29/16.
   */
 class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
 
   behavior of "TransactionSignatureChecker"
+
+  // fixed, deterministic key -- no randomness in this security regression test
+  private val privKey1: ECPrivateKey =
+    ECPrivateKey.fromFieldElement(FieldElement.one)
 
   // Positive Test Cases
 
@@ -761,6 +764,60 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
       )
 
     assert(!result3.isValid, s"result: $result3")
+  }
+
+  it must "commit the segwit v0 sighash to the scriptCode after the last executed OP_CODESEPARATOR" in {
+    // BIP143 commits the sighash to the scriptCode after the last executed
+    // OP_CODESEPARATOR, not the full witness script.
+    val pubKey = privKey1.publicKey
+    // <pubkey> OP_CODESEPARATOR OP_CHECKSIG
+    val fullScriptBytes = ByteVector.fromValidHex("21") ++ pubKey.bytes ++
+      ByteVector.fromValidHex("abac")
+    val witnessScript = ScriptPubKey
+      .fromAsmBytes(fullScriptBytes)
+      .asInstanceOf[RawScriptPubKey]
+    // the scriptCode Core would use: everything after the last OP_CODESEPARATOR
+    val strippedScript =
+      ScriptPubKey.fromAsmBytes(ByteVector.fromValidHex("ac"))
+    val p2wsh = P2WSHWitnessSPKV0(witnessScript)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(p2wsh, Some(amount))
+    val witness = P2WSHWitnessV0(witnessScript, Vector.empty)
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+    val flags = Policy.standardFlags
+    val rawComponent =
+      WitnessTxSigComponentRaw(wtx,
+                               inputIndex,
+                               TransactionOutput(amount, p2wsh),
+                               flags)
+    // manually compute the expected BIP143 sighash with the post-codeseparator
+    // scriptCode, and sign that hash
+    val expectedHashComponent =
+      WitnessTxSigComponentRebuilt(wtx = wtx,
+                                   inputIndex = inputIndex,
+                                   output =
+                                     TransactionOutput(amount, strippedScript),
+                                   witScriptPubKey = p2wsh,
+                                   flags = flags)
+    val expectedHash = TransactionSignatureSerializer.hashForSignature(
+      expectedHashComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    val sig =
+      privKey1.sign(expectedHash.bytes).appendHashType(HashType.sigHashAll)
+    val result = TransactionSignatureChecker.checkSignature(
+      txSignatureComponent = rawComponent,
+      script = strippedScript.asm,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = sig,
+      flags = flags)
+    result must be(SignatureValidationSuccess)
   }
 
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -5,7 +5,11 @@ import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
+import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.constant.ScriptToken
+import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNullFail}
+import org.bitcoins.core.script.interpreter.ScriptInterpreter
+import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.crypto._
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
@@ -17,9 +21,49 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
 
   behavior of "TransactionSignatureChecker"
 
-  // fixed, deterministic key -- no randomness in this security regression test
+  // fixed, deterministic keys -- no randomness in these security regression tests
   private val privKey1: ECPrivateKey =
     ECPrivateKey.fromFieldElement(FieldElement.one)
+  private val privKey2: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(2.toByte))
+  private val noncePrivKey: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(3.toByte))
+
+  /** Builds a single input taproot script path spend of a single tapleaf.
+    * Returns the sig component and the tapleaf hash so callers can compute the
+    * BIP341 sighash themselves.
+    */
+  private def buildTapscriptSpend(
+      leafScriptBytes: ByteVector,
+      witnessStack: Vector[ByteVector],
+      flags: Seq[ScriptFlag]): (TaprootTxSigComponent, Sha256Digest) = {
+    val leafSPK =
+      ScriptPubKey.fromAsmBytes(leafScriptBytes).asInstanceOf[RawScriptPubKey]
+    val internalKey = privKey2.toXOnly
+    val leaf = TapLeaf(LeafVersion.Tapscript, leafSPK)
+    val (keyParity, taprootSPK) =
+      TaprootScriptPubKey.fromInternalKeyTapscriptTree(internalKey, leaf)
+    val controlBlock =
+      TapscriptControlBlock.fromSingleLeaf(LeafVersion.Tapscript,
+                                           internalKey,
+                                           keyParity)
+    val witness = TaprootScriptPath(controlBlock, None, leafSPK, witnessStack)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount))
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+    val outpoint = wtx.inputs(inputIndex.toInt).previousOutput
+    val outputMap = PreviousOutputMap(
+      Map(outpoint -> creditingTx.outputs(outputIndex.toInt)))
+    val component = TaprootTxSigComponent(wtx, inputIndex, outputMap, flags)
+    val tapLeafHash = TaprootScriptPath.computeTapleafHash(leaf)
+    (component, tapLeafHash)
+  }
 
   // Positive Test Cases
 
@@ -820,4 +864,25 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
     result must be(SignatureValidationSuccess)
   }
 
+  it must "fail a tapscript OP_CHECKSIG immediately on an invalid non-empty signature" in {
+    // BIP342 makes NULLFAIL mandatory for tapscript regardless of flags: an
+    // invalid non-empty signature must always fail the script immediately,
+    // unlike the flag-gated legacy/segwit v0 OP_CHECKSIG "soft fail" behavior.
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyNullFail)
+    // <x-only pubkey> OP_CHECKSIG OP_DROP OP_TRUE
+    // if an invalid signature only pushed 0, this script would succeed
+    val leafScriptBytes = ByteVector.fromValidHex("20") ++
+      privKey1.toXOnly.bytes ++ ByteVector.fromValidHex("ac7551")
+    // a well-formed 64-byte schnorr signature over a different message, so it
+    // is invalid for this input's sighash
+    val invalidSig =
+      privKey1.schnorrSignWithNonce(ByteVector.fill(32)(0x55.toByte),
+                                    noncePrivKey)
+    val (component, _) =
+      buildTapscriptSpend(leafScriptBytes, Vector(invalidSig.bytes), flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    assert(
+      result != ScriptOk,
+      s"An invalid non-empty tapscript signature must fail the script immediately, got=$result")
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureCheckerTest.scala
@@ -1,13 +1,17 @@
 package org.bitcoins.core.crypto
 
-import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.constant.ScriptToken
-import org.bitcoins.core.script.flag.{ScriptFlag, ScriptVerifyNullFail}
+import org.bitcoins.core.script.flag.{
+  ScriptFlag,
+  ScriptVerifyLowS,
+  ScriptVerifyNullFail
+}
 import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.script.util.PreviousOutputMap
@@ -884,5 +888,32 @@ class TransactionSignatureCheckerTest extends BitcoinSUnitTest {
     assert(
       result != ScriptOk,
       s"An invalid non-empty tapscript signature must fail the script immediately, got=$result")
+  }
+
+  it must "not fail an empty signature with the LOW_S check" in {
+    // Core's CheckSignatureEncoding exempts the empty signature from all
+    // encoding checks, including LOW_S -- an empty signature combined with
+    // the LOW_S flag must just be an "incorrect signature", not a hard
+    // ScriptErrorSigHighS failure.
+    val pubKey = privKey1.publicKey
+    val spk = P2PKHScriptPubKey(pubKey)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk)
+    val (spendingTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex)
+    val component =
+      BaseTxSigComponent(spendingTx,
+                         inputIndex,
+                         TransactionOutput(CurrencyUnits.zero, spk),
+                         Seq(ScriptVerifyLowS))
+    val result = TransactionSignatureChecker.checkSignature(
+      txSignatureComponent = component,
+      script = spk.asm,
+      pubKey = pubKey.toPublicKeyBytes(),
+      signature = ECDigitalSignature.empty,
+      flags = Seq(ScriptVerifyLowS))
+    result must be(SignatureValidationErrorIncorrectSignatures)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -12,7 +12,7 @@ import org.bitcoins.core.wallet.builder.StandardNonInteractiveFinalizer
 import org.bitcoins.core.wallet.fee.SatoshisPerVirtualByte
 import org.bitcoins.crypto.*
 import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
-import org.bitcoins.testkitcore.util.BitcoinSUnitTest
+import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
 
 import scala.util.Try
@@ -1230,4 +1230,53 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     assert(serialize.toHex == expected)
   }
 
+  it must "fail validation for taproot SIGHASH_SINGLE with no corresponding output" in {
+    // BIP341 requires taproot SIGHASH_SINGLE with a missing corresponding
+    // output to fail validation outright -- there is no placeholder hash
+    // concept in BIP341's tagged-hash sighash algorithm, unlike the legacy
+    // (SigVersionBase) sighash algorithm's uint256-one error hash.
+    val privKey1: ECPrivateKey = ECPrivateKey.fromFieldElement(FieldElement.one)
+    val taprootSPK = TaprootScriptPubKey(privKey1.toXOnly)
+    val amount1 = Satoshis(10000)
+    val amount2 = Satoshis(20000)
+    val (creditingTx1, _) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount1))
+    val (creditingTx2, _) =
+      TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount2))
+    val outpoint1 = TransactionOutPoint(creditingTx1.txId, UInt32.zero)
+    val outpoint2 = TransactionOutPoint(creditingTx2.txId, UInt32.zero)
+    val inputs = Vector(
+      TransactionInput(outpoint1,
+                       EmptyScriptSignature,
+                       TransactionConstants.sequence),
+      TransactionInput(outpoint2,
+                       EmptyScriptSignature,
+                       TransactionConstants.sequence)
+    )
+    // only one output, so input index 1 has no corresponding output
+    val outputs =
+      Vector(TransactionOutput(Satoshis(5000), EmptyScriptPubKey))
+    val witness =
+      TransactionWitness(Vector(TaprootKeyPath.dummy, TaprootKeyPath.dummy))
+    val wtx = WitnessTransaction(
+      TransactionConstants.version,
+      inputs,
+      outputs,
+      TransactionConstants.lockTime,
+      witness
+    )
+    val outputMap = PreviousOutputMap(
+      Map(outpoint1 -> creditingTx1.outputs.head,
+          outpoint2 -> creditingTx2.outputs.head))
+    val component =
+      TaprootTxSigComponent(wtx, UInt32.one, outputMap, Policy.standardFlags)
+    val hashT = Try(
+      TransactionSignatureSerializer.hashForSignature(
+        component,
+        HashType.sigHashSingle,
+        TaprootSerializationOptions.empty))
+    assert(
+      hashT.isFailure,
+      s"BIP341 requires taproot SIGHASH_SINGLE with no corresponding output to fail validation, got=$hashT")
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/crypto/TransactionSignatureSerializerTest.scala
@@ -15,7 +15,7 @@ import org.bitcoins.testkitcore.gen.{CreditingTxGen, ScriptGenerators}
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /** Created by chris on 2/19/16.
   */
@@ -1278,5 +1278,49 @@ class TransactionSignatureSerializerTest extends BitcoinSUnitTest {
     assert(
       hashT.isFailure,
       s"BIP341 requires taproot SIGHASH_SINGLE with no corresponding output to fail validation, got=$hashT")
+  }
+
+  it must "compute the BIP143 sighash with zero hashOutputs for a segwit v0 SIGHASH_SINGLE with an out of range input index" in {
+    // Per Core (src/script/interpreter.cpp): the uint256-one error hash
+    // applies ONLY to the legacy (SigVersion::BASE) sighash. For segwit v0,
+    // Core computes a normal BIP143 sighash; when the input index has no
+    // corresponding output under SIGHASH_SINGLE, BIP143 sets hashOutputs to
+    // 32 zero bytes instead of erroring. A fully independent preimage
+    // computation is impractical here because an out-of-range input index has
+    // no outpoint to commit to, so this test asserts the call completes
+    // without throwing and does not return the legacy uint256-one error hash.
+    val uint256OneErrorHash = DoubleSha256Digest.fromHex(
+      "0100000000000000000000000000000000000000000000000000000000000000")
+    val privKey1: ECPrivateKey = ECPrivateKey.fromFieldElement(FieldElement.one)
+    val pubKey = privKey1.publicKey
+    val spk = P2WPKHWitnessSPKV0(pubKey)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk)
+    val witness = P2WPKHWitnessV0(pubKey)
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(
+        creditingTx,
+        EmptyScriptSignature,
+        outputIndex,
+        Some((witness, CurrencyUnits.zero)))
+    val component = WitnessTxSigComponentRaw(
+      spendingTx.asInstanceOf[WitnessTransaction],
+      UInt32.one, // out of range: the transaction has a single input
+      TransactionOutput(CurrencyUnits.zero, spk),
+      Policy.standardFlags
+    )
+    val hashT = Try(
+      TransactionSignatureSerializer.hashForSignature(
+        component,
+        HashType.sigHashSingle,
+        TaprootSerializationOptions.empty))
+    assert(
+      hashT.isSuccess,
+      s"A segwit v0 SIGHASH_SINGLE sighash with an out of range input index must be computed with hashOutputs=zero (BIP143), not throw, got=$hashT"
+    )
+    assert(
+      hashT != Success(uint256OneErrorHash),
+      s"The uint256-one error hash only applies to the legacy sighash algorithm, a segwit v0 sighash must not return it"
+    )
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/script/ScriptPubKeyTest.scala
@@ -48,7 +48,7 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
     assert(witSPKV1.pubKey == pubKey)
   }
 
-  it must "fail to construct a valid witness spk v1 when the coordinate is not on the curve" in {
+  it must "construct a witness spk v1 when the coordinate is not on the curve, but fail to access its pubKey" in {
     // all zeroes
     val pubKey = ByteVector.fill(32)(0.toByte)
     // reconstruct asm
@@ -56,8 +56,13 @@ class ScriptPubKeyTest extends BitcoinSUnitTest {
       ScriptConstant(pubKey)
     ))
 
+    // classification is structural (witness v1, 32-byte program), so
+    // construction itself must not throw -- otherwise parsing untrusted/
+    // on-chain data containing such an output would crash instead of
+    // classifying it as taproot (see SignatureCheckingSecurityTest)
+    val spk = TaprootScriptPubKey.fromAsm(asm)
     assertThrows[IllegalArgumentException] {
-      TaprootScriptPubKey.fromAsm(asm)
+      spk.pubKey
     }
   }
 

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/transaction/TransactionTest.scala
@@ -22,6 +22,8 @@ import org.bitcoins.testkitcore.util.{
 }
 import scodec.bits.*
 
+import scala.util.Try
+
 class TransactionTest extends BitcoinSUnitTest {
   behavior of "Transaction"
 
@@ -442,7 +444,14 @@ class TransactionTest extends BitcoinSUnitTest {
       "0100000001a76e1bb0e40d989cf3613c5b73bff552adaa09bdf79264cc0c44b968502db3be01000000fdfd000047304402200b0e9309480146ed5923a14cb3cd607facf9cf7b4f51ac9d448e0c8c3030aa5602201850641a5dd1c002e6ed9b723404a069a002608f45f77af1e3eb96e911d17afd01483045022100c7063f26164395e0ac8127b827cf6ad6a472fa8516197ef9ff565d7465b08dff022073329ded25b9559ce0dfef313ed084f9e294da47ddc814d2eab8839a8a4a9f16014c69522102b09c72ee2fa77abc24613b227d1cb6944c70af7f96711d5f1c4675daaa7554d221029787faf77569cdc59db5a34e0e9f552b9950b61d593e797ae12ac1d69eb5f98821022e9df5da07c71f7e8f5f639a28900d967714f2ae72b096c69c93fd76837b01a753aeffffffff02204e000000000000225120658204033e46a1fa8cceb84013cfe2d376ca72d5f595319497b95b08aa64a97014be00000000000017a914d06f57927ef98f7dfd25e9abdf5de65e1e7215698700000000"
     val btx = BaseTransaction.fromHex(hex)
     val spk = btx.outputs(0).scriptPubKey
-    assert(spk.isInstanceOf[UnassignedWitnessScriptPubKey])
+    // a v1 32-byte witness program is unambiguously taproot regardless of
+    // whether its 32 bytes are a valid x-only coordinate -- classifying it
+    // as UnassignedWitnessScriptPubKey would make it anyone-can-spend
+    assert(spk.isInstanceOf[TaprootScriptPubKey])
+    assert(
+      Try(spk.asInstanceOf[TaprootScriptPubKey].pubKey).isFailure,
+      "the x coordinate in this output is invalid"
+    )
   }
 
   it must "parse a05213473724e2e7f489ae0cbe1d17eef4f6c1b9806e33e5115d85e71d81e994" in {

--- a/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/crypto/CryptoInterpreterTest.scala
@@ -1,16 +1,30 @@
 package org.bitcoins.core.script.crypto
 
-import org.bitcoins.core.crypto.BaseTxSigComponent
-import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.crypto.{
+  BaseTxSigComponent,
+  TaprootSerializationOptions,
+  TaprootTxSigComponent,
+  TransactionSignatureSerializer
+}
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
 import org.bitcoins.core.number.UInt32
-import org.bitcoins.core.protocol.script.ScriptSignature
+import org.bitcoins.core.policy.Policy
+import org.bitcoins.core.protocol.script._
 import org.bitcoins.core.protocol.transaction._
 import org.bitcoins.core.script._
 import org.bitcoins.core.script.constant._
 import org.bitcoins.core.script.flag.{ScriptVerifyDerSig, ScriptVerifyNullDummy}
+import org.bitcoins.core.script.interpreter.ScriptInterpreter
 import org.bitcoins.core.script.result._
+import org.bitcoins.core.script.util.PreviousOutputMap
 import org.bitcoins.core.util.ScriptProgramTestUtil
-import org.bitcoins.testkitcore.util.{BitcoinSJvmTest, TestUtil}
+import org.bitcoins.crypto._
+import org.bitcoins.testkitcore.util.{
+  BitcoinSJvmTest,
+  TestUtil,
+  TransactionTestUtil
+}
+import scodec.bits.ByteVector
 
 import scala.util.Try
 
@@ -282,4 +296,64 @@ class CryptoInterpreterTest extends BitcoinSJvmTest {
     newProgram.lastCodeSeparator must be(Some(0))
   }
 
+  // fixed, deterministic keys -- no randomness in this security regression test
+  private val privKey1: ECPrivateKey =
+    ECPrivateKey.fromFieldElement(FieldElement.one)
+  private val privKey2: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(2.toByte))
+  private val noncePrivKey: ECPrivateKey =
+    ECPrivateKey.fromBytes(ByteVector.fill(32)(3.toByte))
+
+  it must "reject a 65-byte tapscript signature with an explicit SIGHASH_DEFAULT byte" in {
+    // BIP341 requires SIGHASH_DEFAULT to be implicit only: a 65-byte
+    // signature that explicitly encodes 0x00 as its trailing hash type byte
+    // must be rejected with ScriptErrorSchnorrSigHashType.
+    val flags = Policy.standardFlags
+    // <x-only pubkey> OP_CHECKSIG
+    val leafScriptBytes = ByteVector.fromValidHex("20") ++
+      privKey1.toXOnly.bytes ++ ByteVector.fromValidHex("ac")
+    val leafSPK =
+      ScriptPubKey.fromAsmBytes(leafScriptBytes).asInstanceOf[RawScriptPubKey]
+    val internalKey = privKey2.toXOnly
+    val leaf = TapLeaf(LeafVersion.Tapscript, leafSPK)
+    val (keyParity, taprootSPK) =
+      TaprootScriptPubKey.fromInternalKeyTapscriptTree(internalKey, leaf)
+    val controlBlock =
+      TapscriptControlBlock.fromSingleLeaf(LeafVersion.Tapscript,
+                                           internalKey,
+                                           keyParity)
+    val tapLeafHash = TaprootScriptPath.computeTapleafHash(leaf)
+
+    def buildComponent(
+        witnessStack: Vector[ByteVector]): TaprootTxSigComponent = {
+      val witness =
+        TaprootScriptPath(controlBlock, None, leafSPK, witnessStack)
+      val amount = Satoshis(10000)
+      val (creditingTx, outputIndex) =
+        TransactionTestUtil.buildCreditingTransaction(taprootSPK, Some(amount))
+      val (spendingTx, inputIndex) =
+        TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                     EmptyScriptSignature,
+                                                     outputIndex,
+                                                     Some((witness, amount)))
+      val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+      val outpoint = wtx.inputs(inputIndex.toInt).previousOutput
+      val outputMap = PreviousOutputMap(
+        Map(outpoint -> creditingTx.outputs(outputIndex.toInt)))
+      TaprootTxSigComponent(wtx, inputIndex, outputMap, flags)
+    }
+
+    // build a placeholder spend to compute the BIP341 sighash, then sign it
+    val placeholderComponent = buildComponent(Vector.empty)
+    val sighash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashDefault,
+      TaprootSerializationOptions(Some(tapLeafHash), None, None))
+    val sig64 = privKey1.schnorrSignWithNonce(sighash.bytes, noncePrivKey)
+    // explicitly append SIGHASH_DEFAULT (0x00) — not allowed by BIP341
+    val sig65 = sig64.bytes ++ ByteVector.fromByte(0x00.toByte)
+    val component = buildComponent(Vector(sig65))
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptErrorSchnorrSigHashType)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/flag/ScriptFlagUtilTest.scala
@@ -18,13 +18,16 @@ class ScriptFlagUtilTest extends BitcoinSUnitTest {
   it must "return false if strict der encoding check is not required" in {
     ScriptFlagUtil.requiresStrictDerEncoding(Seq()) must be(false)
 
+    // ScriptVerifyLowS is deliberately excluded here: Core's
+    // CheckSignatureEncoding applies the DER check whenever DERSIG, LOW_S,
+    // or STRICTENC is set, so LOW_S alone must make this return true (see
+    // the dedicated LOW_S test below).
     ScriptFlagUtil.requiresStrictDerEncoding(
       Seq(
         ScriptVerifyCheckLocktimeVerify,
         ScriptVerifyCheckSequenceVerify,
         ScriptVerifyCleanStack,
         ScriptVerifyDiscourageUpgradableNOPs,
-        ScriptVerifyLowS,
         ScriptVerifyMinimalData,
         ScriptVerifyNone,
         ScriptVerifyNullDummy,
@@ -32,5 +35,11 @@ class ScriptFlagUtilTest extends BitcoinSUnitTest {
         ScriptVerifySigPushOnly
       )
     ) must be(false)
+  }
+
+  it must "check that strict der encoding is required when only LOW_S is set" in {
+    ScriptFlagUtil.requiresStrictDerEncoding(Seq(ScriptVerifyLowS)) must be(
+      true
+    )
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -2,7 +2,9 @@ package org.bitcoins.core.script.interpreter
 
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
+  TaprootSerializationOptions,
   TaprootTxSigComponent,
+  TransactionSignatureSerializer,
   WitnessTxSigComponentP2SH,
   WitnessTxSigComponentRaw
 }
@@ -19,12 +21,13 @@ import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.{
   ScriptFlagFactory,
-  ScriptVerifyDiscourageUpgradableWitnessProgram
+  ScriptVerifyDiscourageUpgradableWitnessProgram,
+  ScriptVerifyWitness
 }
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.crypto.SchnorrDigitalSignature
+import org.bitcoins.crypto.{HashType, SchnorrDigitalSignature}
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
 import upickle.default.*
@@ -225,6 +228,46 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
           result != ScriptOk,
           s"Spending a v1 witness program with an invalid x-only key must fail validation, got=$result")
     }
+  }
+
+  it must "not enforce WITNESS_UNEXPECTED when the ScriptVerifyWitness flag is not set" in {
+    // Core only performs the WITNESS_UNEXPECTED check when SCRIPT_VERIFY_WITNESS
+    // is set -- a spend carrying an unused witness for a non-witness output
+    // must still succeed when that flag is absent.
+    val privKey1 =
+      org.bitcoins.crypto.ECPrivateKey
+        .fromFieldElement(org.bitcoins.crypto.FieldElement.one)
+    val pubKey = privKey1.publicKey
+    val spk = P2PKHScriptPubKey(pubKey)
+    val amount = Satoshis(10000)
+    val (creditingTx, outputIndex) =
+      TransactionTestUtil.buildCreditingTransaction(spk, Some(amount))
+    val witness = P2WPKHWitnessV0(pubKey)
+    // placeholder transaction to compute the legacy sighash
+    val (placeholderTx, inputIndex) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   EmptyScriptSignature,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val flags = Policy.standardFlags.filterNot(_ == ScriptVerifyWitness)
+    val output = TransactionOutput(amount, spk)
+    val placeholderComponent =
+      BaseTxSigComponent(placeholderTx, inputIndex, output, flags)
+    val hash = TransactionSignatureSerializer.hashForSignature(
+      placeholderComponent,
+      HashType.sigHashAll,
+      TaprootSerializationOptions.empty)
+    val sig = privKey1.sign(hash.bytes).appendHashType(HashType.sigHashAll)
+    val scriptSig = P2PKHScriptSignature(sig, pubKey)
+    // the spending transaction carries an unused witness for this input
+    val (spendingTx, _) =
+      TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                   scriptSig,
+                                                   outputIndex,
+                                                   Some((witness, amount)))
+    val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
+    val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+    result must be(ScriptOk)
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -14,14 +14,22 @@ import org.bitcoins.core.protocol.transaction.{
   TransactionOutput,
   WitnessTransaction
 }
+import org.bitcoins.core.currency.Satoshis
+import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.script.PreExecutionScriptProgram
-import org.bitcoins.core.script.flag.ScriptFlagFactory
+import org.bitcoins.core.script.flag.{
+  ScriptFlagFactory,
+  ScriptVerifyDiscourageUpgradableWitnessProgram
+}
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
+import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.script.util.PreviousOutputMap
+import org.bitcoins.crypto.SchnorrDigitalSignature
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
+import scodec.bits.ByteVector
 import upickle.default.*
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 1/6/16.
   */
@@ -175,6 +183,48 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
           PreviousOutputMap(Map(EmptyTransactionOutPoint -> prevOut))
         )
     )
+  }
+
+  it must "not treat a v1 witness program with an invalid x coordinate as anyone-can-spend" in {
+    // a v1 32-byte witness program is unambiguously taproot regardless of
+    // whether its 32 bytes are a valid x-only coordinate (0xffff...ff >= the
+    // secp256k1 field size, so it cannot be a valid x coordinate); spending
+    // such an output must fail validation, not be classified as an
+    // anyone-can-spend unassigned witness program
+    val invalidProgram = ByteVector.fill(32)(0xff.toByte)
+    val spkBytes = ByteVector.fromValidHex("5120") ++ invalidProgram
+    Try(ScriptPubKey.fromAsmBytes(spkBytes)) match {
+      case Failure(_) =>
+        // rejecting the invalid taproot output key at parse time is acceptable
+        succeed
+      case Success(spk) =>
+        assert(
+          !spk.isInstanceOf[UnassignedWitnessScriptPubKey],
+          s"A v1 32-byte witness program must be classified as taproot, not as an unassigned witness program, got=$spk"
+        )
+        val amount = Satoshis(10000)
+        val (creditingTx, outputIndex) =
+          TransactionTestUtil.buildCreditingTransaction(spk, Some(amount))
+        val witness =
+          ScriptWitness(Vector(SchnorrDigitalSignature.dummy.bytes))
+        val (spendingTx, inputIndex) =
+          TransactionTestUtil.buildSpendingTransaction(creditingTx,
+                                                       EmptyScriptSignature,
+                                                       outputIndex,
+                                                       Some((witness, amount)))
+        val flags = Policy.standardFlags.filterNot(
+          _ == ScriptVerifyDiscourageUpgradableWitnessProgram)
+        val wtx = spendingTx.asInstanceOf[WitnessTransaction]
+        val outpoint = wtx.inputs(inputIndex.toInt).previousOutput
+        val outputMap =
+          PreviousOutputMap(Map(outpoint -> TransactionOutput(amount, spk)))
+        val component =
+          TaprootTxSigComponent(wtx, inputIndex, outputMap, flags)
+        val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
+        assert(
+          result != ScriptOk,
+          s"Spending a v1 witness program with an invalid x-only key must fail validation, got=$result")
+    }
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/BitcoinScriptUtilTest.scala
@@ -8,7 +8,12 @@ import org.bitcoins.core.script.flag.ScriptVerifyWitnessPubKeyType
 import org.bitcoins.core.script.locktime.OP_CHECKLOCKTIMEVERIFY
 import org.bitcoins.core.script.reserved.{OP_NOP, OP_RESERVED}
 import org.bitcoins.core.script.result.ScriptErrorWitnessPubKeyType
-import org.bitcoins.crypto.{ECPrivateKeyBytes, ECPublicKeyBytes}
+import org.bitcoins.core.script.stack.OP_DROP
+import org.bitcoins.crypto.{
+  ECDigitalSignature,
+  ECPrivateKeyBytes,
+  ECPublicKeyBytes
+}
 import org.bitcoins.testkitcore.gen.ScriptGenerators
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TestUtil}
 import scodec.bits.ByteVector
@@ -391,5 +396,20 @@ class BitcoinScriptUtilTest extends BitcoinSUnitTest {
     BitcoinScriptUtil.castToBool(ScriptConstant("01")) must be(true)
     BitcoinScriptUtil.castToBool(ScriptConstant("80000000")) must be(true)
     BitcoinScriptUtil.castToBool(ScriptConstant("00008000")) must be(true)
+  }
+
+  it must "remove all occurrences of a signature with legacy FindAndDelete" in {
+    // Core's FindAndDelete removes ALL occurrences of a signature from the
+    // script, not just the first -- if the same signature is pushed more
+    // than once, later occurrences must not be left in place.
+    val sig = ECDigitalSignature(
+      "304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901")
+    val sigPush = BitcoinScriptUtil.calculatePushOp(sig.bytes) ++ Vector(
+      ScriptConstant(sig.bytes))
+    // the same signature pushed twice in one script
+    val script = sigPush ++ Vector(OP_DROP) ++ sigPush ++ Vector(OP_DROP)
+    val result = BitcoinScriptUtil.removeSignatureFromScript(sig, script)
+    assert(!result.contains(ScriptConstant(sig.hex)),
+           s"All occurrences of the signature must be removed, got=$result")
   }
 }

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -242,19 +242,13 @@ trait TransactionSignatureChecker {
                                                       taprootOptions)
     ) match {
       case Failure(_) =>
-        nullFailCheckSchnorrSig(sigs = Vector(signature),
-                                result =
-                                  SignatureValidationErrorIncorrectSignatures,
-                                flags = flags)
+        tapscriptNullFailCheck(signature)
       case Success(hash) =>
         val result = pubKey.verify(hash, signature)
         if (result) {
           SignatureValidationSuccess
         } else {
-          nullFailCheckSchnorrSig(sigs = Vector(signature),
-                                  result =
-                                    SignatureValidationErrorIncorrectSignatures,
-                                  flags = flags)
+          tapscriptNullFailCheck(signature)
         }
     }
   }
@@ -354,15 +348,20 @@ trait TransactionSignatureChecker {
     } else result
   }
 
-  private def nullFailCheckSchnorrSig(
-      sigs: Seq[SchnorrDigitalSignature],
-      result: TransactionSignatureCheckerResult,
-      flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    val nullFailEnabled = ScriptFlagUtil.requireScriptVerifyNullFail(flags)
-    if (nullFailEnabled && !result.isValid && sigs.exists(_.bytes.nonEmpty)) {
-      // we need to check that all signatures were empty byte vectors, else this fails because of BIP146 and nullfail
+  /** BIP342 makes NULLFAIL mandatory for tapscript signature checks, regardless
+    * of whether the SCRIPT_VERIFY_NULLFAIL flag is set: an invalid non-empty
+    * signature must always fail the script immediately, not push false and
+    * continue like the legacy/segwit v0 OP_CHECKSIG "soft fail" behavior does.
+    * An empty signature is a valid way to signal "no signature provided" and
+    * continues to soft-fail (push false).
+    */
+  private def tapscriptNullFailCheck(
+      signature: SchnorrDigitalSignature): TransactionSignatureCheckerResult = {
+    if (signature.bytes.nonEmpty) {
       SignatureValidationErrorNullFail
-    } else result
+    } else {
+      SignatureValidationErrorIncorrectSignatures
+    }
   }
 
   /** Removes the hash type from the [[ECDigitalSignature]] */

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -141,7 +141,8 @@ trait TransactionSignatureChecker {
         ) {
           SignatureValidationErrorNotStrictDerEncoding
         } else if (
-          ScriptFlagUtil.requireLowSValue(flags) && !DERSignatureUtil
+          ScriptFlagUtil.requireLowSValue(
+            flags) && signature.bytes.nonEmpty && !DERSignatureUtil
             .isLowS(signature)
         ) {
           SignatureValidationErrorHighSValue

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -270,6 +270,12 @@ trait TransactionSignatureChecker {
     *   correct
     * @param flags
     *   the script verify flags which are rules to verify the signatures
+    * @param originalSigs
+    *   the full signature list as originally provided to OP_CHECKMULTISIG,
+    *   before any were consumed off the front of `sigs` by a successful match
+    *   -- needed for the NULLFAIL check below. Callers making the initial
+    *   (non-recursive) call should pass the same list as `sigs` (or
+    *   `List.empty` if there are no signatures to check).
     * @return
     *   a boolean indicating if all of the signatures are valid against the
     *   given public keys
@@ -281,18 +287,26 @@ trait TransactionSignatureChecker {
       sigs: List[ECDigitalSignature],
       pubKeys: List[ECPublicKeyBytes],
       flags: Seq[ScriptFlag],
-      requiredSigs: Long): TransactionSignatureCheckerResult = {
+      requiredSigs: Long,
+      originalSigs: List[ECDigitalSignature])
+      : TransactionSignatureCheckerResult = {
     require(requiredSigs >= 0,
             s"requiredSigs cannot be negative, got $requiredSigs")
+    // NULLFAIL (BIP146) applies to every signature originally provided to
+    // OP_CHECKMULTISIG, not just the ones remaining at the point validation
+    // is determined to have failed -- a signature that matched earlier and
+    // was "consumed" (sigs.tail'd away) must still be checked.
     if (sigs.size > pubKeys.size) {
       // this is how bitcoin core treats this. If there are ever any more
       // signatures than public keys remaining we immediately return
       // false https://github.com/bitcoin/bitcoin/blob/8c1dbc5e9ddbafb77e60e8c4e6eb275a3a76ac12/src/script/interpreter.cpp#L943-L945
-      nullFailCheck(sigs, SignatureValidationErrorIncorrectSignatures, flags)
+      nullFailCheck(originalSigs,
+                    SignatureValidationErrorIncorrectSignatures,
+                    flags)
     } else if (requiredSigs > sigs.size) {
       // for the case when we do not have enough sigs left to check to meet the required signature threshold
       // https://github.com/bitcoin/bitcoin/blob/8c1dbc5e9ddbafb77e60e8c4e6eb275a3a76ac12/src/script/interpreter.cpp#L990-L991
-      nullFailCheck(sigs, SignatureValidationErrorSignatureCount, flags)
+      nullFailCheck(originalSigs, SignatureValidationErrorSignatureCount, flags)
     } else if (sigs.nonEmpty && pubKeys.nonEmpty) {
       val sig = sigs.head
       val pubKey = pubKeys.head
@@ -305,7 +319,8 @@ trait TransactionSignatureChecker {
                                   sigs.tail,
                                   pubKeys.tail,
                                   flags,
-                                  requiredSigs - 1)
+                                  requiredSigs - 1,
+                                  originalSigs)
         case SignatureValidationErrorIncorrectSignatures |
             SignatureValidationErrorNullFail =>
           // notice we pattern match on 'SignatureValidationErrorNullFail' here, this is because
@@ -316,21 +331,24 @@ trait TransactionSignatureChecker {
                                   sigs,
                                   pubKeys.tail,
                                   flags,
-                                  requiredSigs)
+                                  requiredSigs,
+                                  originalSigs)
         case x @ (SignatureValidationErrorNotStrictDerEncoding |
             SignatureValidationErrorSignatureCount |
             SignatureValidationErrorPubKeyEncoding |
             SignatureValidationErrorHighSValue |
             SignatureValidationErrorHashType |
             SignatureValidationErrorWitnessPubKeyType) =>
-          nullFailCheck(sigs, x, flags)
+          nullFailCheck(originalSigs, x, flags)
       }
     } else if (sigs.isEmpty) {
       // means that we have checked all of the sigs against the public keys
       // validation succeeds
       SignatureValidationSuccess
     } else
-      nullFailCheck(sigs, SignatureValidationErrorIncorrectSignatures, flags)
+      nullFailCheck(originalSigs,
+                    SignatureValidationErrorIncorrectSignatures,
+                    flags)
 
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -11,6 +11,7 @@ import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 /** Created by chris on 2/16/16. Responsible for checking digital signatures on
   * inputs against their respective public keys
@@ -80,12 +81,22 @@ trait TransactionSignatureChecker {
     if (!validHashType) {
       ScriptErrorSchnorrSigHashType
     } else {
-      val hash =
+      // hashForSignature throws for a taproot SIGHASH_SINGLE with no
+      // corresponding output (BIP341 requires that to fail validation,
+      // unlike the legacy sighash algorithm's placeholder error hash) --
+      // that must surface as a clean script failure here, not an uncaught
+      // exception escaping the interpreter
+      Try(
         TransactionSignatureSerializer.hashForSignature(txSigComponent,
                                                         hashType,
                                                         taprootOptions)
-      val result = pubKey.verify(hash, schnorrSignature)
-      if (result) ScriptOk else ScriptErrorSchnorrSig
+      ) match {
+        case Success(hash) =>
+          val result = pubKey.verify(hash, schnorrSignature)
+          if (result) ScriptOk else ScriptErrorSchnorrSig
+        case Failure(_) =>
+          ScriptErrorSchnorrSig
+      }
     }
   }
 
@@ -220,18 +231,31 @@ trait TransactionSignatureChecker {
       hashType: HashType,
       taprootOptions: TaprootSerializationOptions,
       flags: Seq[ScriptFlag]): TransactionSignatureCheckerResult = {
-    val hash =
+    // hashForSignature throws for a taproot SIGHASH_SINGLE with no
+    // corresponding output (BIP341 requires that to fail validation,
+    // unlike the legacy sighash algorithm's placeholder error hash) --
+    // that must surface as a clean signature check failure here, not an
+    // uncaught exception escaping the interpreter
+    Try(
       TransactionSignatureSerializer.hashForSignature(txSignatureComponent,
                                                       hashType,
                                                       taprootOptions)
-    val result = pubKey.verify(hash, signature)
-    if (result) {
-      SignatureValidationSuccess
-    } else {
-      nullFailCheckSchnorrSig(sigs = Vector(signature),
-                              result =
-                                SignatureValidationErrorIncorrectSignatures,
-                              flags = flags)
+    ) match {
+      case Failure(_) =>
+        nullFailCheckSchnorrSig(sigs = Vector(signature),
+                                result =
+                                  SignatureValidationErrorIncorrectSignatures,
+                                flags = flags)
+      case Success(hash) =>
+        val result = pubKey.verify(hash, signature)
+        if (result) {
+          SignatureValidationSuccess
+        } else {
+          nullFailCheckSchnorrSig(sigs = Vector(signature),
+                                  result =
+                                    SignatureValidationErrorIncorrectSignatures,
+                                  flags = flags)
+        }
     }
   }
 

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureChecker.scala
@@ -158,6 +158,22 @@ trait TransactionSignatureChecker {
             ByteVector(0.toByte, 0.toByte, 0.toByte, hashTypeByte))
           val spk = ScriptPubKey.fromAsm(sigsRemovedScript)
           val hashForSignature = txSignatureComponent match {
+            case w: WitnessTxSigComponentRaw =>
+              // BIP143 commits to the scriptCode after the last executed
+              // OP_CODESEPARATOR (sigsRemovedScript/spk above), not the raw
+              // witness script -- rebuild the component with the stripped
+              // script so the sighash actually commits to it, mirroring the
+              // BaseTxSigComponent/WitnessTxSigComponentRebuilt cases below
+              val sigsRemovedTxSigComponent = WitnessTxSigComponentRebuilt(
+                wtx = w.transaction,
+                inputIndex = w.inputIndex,
+                output = TransactionOutput(w.fundingOutput.value, spk),
+                witScriptPubKey = w.scriptPubKey,
+                flags = w.flags)
+              TransactionSignatureSerializer.hashForSignature(
+                sigsRemovedTxSigComponent,
+                hashType,
+                TaprootSerializationOptions.empty)
             case w: WitnessTxSigComponent =>
               TransactionSignatureSerializer.hashForSignature(
                 w,

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -404,6 +404,18 @@ sealed abstract class TransactionSignatureSerializer {
       (hashType.isInstanceOf[SIGHASH_SINGLE] || hashType
         .isInstanceOf[SIGHASH_SINGLE_ANYONECANPAY]) &&
       inputIndex >= UInt32(spendingTransaction.outputs.size) &&
+      txSigComponent.sigVersion.isInstanceOf[SigVersionTaproot]
+    ) {
+      // BIP341 requires taproot SIGHASH_SINGLE with no corresponding output
+      // to fail validation outright, unlike the legacy (SigVersionBase)
+      // sighash algorithm's uint256-one placeholder error hash
+      throw new IllegalArgumentException(
+        "BIP341 requires taproot SIGHASH_SINGLE with no corresponding " +
+          s"output to fail validation, inputIndex=$inputIndex")
+    } else if (
+      (hashType.isInstanceOf[SIGHASH_SINGLE] || hashType
+        .isInstanceOf[SIGHASH_SINGLE_ANYONECANPAY]) &&
+      inputIndex >= UInt32(spendingTransaction.outputs.size) &&
       txSigComponent.sigVersion != SigVersionWitnessV0
     ) {
       errorHash

--- a/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
+++ b/core/src/main/scala/org/bitcoins/core/crypto/TransactionSignatureSerializer.scala
@@ -13,6 +13,8 @@ import org.bitcoins.core.wallet.utxo.{InputInfo, InputSigningInfo}
 import org.bitcoins.crypto.*
 import scodec.bits.ByteVector
 
+import scala.util.Try
+
 /** Created by chris on 2/16/16. Wrapper that serializes like Transaction, but
   * with the modifications required for the signature hash done
   * [[https://github.com/bitcoin/bitcoin/blob/93c85d458ac3e2c496c1a053e1f5925f55e29100/src/script/interpreter.cpp#L1016-L1105]]
@@ -41,9 +43,16 @@ sealed abstract class TransactionSignatureSerializer {
     val spendingTransaction = txSigComponent.transaction
     val inputIndex = txSigComponent.inputIndex
     val output = txSigComponent.fundingOutput
-    val script = BitcoinScriptUtil.calculateScriptForSigning(
-      txSigComponent,
-      output.scriptPubKey.asm)
+    // for a witness sig version, rebuilding the scriptCode reads the witness
+    // stack at inputIndex, which throws for an out-of-range input index (a
+    // scenario the SigVersionWitnessV0 branch below is otherwise built to
+    // tolerate, unlike the legacy sighash algorithm's errorHash short
+    // circuit) -- fall back to the funding output's raw asm rather than
+    // letting that escape as an uncaught exception
+    val script = Try(
+      BitcoinScriptUtil.calculateScriptForSigning(txSigComponent,
+                                                  output.scriptPubKey.asm)
+    ).getOrElse(output.scriptPubKey.asm)
 
     txSigComponent match {
       case _: BaseTxSigComponent | _: WitnessTxSigComponentRaw |
@@ -233,7 +242,17 @@ sealed abstract class TransactionSignatureSerializer {
 
         val scriptBytes = BytesUtil.toByteVector(script)
 
-        val i = spendingTransaction.inputs(inputIndexInt)
+        // an out-of-range input index isn't guarded against for
+        // SigVersionWitnessV0 the way it is for the legacy sighash
+        // algorithm above (which returns errorHash instead) -- BIP143 does
+        // not define a placeholder outpoint/sequence for a nonexistent
+        // input, so fall back to empty/zero values rather than throwing
+        val i = spendingTransaction.inputs
+          .lift(inputIndexInt)
+          .getOrElse(
+            TransactionInput(EmptyTransactionOutPoint,
+                             EmptyScriptSignature,
+                             UInt32.zero))
         val serializationForSig: ByteVector =
           spendingTransaction.version.bytes.reverse ++ outPointHash ++ sequenceHash ++
             i.previousOutput.bytes ++ CompactSizeUInt.calc(scriptBytes).bytes ++

--- a/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/Address.scala
@@ -267,8 +267,12 @@ sealed abstract class Bech32mAddress extends BitcoinAddress {
 
   override def isStandard: Boolean = {
     scriptPubKey match {
-      case _: WitnessScriptPubKeyV0         => false // shouldn't be possible
-      case _: TaprootScriptPubKey           => true
+      case _: WitnessScriptPubKeyV0     => false // shouldn't be possible
+      case taproot: TaprootScriptPubKey =>
+        // a v1 32-byte witness program whose 32 bytes are not a valid x-only
+        // coordinate is structurally taproot but not standard -- Bitcoin
+        // Core's IsWitnessStandard requires a valid taproot output key
+        Try(taproot.pubKey).isSuccess
       case _: UnassignedWitnessScriptPubKey => false
     }
   }

--- a/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/script/ScriptPubKey.scala
@@ -1449,13 +1449,20 @@ case class TaprootScriptPubKey(override val asm: Vector[ScriptToken])
   override def witnessProgram: Seq[ScriptToken] = asm.tail.tail
   override val scriptType: ScriptType = ScriptType.WITNESS_V1_TAPROOT
 
-  val pubKey: XOnlyPubKey = {
+  // lazy: a v1 32-byte witness program is structurally taproot even when its
+  // 32 bytes are not a valid x-only coordinate (see isValidAsm above); parsing
+  // untrusted/on-chain data as a TaprootScriptPubKey must not throw merely by
+  // constructing it, only spending it should fail
+  lazy val pubKey: XOnlyPubKey = {
     require(asm(2).bytes.length == 32,
             s"pubKeyBytes must be 32 bytes in length, got=${asm(2).byteSize}")
     XOnlyPubKey.fromBytes(asm(2).bytes)
   }
 
-  override def toString = s"${ScriptDescriptorType.TR.toString}(${pubKey.hex})"
+  override def toString = {
+    val pubKeyStr = Try(pubKey.hex).getOrElse(s"invalid:${asm(2).hex}")
+    s"${ScriptDescriptorType.TR.toString}($pubKeyStr)"
+  }
 }
 
 object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
@@ -1490,12 +1497,17 @@ object TaprootScriptPubKey extends ScriptFactory[TaprootScriptPubKey] {
 
   override def isValidAsm(asm: Seq[ScriptToken]): Boolean = {
     val asmBytes = BytesUtil.toByteVector(asm)
+    // Classification is purely structural (witness v1, 32-byte program),
+    // matching Bitcoin Core: a v1 32-byte witness program is unambiguously
+    // Taproot regardless of whether its 32 bytes form a valid x-only
+    // coordinate. Requiring cryptographic validity here would misclassify
+    // an invalid-x-coordinate taproot output as an unassigned (future,
+    // anyone-can-spend) witness version instead of a taproot output that
+    // must fail validation.
     asm.length == 3 &&
     asm.headOption.contains(OP_1) &&
     asmBytes.size == 34 &&
-    WitnessScriptPubKey.isValidAsm(asm) &&
-    // have to make sure we have a valid xonly pubkey, not just 32 bytes
-    XOnlyPubKey.fromBytesT(asm(2).bytes).isSuccess
+    WitnessScriptPubKey.isValidAsm(asm)
   }
 
   /** Computes a [[TaprootScriptPubKey]] from a given internal key with no

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -392,7 +392,8 @@ sealed abstract class CryptoInterpreter {
               signatures,
               pubKeys,
               flags,
-              mRequiredSignatures.toLong)
+              mRequiredSignatures.toLong,
+              originalSigs = signatures)
 
           // remove the extra OP_0 (null dummy) for OP_CHECKMULTISIG from the stack
           val restOfStack = stackWithoutPubKeysAndSignatures.tail

--- a/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/crypto/CryptoInterpreter.scala
@@ -161,9 +161,16 @@ sealed abstract class CryptoInterpreter {
       Right((sig, HashType.sigHashDefault))
     } else if (sigBytes.length == 65) {
       val hashTypeByte = sigBytes.last
-      val hashType = HashType.fromByte(hashTypeByte)
-      val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
-      Right((sig, hashType))
+      if (hashTypeByte == HashType.sigHashDefaultByte) {
+        // BIP341: SIGHASH_DEFAULT must never be explicitly encoded as a
+        // trailing hash type byte -- only the 64-byte (implicit) form is
+        // valid for the default hash type
+        Left(ScriptErrorSchnorrSigHashType)
+      } else {
+        val hashType = HashType.fromByte(hashTypeByte)
+        val sig = SchnorrDigitalSignature.fromBytes(sigBytes.dropRight(1))
+        Right((sig, hashType))
+      }
     } else {
       Left(ScriptErrorSchnorrSigSize)
     })

--- a/core/src/main/scala/org/bitcoins/core/script/flag/ScriptFlagUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/flag/ScriptFlagUtil.scala
@@ -10,7 +10,11 @@ trait ScriptFlagUtil {
     * @return
     */
   def requiresStrictDerEncoding(flags: Seq[ScriptFlag]): Boolean = {
-    flags.contains(ScriptVerifyDerSig) || flags.contains(ScriptVerifyStrictEnc)
+    // Core's CheckSignatureEncoding applies the DER check whenever any of
+    // DERSIG, LOW_S, or STRICTENC is set -- LOW_S implies a DER-encoded
+    // signature is required in order to even parse out the S value to check.
+    flags.contains(ScriptVerifyDerSig) || flags.contains(
+      ScriptVerifyLowS) || flags.contains(ScriptVerifyStrictEnc)
   }
 
   /** Checks if we are required to check for strict encoding

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -644,10 +644,19 @@ sealed abstract class ScriptInterpreter {
       } else {
         taprootWitness match {
           case keypath: TaprootKeyPath =>
-            val program = checkSchnorrSignature(
-              keypath,
-              taprootSPK.pubKey.schnorrPublicKey,
-              program = scriptPubKeyExecutedProgram)
+            // taprootSPK.pubKey throws if the output key's 32 bytes are not
+            // a valid x-only coordinate (see TaprootScriptPubKey.isValidAsm,
+            // which classifies a v1 32-byte program as taproot purely
+            // structurally, independent of key validity) -- that must fail
+            // key-path signature verification, not crash the interpreter
+            val program = Try(taprootSPK.pubKey.schnorrPublicKey) match {
+              case Success(schnorrPubKey) =>
+                checkSchnorrSignature(keypath,
+                                      schnorrPubKey,
+                                      program = scriptPubKeyExecutedProgram)
+              case Failure(_) =>
+                scriptPubKeyExecutedProgram.failExecution(ScriptErrorSchnorrSig)
+            }
             Success(program)
           case _: TaprootUnknownPath =>
             // is this right? I believe to maintain softfork compatibility we

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -129,7 +129,10 @@ sealed abstract class ScriptInterpreter {
     executedProgram.error match {
       case Some(err) => err
       case None =>
-        if (hasUnexpectedWitness(program)) {
+        if (
+          program.flags.contains(ScriptVerifyWitness) && hasUnexpectedWitness(
+            program)
+        ) {
           // note: the 'program' value we pass above is intentional, we need to check the original program
           // as the 'executedProgram' may have had the scriptPubKey value changed to the rebuilt ScriptPubKey of the witness program
           ScriptErrorWitnessUnexpected

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -561,15 +561,22 @@ trait BitcoinScriptUtil {
   def removeSignatureFromScript(
       signature: ECDigitalSignature,
       script: Seq[ScriptToken]): Seq[ScriptToken] = {
-    if (script.contains(ScriptConstant(signature.hex))) {
-      // replicates this line in bitcoin core
-      // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L872
-      val sigIndex = script.indexOf(ScriptConstant(signature.hex))
-      // remove sig and it's corresponding BytesToPushOntoStack
-      val sigRemoved =
-        script.slice(0, sigIndex - 1) ++ script.slice(sigIndex + 1, script.size)
-      sigRemoved
-    } else script
+    // Core's FindAndDelete removes ALL occurrences, not just the first, so
+    // we loop until none remain
+    // https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp#L872
+    @tailrec
+    def loop(scriptTokens: Seq[ScriptToken]): Seq[ScriptToken] = {
+      if (scriptTokens.contains(ScriptConstant(signature.hex))) {
+        val sigIndex = scriptTokens.indexOf(ScriptConstant(signature.hex))
+        // remove sig and it's corresponding BytesToPushOntoStack
+        val sigRemoved =
+          scriptTokens.slice(0, sigIndex - 1) ++ scriptTokens.slice(
+            sigIndex + 1,
+            scriptTokens.size)
+        loop(sigRemoved)
+      } else scriptTokens
+    }
+    loop(script)
   }
 
   /** Removes the list of [[ECDigitalSignature ECDigitalSignature]] from the

--- a/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/BitcoinScriptUtil.scala
@@ -429,16 +429,31 @@ trait BitcoinScriptUtil {
       txSignatureComponent: TxSigComponent,
       signature: ECDigitalSignature,
       script: Seq[ScriptToken]): Seq[ScriptToken] = {
-    val scriptForChecking =
-      calculateScriptForSigning(txSignatureComponent, script)
     txSignatureComponent.sigVersion match {
       case SigVersionBase =>
+        val scriptForChecking =
+          calculateScriptForSigning(txSignatureComponent, script)
         removeSignatureFromScript(signature, scriptForChecking)
       case SigVersionWitnessV0 | SigVersionTaprootKeySpend |
           SigVersionTapscript =>
         // BIP143 removes requirement for calling FindAndDelete
         // https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#no-findanddelete
-        scriptForChecking
+        //
+        // `script` is either (a) the scriptCode as tracked by the
+        // interpreter (BitcoinScriptUtil.removeOpCodeSeparator), i.e. a
+        // suffix of the full witness scriptCode truncated after the last
+        // executed OP_CODESEPARATOR, or (b) a placeholder like the funding
+        // output's raw asm, from callers that expect the full scriptCode to
+        // be rebuilt from the witness stack. calculateScriptForSigning
+        // always rebuilds the latter (it has no notion of OP_CODESEPARATOR
+        // truncation); honor the former when `script` is actually a suffix
+        // of that rebuilt scriptCode, otherwise fall back to the rebuild.
+        val rebuiltScript =
+          calculateScriptForSigning(txSignatureComponent, script)
+        val scriptIsTruncatedSuffix =
+          script.size <= rebuiltScript.size &&
+            rebuiltScript.takeRight(script.size) == script
+        if (scriptIsTruncatedSuffix) script else rebuiltScript
     }
   }
 

--- a/crypto-test/src/test/scala/org/bitcoins/crypto/HashTypeTest.scala
+++ b/crypto-test/src/test/scala/org/bitcoins/crypto/HashTypeTest.scala
@@ -131,4 +131,15 @@ class HashTypeTest extends BitcoinSCryptoTest {
       assert(HashType.fromByte(hashType.byte) == hashType)
     }
   }
+
+  it must "not count 0x00 as a defined hashtype byte for STRICTENC" in {
+    // Core's IsDefinedHashtypeSignature masks off the ANYONECANPAY bit and
+    // requires the remaining value be in [SIGHASH_ALL, SIGHASH_SINGLE] (1-3)
+    // -- 0x00 (SIGHASH_DEFAULT) is a taproot-only hash type with no meaning
+    // for legacy/segwit v0 ECDSA signatures.
+    val sigEndingInZero = ECDigitalSignature(
+      ByteVector.fromValidHex("3006020101020101") ++ ByteVector.fromByte(
+        0x00.toByte))
+    HashType.isDefinedHashtypeSignature(sigEndingInZero) must be(false)
+  }
 }

--- a/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
+++ b/crypto/src/main/scala/org/bitcoins/crypto/HashType.scala
@@ -116,8 +116,12 @@ object HashType extends Factory[HashType] {
                            sigHashSingleAnyoneCanPay,
                            sigHashDefault)
 
+  // SIGHASH_DEFAULT (0x00) is deliberately excluded: it is a taproot-only
+  // hash type (see validTaprootHashTypes below). Core's legacy
+  // IsDefinedHashtypeSignature masks off the ANYONECANPAY bit and requires
+  // the remaining value be in [SIGHASH_ALL, SIGHASH_SINGLE] (1-3), which
+  // does not include 0.
   lazy val hashTypeBytes: Vector[Byte] = Vector(
-    sigHashDefaultByte,
     sigHashAllByte,
     sigHashSingleByte,
     sigHashNoneByte,


### PR DESCRIPTION
## Summary
Fixes 12 security-reproduction findings in the core module's signature-checking and sighash paths (taproot invalid x-coordinate classification, BIP143/BIP341/BIP342 sighash computation, NULLFAIL/LOW_S/DER strictness semantics, FindAndDelete, and STRICTENC hashtype handling):

- `9c973a6b04` — don't treat a v1 witness program with an invalid x coordinate as anyone-can-spend
- `2751feda66` — commit the segwit v0 sighash to the scriptCode after OP_CODESEPARATOR
- `79dcf8a9bb` — reject a 65-byte tapscript signature with an explicit SIGHASH_DEFAULT byte
- `334cc6f1e4` — fail validation for taproot SIGHASH_SINGLE with no corresponding output
- `4b3ffa3058` — fail a tapscript OP_CHECKSIG immediately on an invalid non-empty signature
- `42827fd22a` — don't fail an empty signature with the LOW_S check
- `c82d7e1a37` — apply NULLFAIL to all OP_CHECKMULTISIG signatures, including consumed ones
- `66fd85b7e3` — require strict DER encoding when only the LOW_S flag is set
- `11db1bf9e4` — don't enforce WITNESS_UNEXPECTED without the ScriptVerifyWitness flag
- `8283bac411` — remove all occurrences of a signature with legacy FindAndDelete
- `bb04cc5e47` — don't crash on a segwit v0 sighash with an out of range input index
- `8a1e1d1df4` — don't count 0x00 as a defined hashtype byte for STRICTENC

Each fix is its own commit (1 bug per commit) with its reproduction test relocated into an existing test suite (`TransactionSignatureCheckerTest`, `TransactionSignatureSerializerTest`, `ScriptInterpreterTest`, `ScriptPubKeyTest`, `ScriptFlagUtilTest`, `HashTypeTest`, and others touched by each fix) rather than a new test file.

## Test plan
- [x] Each commit's relocated test passes individually
- [x] Full `coreTestJVM/test`: 1720/1720 passed
- [x] `scalafmtCheckAll`: clean
- [x] No new test files added — confirmed no `core-test/.../security/` paths in this branch's history

This is part of a 5-PR split of #6454 (closed in favor of these smaller, logically-grouped PRs) — this one covers signature checking. The other four cover transaction/TLV parsing (#6459), P2P networking (#6458), merkle/consensus, and script arithmetic (#6457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)