### PR TITLE
core: fix 6 merkle/consensus security findings

### DIFF
--- a/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
+++ b/core-test/.jvm/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.testkitcore.gen.BlockchainElementsGenerator
 import org.bitcoins.testkitcore.util.BitcoinSJvmTest
@@ -73,5 +74,21 @@ class BlockTest extends BitcoinSJvmTest {
     forAllParallel(BlockchainElementsGenerator.block) { block =>
       assert(Block(block.hex) == block)
     }
+  }
+
+  it must "include the 80-byte header and txCount varint in blockWeight" in {
+    // Bitcoin Core's GetBlockWeight scales the WHOLE serialized block
+    // (header and txCount included, not just the transaction list) by
+    // WITNESS_SCALE_FACTOR in its base-size term (block.cpp). The header
+    // and txCount carry no witness data, so they must count at the full
+    // scale factor (4), the same way legacy (non-segwit) transaction bytes
+    // do.
+    val block = MainNetChainParams.genesisBlock
+
+    val expectedWeight =
+      (block.blockHeader.bytes.size + block.txCount.bytes.size) *
+        Consensus.weightScalar + block.transactions.map(_.weight).sum
+
+    block.blockWeight must be(expectedWeight)
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockHeaderSpec.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/BlockHeaderSpec.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.testkitcore.gen.BlockchainElementsGenerator
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
 
@@ -11,5 +12,24 @@ class BlockHeaderSpec extends BitcoinSUnitTest {
     forAll(BlockchainElementsGenerator.blockHeader) { header =>
       assert(BlockHeader(header.hex) == header)
     }
+  }
+
+  it must "return zero block proof for a zero target" in {
+    // Bitcoin Core's GetBlockProof explicitly checks
+    // `fNegative || fOverflow || bnTarget == 0` before dividing
+    // (pow.cpp) -- with nBits encoding a target of exactly zero, dividing
+    // by (target + 1) = 1 would otherwise wrongly produce the enormous
+    // value 2^256 instead of the correct proof-of-work contribution of zero.
+    val genesisHeader = MainNetChainParams.genesisBlock.blockHeader
+    val zeroTargetHeader = BlockHeader(
+      genesisHeader.version,
+      genesisHeader.previousBlockHash,
+      genesisHeader.merkleRootHash,
+      genesisHeader.time,
+      UInt32.zero,
+      genesisHeader.nonce
+    )
+
+    BlockHeader.getBlockProof(zeroTargetHeader) must be(BigInt(0))
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
@@ -449,4 +449,18 @@ class PartialMerkleTreeTests extends BitcoinSUnitTest {
       PartialMerkleTree(UInt32(5), Vector.fill(8)(h), BitVector.high(8))
     }
   }
+
+  it must "compute calcMaxHeight with integer-exact results for large transaction counts" in {
+    // calcMaxHeight used a floating-point log2, which disagrees with Bitcoin
+    // Core's integer loop (`while (CalcTreeWidth(nHeight) > 1) nHeight++;` in
+    // merkleblock.cpp) at exact powers of two due to double-precision
+    // rounding -- e.g. computing 30 instead of 29 for n = 2^29.
+    //
+    // Note: 1 << 31 overflows as a 32-bit Int (wraps to Int.MinValue), so
+    // calcMaxHeight must accept a Long to even be able to represent 2^31 as
+    // an argument; 1L << 31 avoids that overflow by doing the shift in
+    // 64-bit Long arithmetic from the start.
+    PartialMerkleTree.calcMaxHeight(1 << 29) must be(29)
+    PartialMerkleTree.calcMaxHeight(1L << 31) must be(31)
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTreeTests.scala
@@ -412,4 +412,41 @@ class PartialMerkleTreeTests extends BitcoinSUnitTest {
         assert(partialMerkleTree2 == partialMerkleTree)
     }
   }
+
+  it must "reject crafted inputs with a clean error instead of crashing or accepting them" in {
+    // mirrors the sanity checks in Bitcoin Core's
+    // CPartialMerkleTree::ExtractMatches (merkleblock.cpp): zero/absurd
+    // transaction counts and truncated bits/hashes must be rejected cleanly
+    // (IllegalArgumentException) instead of crashing on `.head` of an empty
+    // collection during tree traversal, or being silently accepted.
+    val h = DoubleSha256Digest(
+      "01272b2b1c8c33a1b4e9ab111db41c9ac275e686fbd9c5d482e586d03e9e0552"
+    )
+
+    // zero transactions: calcMaxHeight(0) degenerates and the traversal
+    // crashes on `.head` of the empty bits/hashes instead of rejecting
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32.zero, Vector.empty, BitVector.empty)
+    }
+
+    // absurd transaction count: Bitcoin Core rejects
+    // nTransactions > MAX_BLOCK_WEIGHT / MIN_TRANSACTION_WEIGHT (= 66,666)
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32(100000L), Vector.empty, BitVector.low(8))
+    }
+
+    // fewer hashes than the traversal consumes: crashes with `.head` on the
+    // empty hash vector (root bit set forces traversal into both children)
+    val rootSetBits =
+      BitVector.bits(Seq(true, false, false, false, false, false, false, false))
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32.two, Vector(h), rootSetBits)
+    }
+
+    // fewer bits than the traversal consumes: all-true flags force recursion
+    // past the end of the 8 provided bits, crashing on `.head`
+    intercept[IllegalArgumentException] {
+      PartialMerkleTree(UInt32(5), Vector.fill(8)(h), BitVector.high(8))
+    }
+  }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/script/interpreter/ScriptInterpreterTest.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.script.interpreter
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.crypto.{
   BaseTxSigComponent,
   TaprootSerializationOptions,
@@ -8,15 +9,19 @@ import org.bitcoins.core.crypto.{
   WitnessTxSigComponentP2SH,
   WitnessTxSigComponentRaw
 }
-import org.bitcoins.core.currency.CurrencyUnits
+import org.bitcoins.core.currency.{CurrencyUnits, Satoshis}
+import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.protocol.script.*
 import org.bitcoins.core.protocol.transaction.{
   EmptyTransactionOutPoint,
   Transaction,
+  TransactionConstants,
+  TransactionInput,
+  TransactionOutPoint,
   TransactionOutput,
+  TransactionWitness,
   WitnessTransaction
 }
-import org.bitcoins.core.currency.Satoshis
 import org.bitcoins.core.policy.Policy
 import org.bitcoins.core.script.PreExecutionScriptProgram
 import org.bitcoins.core.script.flag.{
@@ -27,7 +32,11 @@ import org.bitcoins.core.script.flag.{
 import org.bitcoins.core.script.interpreter.testprotocol.CoreTestCase
 import org.bitcoins.core.script.result.ScriptOk
 import org.bitcoins.core.script.util.PreviousOutputMap
-import org.bitcoins.crypto.{HashType, SchnorrDigitalSignature}
+import org.bitcoins.crypto.{
+  DoubleSha256Digest,
+  HashType,
+  SchnorrDigitalSignature
+}
 import org.bitcoins.testkitcore.util.{BitcoinSUnitTest, TransactionTestUtil}
 import scodec.bits.ByteVector
 import upickle.default.*
@@ -268,6 +277,38 @@ class ScriptInterpreterTest extends BitcoinSUnitTest {
     val component = BaseTxSigComponent(spendingTx, inputIndex, output, flags)
     val result = ScriptInterpreter.run(PreExecutionScriptProgram(component))
     result must be(ScriptOk)
+  }
+
+  it must "use Core's witness-stripped base size check in checkTransaction" in {
+    // Bitcoin Core's CheckTransaction only checks the witness-stripped base
+    // size scaled by WITNESS_SCALE_FACTOR against MAX_BLOCK_WEIGHT
+    // (GetSerializeSize(TX_NO_WITNESS(tx)) * WITNESS_SCALE_FACTOR >
+    // MAX_BLOCK_WEIGHT, consensus/tx_check.cpp). There is no separate check
+    // against the legacy 1MB MAX_BLOCK_SIZE using the full witness-inclusive
+    // size, so a transaction with a small base size but a large witness
+    // (well within the weight limit) must not be rejected just because its
+    // total wire size exceeds 1MB.
+    val outPoint = TransactionOutPoint(
+      DoubleSha256Digest(
+        "01272b2b1c8c33a1b4e9ab111db41c9ac275e686fbd9c5d482e586d03e9e0552"
+      ).flip,
+      UInt32.zero
+    )
+    val input =
+      TransactionInput(outPoint, EmptyScriptSignature, UInt32.zero)
+    val output = TransactionOutput(Satoshis.zero, EmptyScriptPubKey)
+    val hugeWitness = ScriptWitness(Vector(ByteVector.fill(2000000)(0x00)))
+    val tx = WitnessTransaction(
+      TransactionConstants.version,
+      Vector(input),
+      Vector(output),
+      TransactionConstants.lockTime,
+      TransactionWitness(Vector(hugeWitness))
+    )
+
+    assert(tx.baseSize * Consensus.weightScalar <= Consensus.maxBlockWeight)
+    assert(tx.bytes.size > Consensus.maxBlockSize)
+    ScriptInterpreter.checkTransaction(tx) must be(true)
   }
 }
 

--- a/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/serializers/blockchain/RawMerkleBlockSerializerTest.scala
@@ -3,6 +3,7 @@ package org.bitcoins.core.serializers.blockchain
 import org.bitcoins.core.number.{Int32, UInt32}
 import org.bitcoins.core.protocol.blockchain.{
   BlockHeader,
+  MainNetChainParams,
   MerkleBlock,
   PartialMerkleTree
 }
@@ -13,7 +14,7 @@ import org.bitcoins.core.util.{
 }
 import org.bitcoins.crypto.DoubleSha256Digest
 import org.bitcoins.testkitcore.util.BitcoinSUnitTest
-import scodec.bits.BitVector
+import scodec.bits.{BitVector, ByteVector}
 
 /** Created by chris on 8/22/16.
   */
@@ -156,5 +157,25 @@ class RawMerkleBlockSerializerTest extends BitcoinSUnitTest {
       "d1eb1f82f9d261b8273b525b02ff1a"
     val merkleBlock = MerkleBlock(hex)
     merkleBlock.hex must be(hex)
+  }
+
+  it must "reject a crafted merkleblock declaring zero transactions with a clean error" in {
+    // mirrors the sanity checks in Bitcoin Core's
+    // CPartialMerkleTree::ExtractMatches (merkleblock.cpp) -- a merkleblock
+    // parsed off the wire that declares zero transactions must be rejected
+    // cleanly (IllegalArgumentException) rather than crashing or being
+    // silently accepted, since RawMerkleBlockSerializer.read constructs a
+    // PartialMerkleTree from the parsed fields.
+    val merkleBlockBytes = {
+      val headerBytes = MainNetChainParams.genesisBlock.blockHeader.bytes
+      val txCountLE = ByteVector.low(4) // nTransactions = 0
+      val hashCount = ByteVector(0.toByte)
+      val flagCount = ByteVector(1.toByte)
+      val flags = ByteVector(0.toByte)
+      headerBytes ++ txCountLE ++ hashCount ++ flagCount ++ flags
+    }
+    intercept[IllegalArgumentException] {
+      RawMerkleBlockSerializer.read(merkleBlockBytes)
+    }
   }
 }

--- a/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
+++ b/core-test/src/test/scala/org/bitcoins/core/util/NumberUtilTest.scala
@@ -127,6 +127,22 @@ class NumberUtilTest extends BitcoinSUnitTest {
     runTest(nBits, diffHelper)
   }
 
+  it must "interpret the nBits exponent byte as unsigned in targetExpansion" in {
+    // Bitcoin Core's SetCompact treats the exponent byte (nCompact >> 24) as
+    // an unsigned value 0-255. Reading it as a signed Scala Byte would make
+    // a byte >= 0x80 wrap negative, taking the "negative exponent, shift
+    // right" branch instead of the correct "large exponent, multiply by
+    // 256^n" branch -- dividing a tiny mantissa by an astronomically large
+    // power of two instead of multiplying it, silently producing a target
+    // of zero for a huge, nonzero exponent.
+    val nBits =
+      UInt32.fromBytes(scodec.bits.ByteVector.fromValidHex("c8010203"))
+
+    val target = NumberUtil.targetExpansion(nBits)
+
+    target.target must not be BigInt(0)
+  }
+
   behavior of "NumberUtil.targetCompression"
 
   it must "handle all cases as enumerated in bitcoin core" in {

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/Block.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.number.UInt64
 import org.bitcoins.core.protocol.CompactSizeUInt
 import org.bitcoins.core.protocol.transaction.Transaction
@@ -42,7 +43,15 @@ sealed abstract class Block extends NetworkElement {
     * Block weight is defined as Base size * 3 + Total size
     * [[https://github.com/bitcoin/bitcoin/blob/7490ae8b699d2955b665cf849d86ff5bb5245c28/src/primitives/block.cpp#L35]]
     */
-  def blockWeight: Long = transactions.map(_.weight).sum
+  def blockWeight: Long = {
+    // the 80-byte header and the txCount varint carry no witness data, so
+    // they contribute at the full WITNESS_SCALE_FACTOR the same way
+    // Bitcoin Core's GetBlockWeight includes the whole serialized block
+    // (not just the transactions) in both its base-size and total-size terms
+    val headerAndTxCountWeight =
+      (blockHeader.bytes.size + txCount.bytes.size) * Consensus.weightScalar
+    headerAndTxCountWeight + transactions.map(_.weight).sum
+  }
 }
 
 /** Companion object for creating Blocks

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/BlockHeader.scala
@@ -205,7 +205,7 @@ object BlockHeader extends Factory[BlockHeader] {
   def getBlockProof(header: BlockHeader): BigInt = {
     val target = NumberUtil.targetExpansion(header.nBits)
 
-    if (target.isNegative || target.isOverflow) {
+    if (target.isNegative || target.isOverflow || target.target == BigInt(0)) {
       BigInt(0)
     } else {
       (BigInt(1) << 256) / (target.target + BigInt(1))

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -1,5 +1,6 @@
 package org.bitcoins.core.protocol.blockchain
 
+import org.bitcoins.core.consensus.Consensus
 import org.bitcoins.core.number.UInt32
 import org.bitcoins.core.util._
 import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
@@ -274,10 +275,35 @@ object PartialMerkleTree {
     *   the bits used indicate the structure of the partial merkle tree
     * @return
     */
+  /** A minimal valid serialized transaction is at least 60 bytes, matching
+    * Bitcoin Core's MIN_TRANSACTION_WEIGHT (merkleblock.cpp), used below to cap
+    * the declared transaction count to a value that could plausibly fit in a
+    * block.
+    */
+  private val minTransactionWeight: Long = 60
+
   def apply(
       transactionCount: UInt32,
       hashes: Vector[DoubleSha256Digest],
       bits: BitVector): PartialMerkleTree = {
+    // sanity checks mirroring Bitcoin Core's CPartialMerkleTree::ExtractMatches
+    // (merkleblock.cpp) -- reject degenerate/absurd inputs cleanly before
+    // attempting to reconstruct the tree, rather than crashing or silently
+    // accepting them
+    require(transactionCount != UInt32.zero,
+            "PartialMerkleTree must have at least 1 transaction")
+    require(
+      transactionCount.toLong <= Consensus.maxBlockWeight / minTransactionWeight,
+      s"PartialMerkleTree transaction count is too high, got=$transactionCount"
+    )
+    require(
+      hashes.size <= transactionCount.toInt,
+      s"Cannot have more hashes than transactions, got ${hashes.size} hashes for $transactionCount transactions"
+    )
+    require(
+      bits.size >= hashes.size,
+      s"Must have at least one bit per hash, got ${bits.size} bits for ${hashes.size} hashes"
+    )
     val tree = reconstruct(transactionCount.toInt, hashes, bits)
     PartialMerkleTree(tree, transactionCount, bits, hashes)
   }
@@ -320,8 +346,14 @@ object PartialMerkleTree {
         pos: Int): (BinaryTreeDoubleSha256Digest,
                     Vector[DoubleSha256Digest],
                     BitVector) = {
+      require(
+        remainingMatches.nonEmpty,
+        "Traversal ran out of bits while reconstructing the partial merkle tree")
       if (height == maxHeight) {
         // means we have a txid node
+        require(
+          remainingHashes.nonEmpty,
+          "Traversal ran out of hashes while reconstructing the partial merkle tree")
         (LeafDoubleSha256Digest(remainingHashes.head),
          remainingHashes.tail,
          remainingMatches.tail)
@@ -361,6 +393,9 @@ object PartialMerkleTree {
           val node = NodeDoubleSha256Digest(nodeHash, leftNode, rightNode)
           (node, rightRemainingHashes, rightRemainingBits)
         } else {
+          require(
+            remainingHashes.nonEmpty,
+            "Traversal ran out of hashes while reconstructing the partial merkle tree")
           (LeafDoubleSha256Digest(remainingHashes.head),
            remainingHashes.tail,
            remainingMatches.tail)

--- a/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
+++ b/core/src/main/scala/org/bitcoins/core/protocol/blockchain/PartialMerkleTree.scala
@@ -7,7 +7,6 @@ import org.bitcoins.crypto.{CryptoUtil, DoubleSha256Digest}
 import scodec.bits.BitVector
 
 import scala.annotation.tailrec
-import scala.math._
 
 /** Created by chris on 8/7/16. Represents a subset of known txids inside of a
   * [[org.bitcoins.core.protocol.blockchain.Block Block]] in a way that allows
@@ -421,10 +420,20 @@ object PartialMerkleTree {
   }
 
   /** Calculates the maximum height for a binary tree with the number of
-    * transactions specified
+    * transactions specified. Mirrors Bitcoin Core's integer-exact loop (`while
+    * (CalcTreeWidth(nHeight) > 1) nHeight++;` in merkleblock.cpp) rather than a
+    * floating point log2, which can disagree with Core at exact powers of two
+    * due to double-precision rounding (e.g. computing 30 instead of 29 for n =
+    * 2^29).
     */
-  def calcMaxHeight(numTransactions: Int): Int =
-    Math.ceil((log(numTransactions) / log(2))).toInt
+  def calcMaxHeight(numTransactions: Long): Int = {
+    @tailrec
+    def loop(height: Int): Int = {
+      val width = (numTransactions + (1L << height) - 1) >> height
+      if (width > 1) loop(height + 1) else height
+    }
+    loop(0)
+  }
 
   /** Determines if the right sub tree can exists inside of the partial merkle
     * tree This function should only be used to determine if a right sub tree

--- a/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
+++ b/core/src/main/scala/org/bitcoins/core/script/interpreter/ScriptInterpreter.scala
@@ -1408,8 +1408,15 @@ sealed abstract class ScriptInterpreter {
   def checkTransaction(transaction: Transaction): Boolean = {
     val inputOutputsNotZero =
       !(transaction.inputs.isEmpty || transaction.outputs.isEmpty)
-    val txNotLargerThanBlock = transaction.bytes.size < Consensus.maxBlockSize
-    val txNotHeavierThanBlock = transaction.weight < Consensus.maxBlockWeight
+    // Bitcoin Core's CheckTransaction only checks the witness-stripped base
+    // size scaled by WITNESS_SCALE_FACTOR against MAX_BLOCK_WEIGHT
+    // (GetSerializeSize(TX_NO_WITNESS(tx)) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT).
+    // There is no separate check against the legacy 1MB MAX_BLOCK_SIZE using
+    // the full witness-inclusive size, so a transaction with a small base
+    // size but a large witness (well within the weight limit) must not be
+    // rejected just because its total serialized size exceeds 1MB.
+    val txNotHeavierThanBlock =
+      transaction.baseSize * Consensus.weightScalar <= Consensus.maxBlockWeight
     val outputsSpendValidAmountsOfMoney = !transaction.outputs.exists(o =>
       o.value < CurrencyUnits.zero || o.value > Consensus.maxMoney)
 
@@ -1426,7 +1433,7 @@ sealed abstract class ScriptInterpreter {
     } else {
       !transaction.inputs.exists(_.previousOutput == EmptyTransactionOutPoint)
     }
-    inputOutputsNotZero && txNotLargerThanBlock && txNotHeavierThanBlock && outputsSpendValidAmountsOfMoney &&
+    inputOutputsNotZero && txNotHeavierThanBlock && outputsSpendValidAmountsOfMoney &&
     allOutputsValidMoneyRange && noDuplicateInputs && isValidScriptSigForCoinbaseTx
   }
 

--- a/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
+++ b/core/src/main/scala/org/bitcoins/core/util/NumberUtil.scala
@@ -144,7 +144,10 @@ sealed abstract class NumberUtil extends CryptoNumberUtil {
       noSignBit.toByteVector
     }
 
-    val significand = nBits.bytes.head
+    // unsigned: nBits.bytes.head is a signed Scala Byte, so an exponent
+    // byte >= 0x80 (128-255) would otherwise wrap negative and take the
+    // wrong branch below
+    val significand = nBits.bytes.head & 0xff
 
     // if the most significant bit is set, we have a negative number
     val signum = if (noSignificand.bits.head) {


### PR DESCRIPTION
## Summary
Fixes 6 security-reproduction findings in the core module's merkle-block and consensus-checking paths:

- `4f85e915ea` — reject crafted merkleblock inputs instead of crashing or accepting them
- `a9bd6ed837` — compute calcMaxHeight with integer-exact results for large tx counts
- `1c353f0e07` — use Core's witness-stripped base size check in checkTransaction
- `646a6449d2` — return zero block proof for a zero target
- `8bed35568e` — interpret the nBits exponent byte as unsigned in targetExpansion
- `9b11f4d697` — include the 80-byte header and txCount varint in Block.blockWeight

Each fix is its own commit (1 bug per commit) with its reproduction test relocated into an existing test suite (`PartialMerkleTreeTest`, `ScriptInterpreterTest`, `BlockHeaderSpec`, `NumberUtilTest`, `BlockTest`) rather than a new test file.

Note: a 7th finding from the original investigation (CVE-2012-2459 duplicate-leaf merkle mutation detection) was intentionally left out of scope and not fixed in this branch.

## Test plan
- [x] Each commit's relocated test passes individually
- [x] Full `coreTestJVM/test`: 1716/1716 passed
- [x] `scalafmtCheckAll`: clean
- [x] No new test files added — confirmed no `core-test/.../security/` paths in this branch's history

This is part of a 5-PR split of #6454 (closed in favor of these smaller, logically-grouped PRs) — this one covers merkle/consensus. The other four cover transaction/TLV parsing (#6459), P2P networking (#6458), script arithmetic (#6457), and signature checking (#6460).

🤖 Generated with [Claude Code](https://claude.com/claude-code)