### PR TITLE
Fix recurring Release and Dependabot CI failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,13 @@ updates:
     directory: "/website"
     schedule:
       interval: "weekly"
+    ignore:
+      # These are transitive deps pinned by docusaurus@1.14.7 (via request,
+      # autoprefixer, postcss-svgo, react-dev-utils). Dependabot can't bump
+      # them past the vulnerable range without breaking the docusaurus 1.x
+      # dependency tree, so every security PR for them fails CI. Re-enable
+      # once /website is migrated off docusaurus 1.x.
+      - dependency-name: "form-data"
+      - dependency-name: "svgo"
+      - dependency-name: "postcss"
+      - dependency-name: "shell-quote"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # docs/publishWebsite pushes to the shared gh-pages branch; overlapping
+    # runs race and get a non-fast-forward push rejection, so serialize them.
+    concurrency:
+      group: release-publish-ghpages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary
- Serialize the `Release` workflow's `publish` job (`concurrency: release-publish-ghpages`) so overlapping runs don't race to push `gh-pages` and hit a non-fast-forward rejection.
- Add `ignore` rules to `.github/dependabot.yml` for `form-data`, `svgo`, `postcss`, `shell-quote` under `/website` — these are transitively pinned by `docusaurus@1.14.7`, so Dependabot can never land a security update for them and just fails every attempt.

Fixes #6473. The underlying fix (migrating `website/` off Docusaurus 1.x, which would let Dependabot actually update these deps) is tracked separately in #6474.

## Test plan
- [x] Validated both YAML files parse correctly
- [ ] Confirm the next `Release` workflow run on `master` succeeds (or queues cleanly if another run is in flight)
- [ ] Confirm `Dependabot Updates` no longer opens/fails PRs for `form-data`/`svgo`/`postcss`/`shell-quote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw2Wgx6BR6ivTQNdRLQgNb