### PR TITLE
Serialize ZMQ wallet callback processing

### DIFF
--- a/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/BitcoindRpcBackendUtil.scala
@@ -223,60 +223,101 @@ object BitcoindRpcBackendUtil extends BitcoinSLogger {
     pairedWallet
   }
 
+  // how many messages to buffer before backpressuring the ZMQ subscriber
+  // thread; sized comfortably above a burst from generateToAddress()
+  // mining requiredConfirmations blocks at once
+  private val zmqQueueBufferSize = 128
+
   def startZMQWalletCallbacks(
       wallet: NeutrinoHDWalletApi,
       zmqConfig: ZmqConfig
-  )(implicit ec: ExecutionContext): WalletZmqSubscribers = {
+  )(implicit system: ActorSystem): WalletZmqSubscribers = {
+    import system.dispatcher
     require(
       zmqConfig != ZmqConfig.empty,
       "Must have the zmq raw configs defined to setup ZMQ callbacks"
     )
 
-    val rawTxSub = zmqConfig.rawTx.map { zmq =>
-      val rawTxListener: Option[Transaction => Unit] = Some {
-        { (tx: Transaction) =>
-          logger.debug(s"Received tx ${tx.txIdBE.hex}, processing")
-          val f = wallet.transactionProcessing.processTransaction(tx, None)
-          f.failed.foreach { err =>
-            logger.error("failed to process raw tx zmq message", err)
+    // ZMQSubscriber invokes its listener synchronously and does not wait on
+    // the Future it returns before reading the next message, so a burst of
+    // messages (e.g. several rawblock notifications from a single
+    // generateToAddress call) must be serialized downstream ourselves via
+    // mapAsync(1) -- otherwise wallet processing for that burst runs
+    // concurrently against the same underlying database.
+    val rawTxOpt
+        : Option[(SourceQueueWithComplete[Transaction], ZMQSubscriber)] =
+      zmqConfig.rawTx.map { zmq =>
+        val queue = Source
+          .queue[Transaction](zmqQueueBufferSize, OverflowStrategy.backpressure)
+          .mapAsync(parallelism = 1) { tx =>
+            logger.debug(s"Received tx ${tx.txIdBE.hex}, processing")
+            wallet.transactionProcessing
+              .processTransaction(tx, None)
+              .map(_ => ())
+              .recover { case err =>
+                logger.error("failed to process raw tx zmq message", err)
+              }
           }
-          ()
+          .toMat(Sink.ignore)(Keep.left)
+          .run()
+
+        val rawTxListener: Option[Transaction => Unit] = Some {
+          { (tx: Transaction) =>
+            queue.offer(tx)
+            ()
+          }
         }
+
+        val sub = new ZMQSubscriber(
+          socket = zmq,
+          hashTxListener = None,
+          hashBlockListener = None,
+          rawTxListener = rawTxListener,
+          rawBlockListener = None
+        )
+        (queue, sub)
       }
 
-      new ZMQSubscriber(
-        socket = zmq,
-        hashTxListener = None,
-        hashBlockListener = None,
-        rawTxListener = rawTxListener,
-        rawBlockListener = None
-      )
-    }
-
-    val rawBlockSub = zmqConfig.rawBlock.map { zmq =>
-      val rawBlockListener: Option[Block => Unit] = Some {
-        { (block: Block) =>
-          logger.info(
-            s"Received block ${block.blockHeader.hashBE.hex}, processing"
-          )
-          val f = wallet.transactionProcessing.processBlock(block)
-          f.failed.foreach { err =>
-            logger.error("failed to process raw block zmq message", err)
+    val rawBlockOpt: Option[(SourceQueueWithComplete[Block], ZMQSubscriber)] =
+      zmqConfig.rawBlock.map { zmq =>
+        val queue = Source
+          .queue[Block](zmqQueueBufferSize, OverflowStrategy.backpressure)
+          .mapAsync(parallelism = 1) { block =>
+            logger.info(
+              s"Received block ${block.blockHeader.hashBE.hex}, processing"
+            )
+            wallet.transactionProcessing
+              .processBlock(block)
+              .recover { case err =>
+                logger.error("failed to process raw block zmq message", err)
+              }
           }
-          ()
+          .toMat(Sink.ignore)(Keep.left)
+          .run()
+
+        val rawBlockListener: Option[Block => Unit] = Some {
+          { (block: Block) =>
+            queue.offer(block)
+            ()
+          }
         }
+
+        val sub = new ZMQSubscriber(
+          socket = zmq,
+          hashTxListener = None,
+          hashBlockListener = None,
+          rawTxListener = None,
+          rawBlockListener = rawBlockListener
+        )
+        (queue, sub)
       }
 
-      new ZMQSubscriber(
-        socket = zmq,
-        hashTxListener = None,
-        hashBlockListener = None,
-        rawTxListener = None,
-        rawBlockListener = rawBlockListener
-      )
-    }
-
-    val subs = WalletZmqSubscribers(rawTxSub, rawBlockSub)
+    val subs = WalletZmqSubscribers(
+      rawTxSubscriberOpt = rawTxOpt.map(_._2),
+      rawBlockSubscriberOpt = rawBlockOpt.map(_._2),
+      rawTxQueueOpt = rawTxOpt.map(_._1),
+      rawBlockQueueOpt = rawBlockOpt.map(_._1)
+    )
     subs.start()
     subs
   }

--- a/app/server/src/main/scala/org/bitcoins/server/WalletZmqSubscribers.scala
+++ b/app/server/src/main/scala/org/bitcoins/server/WalletZmqSubscribers.scala
@@ -1,5 +1,8 @@
 package org.bitcoins.server
 
+import org.apache.pekko.stream.scaladsl.SourceQueueWithComplete
+import org.bitcoins.core.protocol.blockchain.Block
+import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.core.util.StartStop
 import org.bitcoins.zmq.ZMQSubscriber
 
@@ -7,7 +10,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 case class WalletZmqSubscribers(
     rawTxSubscriberOpt: Option[ZMQSubscriber],
-    rawBlockSubscriberOpt: Option[ZMQSubscriber]
+    rawBlockSubscriberOpt: Option[ZMQSubscriber],
+    rawTxQueueOpt: Option[SourceQueueWithComplete[Transaction]],
+    rawBlockQueueOpt: Option[SourceQueueWithComplete[Block]]
 ) extends StartStop[Unit] {
   private val isStarted: AtomicBoolean = new AtomicBoolean(false)
 
@@ -25,6 +30,8 @@ case class WalletZmqSubscribers(
     if (isStarted.get()) {
       rawTxSubscriberOpt.foreach(_.stop())
       rawBlockSubscriberOpt.foreach(_.stop())
+      rawTxQueueOpt.foreach(_.complete())
+      rawBlockQueueOpt.foreach(_.complete())
       isStarted.set(false)
     } else {
       ()


### PR DESCRIPTION
## Summary
`org.bitcoins.zmq.ZMQSubscriber` invokes its listener synchronously and does not wait on the `Future` the listener kicks off before reading the next ZMQ message. `BitcoindRpcBackendUtil.startZMQWalletCallbacks`'s `rawTx`/`rawBlock` listeners were fire-and-forget (`processTransaction`/`processBlock` were never awaited), so a burst of ZMQ messages fanned out into several concurrent, unserialized wallet DB writes with no ordering guarantee.

This is plausible as a contributing factor in the intermittent timeout in `BitcoindZMQBackendTest` ("must get txs and blocks through zmq") and possibly other ZMQ/P2P timing flakiness (e.g. #6417): `bitcoind.generateToAddress(requiredConfirmations, addr)` mines `requiredConfirmations` blocks (default 6) in one RPC call, which publishes a burst of `rawblock` messages back-to-back, each kicking off a concurrent `processBlock` call against the same SQLite-backed wallet DB.

- Routes `rawTx`/`rawBlock` processing through a backpressured `Source.queue(...).mapAsync(1)(...)` stream instead of firing Futures unawaited, so messages are processed one at a time in arrival order.
- `startZMQWalletCallbacks` now takes an implicit `ActorSystem` (for the stream materializer) instead of `ExecutionContext`.
- `WalletZmqSubscribers` now also holds the two queues so `stop()` completes them alongside the underlying ZMQ sockets.

## Test plan
- [x] `appServer/compile`, `appServerTest/Test/compile`, `walletTest/Test/compile` all pass
- [x] `scalafmtCheckAll` passes
- [ ] Watch `BitcoindZMQBackendTest` ("must get txs and blocks through zmq") in CI over the next several runs for reduced flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw2Wgx6BR6ivTQNdRLQgNb