### PR TITLE
Fix testkit zmq queue race causing chain MTP flake

### DIFF
--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -1,7 +1,5 @@
 package org.bitcoins.chain.blockchain
 
-import org.apache.pekko.stream.{OverflowStrategy, QueueOfferResult}
-import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
@@ -9,8 +7,7 @@ import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaZmq
 import org.scalatest.{Assertion, FutureOutcome}
 
-import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
@@ -79,96 +76,5 @@ class BitcoindChainHandlerViaZmqTest extends ChainUnitTest {
       bitcoindMTP <- bitcoind.getMedianTimePast()
       bitcoinSMTP <- chainHandler.getMedianTimePast()
     } yield assert(bitcoinSMTP == bitcoindMTP)
-  }
-
-  // The two tests below reproduce and validate the fix for the queue race in
-  // ChainUnitTest.createChainHandlerWithBitcoindZmq's handleRawBlock: it used
-  // to call queue.offer(block) without waiting for the previously returned
-  // Future to complete. ZMQSubscriber's receive loop invokes that listener
-  // synchronously and moves on to the next message as soon as the call
-  // returns, so a burst of zmq messages (e.g. from generating many blocks in
-  // one bitcoind RPC call, as "correctly calculate the mediantimepast" above
-  // does) fired concurrent, unawaited offer() calls against one Source.queue.
-  // That's unsafe -- the calls race each other and the queue can stall --
-  // which was silently dropping blocks and produced flakes like "not enough
-  // blocks in the chain, got only N headers". These don't need
-  // bitcoind/zmq -- they isolate the Source.queue usage pattern directly.
-
-  it must "drop elements when Source.queue offer is not awaited between calls" in {
-    (_: BitcoindChainHandlerViaZmq) =>
-      val processed = new AtomicInteger(0)
-
-      // slow downstream, same shape as the real processHeaders() call in
-      // ChainUnitTest -- takes long enough that a tight offer loop will race it
-      val sink = Sink.foreachAsync[Int](1) { (_: Int) =>
-        Future {
-          Thread.sleep(20)
-          processed.incrementAndGet()
-          ()
-        }(using executionContext)
-      }
-
-      val queue = Source
-        .queue[Int](10, OverflowStrategy.backpressure)
-        .to(sink)
-        .run()
-
-      val n = 100
-
-      // the pre-fix bug: fire offer() for every element back-to-back without
-      // waiting for the previous call's returned Future to complete
-      (0 until n).foreach { i =>
-        queue
-          .offer(i)
-          .foreach {
-            case QueueOfferResult.Enqueued    => ()
-            case QueueOfferResult.Dropped     => ()
-            case QueueOfferResult.Failure(_)  => ()
-            case QueueOfferResult.QueueClosed => ()
-          }(using executionContext)
-      }
-
-      // bounded wait rather than "retry until all n accounted for" -- the
-      // race can wedge the queue so that some offers never resolve at all
-      org.apache.pekko.pattern
-        .after(3.seconds)(Future.unit)(using system)
-        .map { _ =>
-          // never all n make it through the sink within the wait window
-          assert(processed.get() < n)
-        }
-  }
-
-  it must "process all elements when each Source.queue offer is awaited" in {
-    (_: BitcoindChainHandlerViaZmq) =>
-      val processed = new AtomicInteger(0)
-
-      val sink = Sink.foreachAsync[Int](1) { (_: Int) =>
-        Future {
-          Thread.sleep(20)
-          processed.incrementAndGet()
-          ()
-        }(using executionContext)
-      }
-
-      val queue = Source
-        .queue[Int](10, OverflowStrategy.backpressure)
-        .to(sink)
-        .run()
-
-      val n = 100
-
-      // the fix applied in ChainUnitTest.createChainHandlerWithBitcoindZmq:
-      // block on each offer's Future before issuing the next one, so calls
-      // never race each other
-      (0 until n).foreach { i =>
-        Await.result(queue.offer(i), 5.seconds)
-        ()
-      }
-
-      AsyncUtil
-        .awaitCondition(() => processed.get() == n,
-                        interval = 50.millis,
-                        maxTries = 100)(using executionContext)
-        .map(_ => assert(processed.get() == n))
   }
 }

--- a/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
+++ b/chain-test/src/test/scala/org/bitcoins/chain/blockchain/BitcoindChainHandlerViaZmqTest.scala
@@ -1,5 +1,7 @@
 package org.bitcoins.chain.blockchain
 
+import org.apache.pekko.stream.{OverflowStrategy, QueueOfferResult}
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import org.bitcoins.asyncutil.AsyncUtil
 import org.bitcoins.core.api.chain.ChainApi
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
@@ -7,7 +9,8 @@ import org.bitcoins.testkit.chain.ChainUnitTest
 import org.bitcoins.testkit.chain.fixture.BitcoindChainHandlerViaZmq
 import org.scalatest.{Assertion, FutureOutcome}
 
-import scala.concurrent.Future
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
@@ -76,5 +79,96 @@ class BitcoindChainHandlerViaZmqTest extends ChainUnitTest {
       bitcoindMTP <- bitcoind.getMedianTimePast()
       bitcoinSMTP <- chainHandler.getMedianTimePast()
     } yield assert(bitcoinSMTP == bitcoindMTP)
+  }
+
+  // The two tests below reproduce and validate the fix for the queue race in
+  // ChainUnitTest.createChainHandlerWithBitcoindZmq's handleRawBlock: it used
+  // to call queue.offer(block) without waiting for the previously returned
+  // Future to complete. ZMQSubscriber's receive loop invokes that listener
+  // synchronously and moves on to the next message as soon as the call
+  // returns, so a burst of zmq messages (e.g. from generating many blocks in
+  // one bitcoind RPC call, as "correctly calculate the mediantimepast" above
+  // does) fired concurrent, unawaited offer() calls against one Source.queue.
+  // That's unsafe -- the calls race each other and the queue can stall --
+  // which was silently dropping blocks and produced flakes like "not enough
+  // blocks in the chain, got only N headers". These don't need
+  // bitcoind/zmq -- they isolate the Source.queue usage pattern directly.
+
+  it must "drop elements when Source.queue offer is not awaited between calls" in {
+    (_: BitcoindChainHandlerViaZmq) =>
+      val processed = new AtomicInteger(0)
+
+      // slow downstream, same shape as the real processHeaders() call in
+      // ChainUnitTest -- takes long enough that a tight offer loop will race it
+      val sink = Sink.foreachAsync[Int](1) { (_: Int) =>
+        Future {
+          Thread.sleep(20)
+          processed.incrementAndGet()
+          ()
+        }(using executionContext)
+      }
+
+      val queue = Source
+        .queue[Int](10, OverflowStrategy.backpressure)
+        .to(sink)
+        .run()
+
+      val n = 100
+
+      // the pre-fix bug: fire offer() for every element back-to-back without
+      // waiting for the previous call's returned Future to complete
+      (0 until n).foreach { i =>
+        queue
+          .offer(i)
+          .foreach {
+            case QueueOfferResult.Enqueued    => ()
+            case QueueOfferResult.Dropped     => ()
+            case QueueOfferResult.Failure(_)  => ()
+            case QueueOfferResult.QueueClosed => ()
+          }(using executionContext)
+      }
+
+      // bounded wait rather than "retry until all n accounted for" -- the
+      // race can wedge the queue so that some offers never resolve at all
+      org.apache.pekko.pattern
+        .after(3.seconds)(Future.unit)(using system)
+        .map { _ =>
+          // never all n make it through the sink within the wait window
+          assert(processed.get() < n)
+        }
+  }
+
+  it must "process all elements when each Source.queue offer is awaited" in {
+    (_: BitcoindChainHandlerViaZmq) =>
+      val processed = new AtomicInteger(0)
+
+      val sink = Sink.foreachAsync[Int](1) { (_: Int) =>
+        Future {
+          Thread.sleep(20)
+          processed.incrementAndGet()
+          ()
+        }(using executionContext)
+      }
+
+      val queue = Source
+        .queue[Int](10, OverflowStrategy.backpressure)
+        .to(sink)
+        .run()
+
+      val n = 100
+
+      // the fix applied in ChainUnitTest.createChainHandlerWithBitcoindZmq:
+      // block on each offer's Future before issuing the next one, so calls
+      // never race each other
+      (0 until n).foreach { i =>
+        Await.result(queue.offer(i), 5.seconds)
+        ()
+      }
+
+      AsyncUtil
+        .awaitCondition(() => processed.get() == n,
+                        interval = 50.millis,
+                        maxTries = 100)(using executionContext)
+        .map(_ => assert(processed.get() == n))
   }
 }

--- a/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
+++ b/testkit/src/main/scala/org/bitcoins/testkit/chain/ChainUnitTest.scala
@@ -40,7 +40,7 @@ import java.net.InetSocketAddress
 import java.nio.file.Files
 import scala.annotation.tailrec
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 trait ChainUnitTest extends BitcoinSFixture with PostgresTestDatabase {
 
@@ -272,21 +272,37 @@ trait ChainUnitTest extends BitcoinSFixture with PostgresTestDatabase {
         .to(sink)
         .run()(using Materializer.matFromSystem(using system))
       val handleRawBlock: Block => Unit = { (block: Block) =>
-        queue
-          .offer(block)
-          .foreach {
-            case org.apache.pekko.stream.QueueOfferResult.Enqueued => // all good
-            case org.apache.pekko.stream.QueueOfferResult.Dropped =>
-              logger.warn(
-                s"Block offer dropped for block ${block.blockHeader.hashBE}")
-            case org.apache.pekko.stream.QueueOfferResult.Failure(ex) =>
-              logger.error(
-                s"Block offer failed for block ${block.blockHeader.hashBE}",
-                ex)
-            case org.apache.pekko.stream.QueueOfferResult.QueueClosed =>
-              logger.error(
-                s"Block offer failed: queue closed for block ${block.blockHeader.hashBE}")
-          }(using executionContext)
+        // ZMQSubscriber's receive loop invokes this listener synchronously
+        // and moves on to the next message as soon as this call returns, so
+        // offer() must be awaited here -- calling it again before the
+        // previous call's Future resolves is unsafe for Source.queue and
+        // can silently stall/drop blocks under a burst of zmq messages
+        // (e.g. from generating many blocks in one bitcoind RPC call).
+        val offerResultT = scala.util.Try(
+          Await.result(queue.offer(block), 30.seconds)
+        )
+        offerResultT match {
+          case scala.util.Success(
+                org.apache.pekko.stream.QueueOfferResult.Enqueued
+              ) => // all good
+          case scala.util.Success(
+                org.apache.pekko.stream.QueueOfferResult.Dropped) =>
+            logger.warn(
+              s"Block offer dropped for block ${block.blockHeader.hashBE}")
+          case scala.util.Success(
+                org.apache.pekko.stream.QueueOfferResult.Failure(ex)) =>
+            logger.error(
+              s"Block offer failed for block ${block.blockHeader.hashBE}",
+              ex)
+          case scala.util.Success(
+                org.apache.pekko.stream.QueueOfferResult.QueueClosed) =>
+            logger.error(
+              s"Block offer failed: queue closed for block ${block.blockHeader.hashBE}")
+          case scala.util.Failure(ex) =>
+            logger.error(
+              s"Block offer timed out for block ${block.blockHeader.hashBE}",
+              ex)
+        }
         ()
       }
 


### PR DESCRIPTION
## Summary

`ChainUnitTest.createChainHandlerWithBitcoindZmq`'s `handleRawBlock` fired `Source.queue.offer(block)` without awaiting the previously returned `Future`. `ZMQSubscriber`'s receive loop invokes that listener synchronously and moves on to the next zmq message as soon as the call returns, so a burst of `rawblock` messages (e.g. from `bitcoind.generate(n)` mining many blocks in one RPC call) fired concurrent, unawaited `offer()` calls against a single `Source.queue`. That's unsafe -- `Source.queue` requires the previous `offer()`'s `Future` to resolve before calling `offer()` again -- and the calls racing each other silently dropped/stalled blocks.

This matches a flake seen in CI on an unrelated PR (#6486): `BitcoindChainHandlerViaZmqTest` "must correctly calculate the mediantimepast the same as bitcoind" failed with:
```
java.lang.RuntimeException: Could not calculate median time past, not enough blocks in the chain, got only 7 headers
```
This is the same class of bug as #6476 (unawaited/fire-and-forget async work racing itself under a burst of zmq messages), but in `testkit` fixture code, not the production `BitcoindRpcBackendUtil` wallet path.

## Fix

Block on each `offer()`'s `Future` before issuing the next one, so calls never race each other.

Filed #6491 to fix this at the root: `ZMQSubscriber`'s listener callbacks are synchronous (`T => Unit`), which is what forces this `Await.result` workaround (and forced the `Source.queue.mapAsync(1)` workaround in #6476) in the first place. Changing the listeners to `T => Future[Unit]` and awaiting inside `ZMQSubscriber`'s own receive thread would let both callers drop their workaround plumbing.

## Tests

No new test file -- the existing `must correctly calculate the mediantimepast the same as bitcoind` test already exercises the fixed code path end-to-end against real bitcoind/zmq (with a randomized 5-100 block burst per run). Ran it 5/5 times locally against the fix with no failures.

## Checklist

- [x] `chainTest/Test/compile` and `testkit/compile` pass
- [x] `scalafmtCheckAll` passes
- [x] `BitcoindChainHandlerViaZmqTest` passes reliably locally (5/5 runs) against real bitcoind/zmq
- [ ] Watch `BitcoindChainHandlerViaZmqTest` in CI over the next several runs for reduced flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fw2Wgx6BR6ivTQNdRLQgNb